### PR TITLE
Don't publish test reports from forked PRs

### DIFF
--- a/.github/actions/build-and-test/action.yml
+++ b/.github/actions/build-and-test/action.yml
@@ -32,19 +32,18 @@ runs:
 
     - name: Build and test
       uses: gradle/gradle-build-action@v2
-      if: ${{ github.actor == 'dependabot[bot]' }}
       with:
-        arguments: "check"
+        arguments: check
 
-    - name: Build and test
+    - name: Sonar analysis
       uses: gradle/gradle-build-action@v2
-      if: ${{ github.actor != 'dependabot[bot]' }}
+      if: ${{ github.event.pull_request.head.repo.fork == false }}
       with:
-        arguments: "build sonarqube"
+        arguments: sonarqube
 
     - name: Publish test reports
       uses: mikepenz/action-junit-report@main # switch to tag once multi-report feature is released - see https://github.com/mikepenz/action-junit-report/releases
-      if: always()
+      if: always() && github.event.pull_request.head.repo.fork == false
       with:
         check_name: |-
           Unit test results

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,8 +29,12 @@ on:
           # See https://github.com/community/community/discussions/11795
       environment:
         description: Environment
-        type: environment
+        type: choice
         required: true
+        options:
+          - test
+          - preprod
+          - prod
       version:
         description: Image version
         type: string


### PR DESCRIPTION
Forked PRs are read-only, so the test reporter is unable to create the checks