### PR TITLE
Updated HmppsEvent to make detailUrl optional

### DIFF
--- a/libs/commons/src/main/kotlin/uk/gov/justice/digital/hmpps/message/HmppsEvent.kt
+++ b/libs/commons/src/main/kotlin/uk/gov/justice/digital/hmpps/message/HmppsEvent.kt
@@ -11,7 +11,7 @@ interface IntegrationEvent {
 data class HmppsEvent(
     override val eventType: String,
     val version: Int,
-    val detailUrl: String,
+    val detailUrl: String? = null,
     val occurredAt: ZonedDateTime,
     val description: String? = null,
     val additionalInformation: AdditionalInformation = AdditionalInformation(),

--- a/libs/commons/src/main/kotlin/uk/gov/justice/digital/hmpps/telemetry/TelemetryService.kt
+++ b/libs/commons/src/main/kotlin/uk/gov/justice/digital/hmpps/telemetry/TelemetryService.kt
@@ -16,10 +16,9 @@ class TelemetryService(private val telemetryClient: TelemetryClient = TelemetryC
     fun hmppsEventReceived(hmppsEvent: HmppsEvent) {
         trackEvent(
             "${hmppsEvent.eventType.uppercase().replace(".", "_")}_RECEIVED",
-            mapOf(
-                "eventType" to hmppsEvent.eventType,
-                "detailUrl" to hmppsEvent.detailUrl
-            ) + (hmppsEvent.personReference.identifiers.associate { Pair(it.type, it.value) })
+            mapOf("eventType" to hmppsEvent.eventType) +
+                (hmppsEvent.detailUrl?.let { mapOf("detailUrl" to it) } ?: mapOf()) +
+                (hmppsEvent.personReference.identifiers.associate { Pair(it.type, it.value) })
         )
     }
 }

--- a/libs/dev-tools/src/main/kotlin/uk/gov/justice/digital/hmpps/TestHelper.kt
+++ b/libs/dev-tools/src/main/kotlin/uk/gov/justice/digital/hmpps/TestHelper.kt
@@ -9,10 +9,7 @@ import java.time.temporal.ChronoUnit
 fun prepMessage(fileName: String, port: Int): HmppsEvent {
     val hmppsEvent = ResourceLoader.message<HmppsEvent>(fileName)
     return hmppsEvent.copy(
-        detailUrl = hmppsEvent.detailUrl.replace(
-            "{wiremock.port}",
-            port.toString()
-        )
+        detailUrl = hmppsEvent.detailUrl?.replace("{wiremock.port}", port.toString())
     )
 }
 

--- a/projects/pre-sentence-reports-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/listener/MessageListener.kt
+++ b/projects/pre-sentence-reports-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/listener/MessageListener.kt
@@ -27,7 +27,7 @@ class MessageListener(
     fun receive(hmppsEvent: HmppsEvent) {
         log.debug("received $hmppsEvent")
         telemetryService.hmppsEventReceived(hmppsEvent)
-        val psrDocument = psrClient.getPsrReport(URI.create(hmppsEvent.detailUrl + "/pdf"))
+        val psrDocument = psrClient.getPsrReport(URI.create(hmppsEvent.detailUrl!! + "/pdf"))
         documentService.updateCourtReportDocument(hmppsEvent, psrDocument)
     }
 }

--- a/projects/workforce-allocations-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/listener/MessageListener.kt
+++ b/projects/workforce-allocations-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/listener/MessageListener.kt
@@ -35,7 +35,7 @@ class MessageListener(
         log.debug("received $allocationEvent")
         telemetryService.hmppsEventReceived(allocationEvent)
 
-        when (val allocationDetail = allocationsClient.getAllocationDetail(URI.create(allocationEvent.detailUrl))) {
+        when (val allocationDetail = allocationsClient.getAllocationDetail(URI.create(allocationEvent.detailUrl!!))) {
             is PersonAllocationDetail -> allocatePersonService.createPersonAllocation(allocationDetail)
             is EventAllocationDetail -> allocateEventService.createEventAllocation(
                 allocationEvent.findCrn(), allocationDetail


### PR DESCRIPTION
The release and recall messages don't specify a detailUrl - all the information is in the message.  I expect it'll be the same for the RSR score messages too.