### PR TITLE
PI-406 Send failed Logstash events to the SQS DLQ

### DIFF
--- a/projects/person-search-index-from-delius/container/Dockerfile
+++ b/projects/person-search-index-from-delius/container/Dockerfile
@@ -2,8 +2,11 @@ FROM opensearchproject/logstash-oss-with-opensearch-output-plugin:7.16.3
 
 COPY --chown=logstash ojdbc11.jar statement.sql /etc/logstash/
 COPY --chown=logstash logstash-full-load.conf /usr/share/logstash/full-load/logstash.conf
+COPY --chown=logstash logstash-full-load-dlq.conf /usr/share/logstash/full-load-dlq/logstash.conf
 COPY --chown=logstash logstash-incremental.conf /usr/share/logstash/incremental/logstash.conf
+COPY --chown=logstash logstash-incremental-dlq.conf /usr/share/logstash/incremental-dlq/logstash.conf
 COPY --chown=logstash logstash.yml pipelines.yml /usr/share/logstash/config/
+RUN mkdir -p /usr/share/logstash/data/dead_letter_queue/incremental /usr/share/logstash/data/dead_letter_queue/full-load
 
 # Workaround for the jdbc_streaming plugin not supporting statement_filepath.
 # See https://github.com/logstash-plugins/logstash-integration-jdbc/issues/51

--- a/projects/person-search-index-from-delius/container/logstash-full-load-dlq.conf
+++ b/projects/person-search-index-from-delius/container/logstash-full-load-dlq.conf
@@ -1,0 +1,30 @@
+input {
+    dead_letter_queue {
+        id => "read-logstash-dlq"
+        path => "/usr/share/logstash/data/dead_letter_queue"
+        pipeline_id => "full-load"
+    }
+}
+
+filter {
+    mutate {
+        id => "synthesize-sqs-message"
+        add_field => {
+            "Message" => "{\"offenderId\": %{offenderId}}"
+            "error_reason" => "%{[@metadata][dead_letter_queue][reason]}"
+            "plugin_id" => "%{[@metadata][dead_letter_queue][plugin_id]}"
+            "plugin_type" => "%{[@metadata][dead_letter_queue][plugin_type]}"
+            "entry_time" => "%{[@metadata][dead_letter_queue][entry_time]}"
+       }
+    }
+}
+
+output {
+    sqs {
+        id => "send-to-sqs-dlq"
+        queue => "${SQS_DLQ_NAME}"
+        access_key_id => "${SQS_DLQ_ACCESS_KEY_ID}"
+        secret_access_key => "${SQS_DLQ_SECRET_ACCESS_KEY}"
+        region => "eu-west-2"
+    }
+}

