### PR TITLE
Fix URLs for prison case notes service

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,14 +46,14 @@ jobs:
       - run: echo 'Hello, world!'
 
   deploy-to-pre-prod:
-    name: Deploy to pre-prod
+    name: Deploy to preprod
     uses: ./.github/workflows/deploy.yml
     if: github.ref == 'refs/heads/main'
     needs:
       - build
       - end-to-end-tests
     with:
-      environment: pre-prod
+      environment: preprod
       values-file: values-preprod.yml
       version: ${{ needs.build.outputs.version }}
       projects: ${{ needs.build.outputs.changed-projects }}

--- a/projects/prison-case-notes-to-probation/deploy/values-dev.yml
+++ b/projects/prison-case-notes-to-probation/deploy/values-dev.yml
@@ -3,7 +3,7 @@ environment_name: delius-test
 env:
   SENTRY_ENVIRONMENT: dev
   SPRING_JMS_TEMPLATE_DEFAULT-DESTINATION: Digital-Prison-Services-dev-case_note_poll_pusher_queue
-  INTEGRATIONS_PRISON-CASE-NOTES_URL: https://offender-case-notes-dev.hmpps.service.justice.gov.uk
+  INTEGRATIONS_PRISON-CASE-NOTES_URL: https://dev.offender-case-notes.service.justice.gov.uk
   SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_HMPPS-AUTH_TOKEN-URI: https://sign-in-dev.hmpps.service.justice.gov.uk/auth/oauth/token
   DELIUS_DB_USERNAME: APIUser
 

--- a/projects/prison-case-notes-to-probation/deploy/values-preprod.yml
+++ b/projects/prison-case-notes-to-probation/deploy/values-preprod.yml
@@ -3,5 +3,5 @@ environment_name: delius-pre-prod
 env:
   SENTRY_ENVIRONMENT: preprod
   SPRING_JMS_TEMPLATE_DEFAULT-DESTINATION: Digital-Prison-Services-preprod-case_note_poll_pusher_queue
-  INTEGRATIONS_PRISON-CASE-NOTES_URL: https://offender-case-notes-preprod.hmpps.service.justice.gov.uk
+  INTEGRATIONS_PRISON-CASE-NOTES_URL: https://preprod.offender-case-notes.service.justice.gov.uk
   SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_HMPPS-AUTH_TOKEN-URI: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth/oauth/token


### PR DESCRIPTION
* Fix URLs for prison case notes service
* Update pre-prod to preprod, to remain consistent with MOJ CP and to prevent Jira from classifying the environment as production (see: https://github.com/atlassian/github-for-jira/blob/main/src/transforms/transform-deployment.ts#L126)