### PR TITLE
Specify Dockerfile location for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,6 @@ updates:
     schedule:
       interval: "daily"
   - package-ecosystem: "docker"
-    directory: "/"
+    directory: "/projects/person-search-index-from-delius"
     schedule:
       interval: "daily"


### PR DESCRIPTION
Dependabot doesn't support wildcards or searching through subdirectories, so for now we'll have to specify any Dockerfiles manually.  See https://github.com/dependabot/dependabot-core/issues/2178