### PR TITLE
PI-367

### DIFF
--- a/projects/prison-case-notes-to-probation/src/main/resources/application.yml
+++ b/projects/prison-case-notes-to-probation/src/main/resources/application.yml
@@ -35,6 +35,8 @@ spring.security.oauth2.client:
   provider:
     hmpps-auth:
 
+logging.level:
+    org.hibernate.engine.jdbc.spi.SqlExceptionHelper: OFF
 
 ---
 # Shared dev/test config


### PR DESCRIPTION
Turned off hibernate SQL Exception Handler loggers to prevent filling the log with expected constraint violations - they are being caught and dealt with - so no need to log them