### PR TITLE
PI-276 Add scheduled Trivy image scan

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -61,7 +61,7 @@ jobs:
           QUAYIO_USERNAME: ${{ secrets.QUAYIO_USERNAME }}
           QUAYIO_PASSWORD: ${{ secrets.QUAYIO_PASSWORD }}
         with:
-          arguments: jib
+          arguments: jib -Djib.to.tags=latest
 
   deploy-to-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,40 @@
+name: Security
+
+on:
+  schedule:
+    - cron: "30 5 * * MON-FRI" # Every weekday at 05:30 UTC
+
+jobs:
+  get-projects:
+    runs-on: ubuntu-latest
+    outputs:
+      projects: ${{ steps.get-projects.outputs.projects }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: get-projects
+        run: echo "::set-output name=projects::$(cd projects && ls | jq --raw-input . | jq --slurp --compact-output .)"
+
+  scan:
+    runs-on: ubuntu-latest
+    needs:
+      - get-projects
+    strategy:
+      matrix:
+        project: ${{ fromJson(needs.get-projects.outputs.projects) }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Scan image
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'quay.io/hmpps/${{ matrix.project }}:latest'
+          ignore-unfixed: true
+          severity: 'CRITICAL,HIGH'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 > :memo: This repository is a work-in-progress and subject to change.
  
 [![repo standards badge](https://img.shields.io/badge/dynamic/json?color=blue&logo=github&label=MoJ%20Compliant&query=%24.data%5B%3F%28%40.name%20%3D%3D%20%22hmpps-probation-integration-services%22%29%5D.status&url=https%3A%2F%2Foperations-engineering-reports.cloud-platform.service.justice.gov.uk%2Fgithub_repositories)](https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/github_repositories#hmpps-probation-integration-services "Link to report")
+[![Trivy](https://github.com/ministryofjustice/hmpps-probation-integration-services/actions/workflows/security.yml/badge.svg)](https://github.com/ministryofjustice/hmpps-probation-integration-services/actions/workflows/security.yml)
+[![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=ministryofjustice_hmpps-probation-integration-services&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=ministryofjustice_hmpps-probation-integration-services)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=ministryofjustice_hmpps-probation-integration-services&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=ministryofjustice_hmpps-probation-integration-services)
+[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=ministryofjustice_hmpps-probation-integration-services&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=ministryofjustice_hmpps-probation-integration-services)
 [![codecov](https://codecov.io/gh/ministryofjustice/hmpps-probation-integration-services/branch/main/graph/badge.svg?token=CCgT1zYksg)](https://codecov.io/gh/ministryofjustice/hmpps-probation-integration-services)
 
 A collection of small, domain-focused integrations to support HMPPS Digital services that need to interact with 


### PR DESCRIPTION
This runs every weekday morning against the latest image for each project, and uploads the results to GitHub's [security page](https://github.com/ministryofjustice/hmpps-probation-integration-services/security/code-scanning).  Security alerts will appear in the repository as configured in the [GitHub settings](https://github.com/ministryofjustice/hmpps-probation-integration-services/settings/security_analysis).