### PR TITLE
PI-424 Remove tags at start of incremental pipeline

### DIFF
--- a/projects/person-search-index-from-delius/container/logstash-incremental.conf
+++ b/projects/person-search-index-from-delius/container/logstash-incremental.conf
@@ -18,6 +18,7 @@ input {
 
 filter {
 #    json { source => "message" }  # required when testing with 'generator' input
+    mutate { remove_field => [ "tags" ] } # Remove any previous errors during a DLQ redrive
     json {
         id => "parse-nested-json"
         source => "Message"

--- a/projects/person-search-index-from-delius/container/logstash-incremental.conf
+++ b/projects/person-search-index-from-delius/container/logstash-incremental.conf
@@ -41,9 +41,9 @@ filter {
             id => "parse-db-json"
             source => "[db][0][json]"
         }
-        mutate { add_field => { "action" => "index" } }
+        mutate { add_field => { "[@metadata][action]" => "index" } }
     } else {
-        mutate { add_field => { "action" => "delete" } }
+        mutate { add_field => { "[@metadata][action]" => "delete" } }
     }
     if ![tags] or ![tags][0] {
         mutate { remove_field => ["db", "Message", "MessageAttributes"] }
@@ -66,7 +66,7 @@ output {
             user => "${SEARCH_INDEX_USERNAME}"
             password => "${SEARCH_INDEX_PASSWORD}"
             index => "${PRIMARY_INDEX_NAME}"
-            action => "%{action}"
+            action => "%{[@metadata][action]}"
             document_id => "%{offenderId}"
         }
         opensearch {
@@ -76,7 +76,7 @@ output {
             password => "${SEARCH_INDEX_PASSWORD}"
             index => "${STANDBY_INDEX_NAME}"
             document_id => "%{offenderId}"
-            action => "%{action}"
+            action => "%{[@metadata][action]}"
         }
     }
 }


### PR DESCRIPTION
This prevents any previous errors from being detected and re-sent to the DLQ.