### PR TITLE
PI-265 Add database access and audit details per-project

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Configure database access
         shell: bash
         run: |
-          aws ssm start-automation-execution --document-name oracle-{{ steps.env.outputs.short_name }}-probation-integration-access \
+          aws ssm start-automation-execution --document-name oracle-${{ steps.env.outputs.short_name }}-probation-integration-access \
                                              --parameters "Configuration='$(yq access.yml -o json)'" \
                                              --region eu-west-2
         working-directory: projects/${{ matrix.project }}/deploy/database

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Configure database access
         shell: bash
         run: |
-          aws ssm start-automation-execution --document-name oracle-${{ steps.env.outputs.short_name }}-probation-integration-access \
+          aws ssm start-automation-execution --document-name oracle-${{ steps.env.outputs.short-name }}-probation-integration-access \
                                              --parameters "Configuration='$(yq access.yml -o json)'" \
                                              --region eu-west-2
         working-directory: projects/${{ matrix.project }}/deploy/database

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,6 +63,14 @@ jobs:
           done
         working-directory: projects/${{ matrix.project }}/deploy
 
+      - name: Configure database access
+        shell: bash
+        run: |
+          aws ssm start-automation-execution --document-name oracle-{{ steps.env.outputs.short_name }}-probation-integration-access \
+                                             --parameters "Configuration='$(yq access.yml -o json)'" \
+                                             --region eu-west-2
+        working-directory: projects/${{ matrix.project }}/deploy/database
+
       - name: Render values
         shell: bash
         run: yq eval-all 'select(fileIndex == 0) *d select(fileIndex == 1)' --inplace values.yml ${{ inputs.values-file }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,10 +66,12 @@ jobs:
       - name: Configure database access
         shell: bash
         run: |
+          test -f database/access.yml && \
           aws ssm start-automation-execution --document-name oracle-${{ steps.env.outputs.short-name }}-probation-integration-access \
-                                             --parameters "Configuration='$(yq access.yml -o json)'" \
+                                             --parameters "Configuration='$(yq database/access.yml -o json)'" \
                                              --region eu-west-2
-        working-directory: projects/${{ matrix.project }}/deploy/database
+          echo 'Execution started. Follow the logs in AWS: https://eu-west-2.console.aws.amazon.com/systems-manager/automation/executions?region=eu-west-2'
+        working-directory: projects/${{ matrix.project }}/deploy
 
       - name: Render values
         shell: bash

--- a/README.md
+++ b/README.md
@@ -200,6 +200,33 @@ which is how they should be referenced in the `values*.yml` files.
 
 For more details, see the "Add secrets to parameter store" step in [deploy.yml](.github/workflows/deploy.yml).
 
+## Accessing the Delius Database
+To configure access to the Delius probation database, add an `access.yml` file to the project's `deploy/database` 
+folder.
+
+The `access.yml` file defines the account used for accessing the database, as well as an optional user for auditing
+interactions.  Example (see [access.yml](projects/prison-case-notes-to-probation/deploy/database/access.yml):
+```yaml
+database:
+  access:
+    username_key: /prison-case-notes-to-probation/db-username    # references AWS Parameter Store 
+    password_key: /prison-case-notes-to-probation/db-password    # (see Secrets section above)
+    tables:
+      # A list of tables that the service can write to. Read access is granted on all tables.
+      - audited_interaction
+      - contact
+
+  audit:
+    username: PrisonCaseNotesToProbation
+    forename: Prison Case Notes
+    surname: Service
+```
+
+Before each deployment, GitHub Actions will invoke a pre-defined [Systems Manager Automation Runbook](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-automation.html)
+in AWS to create/update the access account and the audit user in the Delius database.  The runbook is in the 
+[hmpps-delius-pipelines](https://github.com/ministryofjustice/hmpps-delius-pipelines/tree/master/components/oracle/playbooks/probation_integration_access) 
+repository.
+
 ## Accessing MOJ Cloud Platform
 To access SQS queues or other resources in MOJ Cloud Platform, add an IAM policy to [cloud-platform-environments](https://github.com/ministryofjustice/cloud-platform-environments)
 that grants access to one of the following roles:

--- a/projects/prison-case-notes-to-probation/deploy/database/access.yml
+++ b/projects/prison-case-notes-to-probation/deploy/database/access.yml
@@ -1,0 +1,14 @@
+database:
+  access:
+    username_key: /prison-case-notes-to-probation/db-username
+    password_key: /prison-case-notes-to-probation/db-password
+    tables:
+      - audited_interaction
+      - contact
+      - staff
+      - staff_team
+
+  audit:
+    username: PrisonCaseNotesToProbation
+    forename: Prison Case Notes
+    surname: Service

--- a/projects/prison-case-notes-to-probation/deploy/values-dev.yml
+++ b/projects/prison-case-notes-to-probation/deploy/values-dev.yml
@@ -5,7 +5,6 @@ env:
   SPRING_JMS_TEMPLATE_DEFAULT-DESTINATION: Digital-Prison-Services-dev-case_note_poll_pusher_queue
   INTEGRATIONS_PRISON-CASE-NOTES_URL: https://dev.offender-case-notes.service.justice.gov.uk
   SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_HMPPS-AUTH_TOKEN-URI: https://sign-in-dev.hmpps.service.justice.gov.uk/auth/oauth/token
-  DELIUS_DB_USERNAME: APIUser
 
   LOGGING_LEVEL_COM_AMAZON_SQS: DEBUG
   LOGGING_LEVEL_UK_GOV_DIGITAL_JUSTICE_HMPPS: DEBUG

--- a/projects/prison-case-notes-to-probation/deploy/values.yml
+++ b/projects/prison-case-notes-to-probation/deploy/values.yml
@@ -8,6 +8,7 @@ memory: 1024 # = 1 GB
 env:
   AWS_REGION: eu-west-2
   JDK_JAVA_OPTIONS: -javaagent:/agent/agent.jar
+  DELIUS_DB_USERNAME: PrisonCaseNotesToProbation # Defined in database/access.yml
 
 secrets:
   APPLICATIONINSIGHTS_CONNECTION_STRING:        /application-insights/connection-string


### PR DESCRIPTION
The deploy action now starts an SSM automation runbook in the background before deploying the service, which runs a SQL script for creating a DB account for access, and a user record for auditing.

The runbook and scripts are defined here: https://github.com/ministryofjustice/hmpps-delius-pipelines/pull/476
And the permissions to run it from CI is here: https://github.com/ministryofjustice/hmpps-security-access-terraform/pull/637