--- a/projects/person-search-index-from-delius/container/logstash-full-load.conf
+++ b/projects/person-search-index-from-delius/container/logstash-full-load.conf
@@ -26,13 +26,23 @@ filter {
 }
 
 output {
-    opensearch {
-        id => "index-into-standby"
-        hosts => ["${SEARCH_INDEX_HOST}"]
-        user => "${SEARCH_INDEX_USERNAME}"
-        password => "${SEARCH_INDEX_PASSWORD}"
-        index => "${STANDBY_INDEX_NAME}"
-        document_id => "%{offenderId}"
-        action => "index"
+    if [tags] and [tags][0] {
+        sqs {
+            id => "send-to-sqs-dlq"
+            queue => "${SQS_DLQ_NAME}"
+            access_key_id => "${SQS_DLQ_ACCESS_KEY_ID}"
+            secret_access_key => "${SQS_DLQ_SECRET_ACCESS_KEY}"
+            region => "eu-west-2"
+        }
+    } else {
+        opensearch {
+            id => "index-into-standby"
+            hosts => ["${SEARCH_INDEX_HOST}"]
+            user => "${SEARCH_INDEX_USERNAME}"
+            password => "${SEARCH_INDEX_PASSWORD}"
+            index => "${STANDBY_INDEX_NAME}"
+            document_id => "%{offenderId}"
+            action => "index"
+        }
     }
 }

--- a/projects/person-search-index-from-delius/container/logstash-incremental-dlq.conf
+++ b/projects/person-search-index-from-delius/container/logstash-incremental-dlq.conf
@@ -1,0 +1,30 @@
+input {
+    dead_letter_queue {
+        id => "read-logstash-dlq"
+        path => "/usr/share/logstash/data/dead_letter_queue"
+        pipeline_id => "incremental"
+    }
+}
+
+filter {
+    mutate {
+        id => "synthesize-sqs-message"
+        add_field => {
+            "Message" => "{\"offenderId\": %{offenderId}}"
+            "error_reason" => "%{[@metadata][dead_letter_queue][reason]}"
+            "plugin_id" => "%{[@metadata][dead_letter_queue][plugin_id]}"
+            "plugin_type" => "%{[@metadata][dead_letter_queue][plugin_type]}"
+            "entry_time" => "%{[@metadata][dead_letter_queue][entry_time]}"
+       }
+    }
+}
+
+output {
+    sqs {
+        id => "send-to-sqs-dlq"
+        queue => "${SQS_DLQ_NAME}"
+        access_key_id => "${SQS_DLQ_ACCESS_KEY_ID}"
+        secret_access_key => "${SQS_DLQ_SECRET_ACCESS_KEY}"
+        region => "eu-west-2"
+    }
+}

--- a/projects/person-search-index-from-delius/container/logstash-incremental.conf
+++ b/projects/person-search-index-from-delius/container/logstash-incremental.conf
@@ -1,20 +1,23 @@
 input {
     sqs {
         id => "poll-for-changes"
-        queue => "${AWS_SQS_QUEUE_NAME}"
+        queue => "${SQS_QUEUE_NAME}"
+        access_key_id => "${SQS_QUEUE_ACCESS_KEY_ID}"
+        secret_access_key => "${SQS_QUEUE_SECRET_ACCESS_KEY}"
         region => "eu-west-2"
     }
 #     # Useful for testing:
 #     generator {
 #         lines => [
-#             '{"Message":"{\"offenderId\":2500000503,\"crn\":\"D001024\"}","MessageAttributes":{"eventType":{"Type":"String","Value":"OFFENDER_CHANGED"}}}',
-#             '{"Message":"{\"offenderId\":2500000506,\"crn\":\"D001027\"}","MessageAttributes":{"eventType":{"Type":"String","Value":"OFFENDER_CHANGED"}}}'
+#             '{"Message":"{\\"offenderId\\":2500000503,\\"crn\\":\\"D001024\\"}","MessageAttributes":{"eventType":{"Type":"String","Value":"OFFENDER_CHANGED"}}}',
+#             '{"Message":"{\\"offenderId\\":2500000506,\\"crn\\":\\"D001027\\"}","MessageAttributes":{"eventType":{"Type":"String","Value":"OFFENDER_CHANGED"}}}'
 #         ]
 #         count => 1 # remove this to send messages repeatedly
 #     }
 }
 
 filter {
+#    json { source => "message" }  # required when testing with 'generator' input
     json {
         id => "parse-nested-json"
         source => "Message"
@@ -29,37 +32,50 @@ filter {
         statement => "${INCREMENTAL_STATEMENT_SQL}"
         parameters => { "offender_id" => "%{offenderId}" }
         target => "db"
+        tag_on_default_use => []
     }
-    prune { whitelist_names => ["offenderId", "db"] }
-    json {
-        id => "parse-db-json"
-        source => "[db][0][json]"
-    }
-    if [db][0] {
+    prune { whitelist_names => ["offenderId", "db", "tags", "Message"] }
+    if [db][0][json] {
+        json {
+            id => "parse-db-json"
+            source => "[db][0][json]"
+        }
         mutate { add_field => { "action" => "index" } }
     } else {
         mutate { add_field => { "action" => "delete" } }
     }
-    mutate { remove_field => ["db"] }
+    if ![tags] or ![tags][0] {
+        mutate { remove_field => ["db", "Message", "MessageAttributes"] }
+    }
 }
 
 output {
-    opensearch {
-        id => "index-into-primary"
-        hosts => ["${SEARCH_INDEX_HOST}"]
-        user => "${SEARCH_INDEX_USERNAME}"
-        password => "${SEARCH_INDEX_PASSWORD}"
-        index => "${PRIMARY_INDEX_NAME}"
-        action => "%{action}"
-        document_id => "%{offenderId}"
-    }
-    opensearch {
-        id => "index-into-standby"
-        hosts => ["${SEARCH_INDEX_HOST}"]
-        user => "${SEARCH_INDEX_USERNAME}"
-        password => "${SEARCH_INDEX_PASSWORD}"
-        index => "${STANDBY_INDEX_NAME}"
-        document_id => "%{offenderId}"
-        action => "%{action}"
+    if [tags] and [tags][0] {
+        sqs {
+            id => "send-to-sqs-dlq"
+            queue => "${SQS_DLQ_NAME}"
+            access_key_id => "${SQS_DLQ_ACCESS_KEY_ID}"
+            secret_access_key => "${SQS_DLQ_SECRET_ACCESS_KEY}"
+            region => "eu-west-2"
+        }
+    } else {
+        opensearch {
+            id => "index-into-primary"
+            hosts => ["${SEARCH_INDEX_HOST}"]
+            user => "${SEARCH_INDEX_USERNAME}"
+            password => "${SEARCH_INDEX_PASSWORD}"
+            index => "${PRIMARY_INDEX_NAME}"
+            action => "%{action}"
+            document_id => "%{offenderId}"
+        }
+        opensearch {
+            id => "index-into-standby"
+            hosts => ["${SEARCH_INDEX_HOST}"]
+            user => "${SEARCH_INDEX_USERNAME}"
+            password => "${SEARCH_INDEX_PASSWORD}"
+            index => "${STANDBY_INDEX_NAME}"
+            document_id => "%{offenderId}"
+            action => "%{action}"
+        }
     }
 }

--- a/projects/person-search-index-from-delius/container/logstash.yml
+++ b/projects/person-search-index-from-delius/container/logstash.yml
@@ -1,5 +1,3 @@
-pipeline:
-  batch:
-    size: 250
-
 config.support_escapes: true
+dead_letter_queue.enable: true
+pipeline.batch.size: 250

--- a/projects/person-search-index-from-delius/container/pipelines.yml
+++ b/projects/person-search-index-from-delius/container/pipelines.yml
@@ -1,5 +1,11 @@
 - pipeline.id: full-load
   path.config: "/usr/share/logstash/full-load/logstash.conf"
 
+- pipeline.id: full-load-dlq
+  path.config: "/usr/share/logstash/full-load-dlq/logstash.conf"
+
 - pipeline.id: incremental
   path.config: "/usr/share/logstash/incremental/logstash.conf"
+
+- pipeline.id: incremental-dlq
+  path.config: "/usr/share/logstash/incremental-dlq/logstash.conf"

--- a/projects/person-search-index-from-delius/deploy/values.yml
+++ b/projects/person-search-index-from-delius/deploy/values.yml
@@ -11,11 +11,14 @@ env:
   STANDBY_INDEX_NAME: person-search-standby
 
 secrets:
-  JDBC_CONNECTION_STRING: /delius-database/jdbc-url
-  JDBC_USER:              /person-search-index-from-delius/db-username
-  JDBC_PASSWORD:          /person-search-index-from-delius/db-password
-  SEARCH_INDEX_USERNAME:  /person-search-index-from-delius/ingress-username
-  SEARCH_INDEX_PASSWORD:  /person-search-index-from-delius/ingress-password
-  AWS_SQS_QUEUE_NAME:     /person-search-index-from-delius/sqs-queue-name
-  AWS_ACCESS_KEY_ID:      /person-search-index-from-delius/sqs-aws-access-key-id
-  AWS_SECRET_ACCESS_KEY:  /person-search-index-from-delius/sqs-aws-secret-access-key
+  JDBC_CONNECTION_STRING:      /delius-database/jdbc-url
+  JDBC_USER:                   /person-search-index-from-delius/db-username
+  JDBC_PASSWORD:               /person-search-index-from-delius/db-password
+  SEARCH_INDEX_USERNAME:       /person-search-index-from-delius/ingress-username
+  SEARCH_INDEX_PASSWORD:       /person-search-index-from-delius/ingress-password
+  SQS_QUEUE_NAME:              /person-search-index-from-delius/sqs-queue-name
+  SQS_QUEUE_ACCESS_KEY_ID:     /person-search-index-from-delius/sqs-queue-access-key-id
+  SQS_QUEUE_SECRET_ACCESS_KEY: /person-search-index-from-delius/sqs-queue-secret-access-key
+  SQS_DLQ_NAME:                /person-search-index-from-delius/sqs-dlq-name
+  SQS_DLQ_ACCESS_KEY_ID:       /person-search-index-from-delius/sqs-dlq-access-key-id
+  SQS_DLQ_SECRET_ACCESS_KEY:   /person-search-index-from-delius/sqs-dlq-secret-access-key

--- a/projects/person-search-index-from-delius/docker-compose.yml
+++ b/projects/person-search-index-from-delius/docker-compose.yml
@@ -8,11 +8,12 @@ services:
       JDBC_CONNECTION_STRING: jdbc:oracle:thin:@//oracledb:1521/XEPDB1
       JDBC_USER: delius_app_schema
       JDBC_PASSWORD: NDelius1
-      PRIMARY_INDEX_NAME: primary
-      STANDBY_INDEX_NAME: standby
+      PRIMARY_INDEX_NAME: person-search-primary
+      STANDBY_INDEX_NAME: person-search-standby
       SEARCH_INDEX_HOST: "http://elasticsearch:9200"
       SEARCH_INDEX_USERNAME: elastic
       SEARCH_INDEX_PASSWORD: elastic
+      INDEX_SCHEDULE: "* * * * *"
     ports:
       - "9600:9600"
     depends_on:
@@ -33,7 +34,7 @@ services:
       - shared
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.9.3
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
     healthcheck:
       test: curl -f localhost:9200
     environment:


### PR DESCRIPTION
This commit updates the Logstash pipelines to handle two main types of failures:
1. failures in the `filter` plugins (e.g. JSON parsing)
2. failures in the `output` plugins (e.g. non-retryable error responses from Elasticsearch/OpenSearch)

Note that failures in the `input` plugins will result in the pipeline being terminated.

### `filter` failures
Typically, filters add "tags" to the event when an error occurs - rather than actually failing or dropping the event. This is problematic as we could accidentally index partial/invalid documents, if for example the JDBC lookup fails in the incremental pipeline.

This is now handled by checking for the presence of tags and sending the message to the SQS DLQ.

### `output` failures
The `elasticsearch`/`opensearch` output plugins will retry most errors indefinitely, however 400 and 404 errors will be sent to an internal Logstash DLQ. Two additional "dlq" pipelines have been added to capture these and push them to our SQS DLQ.

Note: 409 errors (i.e. version mismatches) will always be logged and dropped, but we shouldn't get any of these as we don't use document versioning.

Depends on:
* https://github.com/ministryofjustice/cloud-platform-environments/pull/8591
* https://github.com/ministryofjustice/cloud-platform-environments/pull/8593
* https://github.com/ministryofjustice/cloud-platform-environments/pull/8594
