### PR TITLE
PI-428 Remove time component from release/recall dates

### DIFF
--- a/projects/prison-custody-status-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/PrisonCustodyStatusToDeliusIntegrationTest.kt
+++ b/projects/prison-custody-status-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/PrisonCustodyStatusToDeliusIntegrationTest.kt
@@ -36,6 +36,7 @@ import uk.gov.justice.digital.hmpps.listener.nomsNumber
 import uk.gov.justice.digital.hmpps.telemetry.TelemetryService
 import uk.gov.justice.digital.hmpps.test.CustomMatchers.isCloseTo
 import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit.DAYS
 
 @SpringBootTest
 @ActiveProfiles("integration-test")
@@ -91,7 +92,7 @@ internal class PrisonCustodyStatusToDeliusIntegrationTest {
         // and the release information is recorded correctly
         val release = getReleases(custody).single()
         assertThat(release.createdDatetime, isCloseTo(ZonedDateTime.now()))
-        assertThat(release.date.withZoneSameInstant(EuropeLondon), equalTo(message.occurredAt))
+        assertThat(release.date.withZoneSameInstant(EuropeLondon), equalTo(message.occurredAt.truncatedTo(DAYS)))
         assertThat(release.person.nomsNumber, equalTo(message.additionalInformation.nomsNumber()))
 
         // and the history is recorded correctly
@@ -109,6 +110,7 @@ internal class PrisonCustodyStatusToDeliusIntegrationTest {
         verify(telemetryService).trackEvent(
             "PrisonerReleased",
             mapOf(
+                "occurredAt" to message.occurredAt.toString(),
                 "nomsNumber" to "A0001AA",
                 "institution" to "WSI",
                 "reason" to "RELEASED",
@@ -134,7 +136,7 @@ internal class PrisonCustodyStatusToDeliusIntegrationTest {
         // and the recall information is recorded correctly
         val recall = getRecalls(custody).single()
         assertThat(recall.createdDatetime, isCloseTo(ZonedDateTime.now()))
-        assertThat(recall.date.withZoneSameInstant(EuropeLondon), equalTo(message.occurredAt))
+        assertThat(recall.date.withZoneSameInstant(EuropeLondon), equalTo(message.occurredAt.truncatedTo(DAYS)))
 
         // and the history is recorded correctly
         val custodyHistory = getCustodyHistory(custody)
@@ -160,6 +162,7 @@ internal class PrisonCustodyStatusToDeliusIntegrationTest {
         verify(telemetryService).trackEvent(
             "PrisonerRecalled",
             mapOf(
+                "occurredAt" to message.occurredAt.toString(),
                 "nomsNumber" to "A0002AA",
                 "institution" to "WSI",
                 "reason" to "ADMISSION",

--- a/projects/prison-custody-status-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/custody/Custody.kt
+++ b/projects/prison-custody-status-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/custody/Custody.kt
@@ -1,6 +1,11 @@
 package uk.gov.justice.digital.hmpps.integrations.delius.custody
 
 import org.hibernate.annotations.Where
+import org.springframework.data.annotation.CreatedBy
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedBy
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import uk.gov.justice.digital.hmpps.integrations.delius.event.Disposal
 import uk.gov.justice.digital.hmpps.integrations.delius.probationarea.institution.Institution
 import uk.gov.justice.digital.hmpps.integrations.delius.referencedata.ReferenceData
@@ -9,6 +14,7 @@ import uk.gov.justice.digital.hmpps.integrations.delius.release.Release
 import java.time.ZonedDateTime
 import javax.persistence.Column
 import javax.persistence.Entity
+import javax.persistence.EntityListeners
 import javax.persistence.Id
 import javax.persistence.JoinColumn
 import javax.persistence.JoinColumns
@@ -18,6 +24,7 @@ import javax.persistence.OneToOne
 import javax.persistence.Version
 
 @Entity
+@EntityListeners(AuditingEntityListener::class)
 @Where(clause = "soft_deleted = 0")
 class Custody(
     @Id
@@ -54,6 +61,22 @@ class Custody(
 
     @OneToMany(mappedBy = "custody")
     val releases: MutableList<Release> = ArrayList(),
+
+    @Column(nullable = false, updatable = false)
+    @CreatedBy
+    var createdByUserId: Long = 0,
+
+    @Column(nullable = false)
+    @LastModifiedBy
+    var lastUpdatedUserId: Long = 0,
+
+    @Column(nullable = false, updatable = false)
+    @CreatedDate
+    var createdDatetime: ZonedDateTime = ZonedDateTime.now(),
+
+    @Column(nullable = false)
+    @LastModifiedDate
+    var lastUpdatedDatetime: ZonedDateTime = ZonedDateTime.now(),
 ) {
     fun isInCustody() = status.code in listOf(
         CustodialStatusCode.RECALLED.code,

--- a/projects/prison-custody-status-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/listener/MessageListener.kt
+++ b/projects/prison-custody-status-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/listener/MessageListener.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.integrations.delius.release.ReleaseService
 import uk.gov.justice.digital.hmpps.message.AdditionalInformation
 import uk.gov.justice.digital.hmpps.message.HmppsEvent
 import uk.gov.justice.digital.hmpps.telemetry.TelemetryService
+import java.time.temporal.ChronoUnit.DAYS
 
 @Component
 @EnableJms
@@ -36,7 +37,7 @@ class MessageListener(
                         hmppsEvent.additionalInformation.nomsNumber(),
                         hmppsEvent.additionalInformation.prisonId(),
                         hmppsEvent.additionalInformation.reason(),
-                        hmppsEvent.occurredAt,
+                        hmppsEvent.occurredAt.truncatedTo(DAYS),
                     )
                     telemetryService.trackEvent("PrisonerReleased", hmppsEvent.telemetryProperties())
                 }
@@ -46,7 +47,7 @@ class MessageListener(
                         hmppsEvent.additionalInformation.nomsNumber(),
                         hmppsEvent.additionalInformation.prisonId(),
                         hmppsEvent.additionalInformation.reason(),
-                        hmppsEvent.occurredAt,
+                        hmppsEvent.occurredAt.truncatedTo(DAYS),
                     )
                     telemetryService.trackEvent("PrisonerRecalled", hmppsEvent.telemetryProperties())
                 }
@@ -65,6 +66,7 @@ fun AdditionalInformation.prisonId() = this["prisonId"] as String
 fun AdditionalInformation.reason() = this["reason"] as String
 fun AdditionalInformation.details() = this["details"] as String?
 fun HmppsEvent.telemetryProperties() = listOfNotNull(
+    "occurredAt" to occurredAt.toString(),
     "nomsNumber" to additionalInformation.nomsNumber(),
     "institution" to additionalInformation.prisonId(),
     "reason" to additionalInformation.reason(),

--- a/projects/prison-custody-status-to-delius/src/test/kotlin/uk/gov/justice/hmpps/listener/MessageListenerTest.kt
+++ b/projects/prison-custody-status-to-delius/src/test/kotlin/uk/gov/justice/hmpps/listener/MessageListenerTest.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.message.AdditionalInformation
 import uk.gov.justice.digital.hmpps.message.HmppsEvent
 import uk.gov.justice.digital.hmpps.telemetry.TelemetryService
 import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit.DAYS
 
 @ExtendWith(MockitoExtension::class)
 internal class MessageListenerTest {
@@ -51,14 +52,14 @@ internal class MessageListenerTest {
     fun releaseMessagesAreHandled() {
         messageListener.receive(testEvent.copy(eventType = "prison-offender-events.prisoner.released"))
 
-        verify(releaseService).release("Z0001ZZ", "ZZZ", "Test data", testEvent.occurredAt)
+        verify(releaseService).release("Z0001ZZ", "ZZZ", "Test data", testEvent.occurredAt.truncatedTo(DAYS))
     }
 
     @Test
     fun recallMessagesAreHandled() {
         messageListener.receive(testEvent.copy(eventType = "prison-offender-events.prisoner.received"))
 
-        verify(recallService).recall("Z0001ZZ", "ZZZ", "Test data", testEvent.occurredAt)
+        verify(recallService).recall("Z0001ZZ", "ZZZ", "Test data", testEvent.occurredAt.truncatedTo(DAYS))
     }
 
     @Test


### PR DESCRIPTION
This otherwise causes validation to fail in Delius when adding licence conditions.

Also adds missing audit fields to the Custody entity.