### PR TITLE
PI-434 Update bootstrap to optionally create a load balancer for API ingress

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -6,12 +6,33 @@ on:
     inputs:
       project_name:
         description: Project name
-        required: false
+        required: true
         type: string
+      create_database_credentials:
+        description: Will the service access the Delius database?
+        default: true
+        required: true
+        type: boolean
+      create_sentry_project:
+        description: Will the service use Sentry for capturing exceptions?
+        default: true
+        required: true
+        type: boolean
+      create_oauth_client:
+        description: Will the service consume another HTTP API that requires HMPPS Auth client credentials?
+        default: true
+        required: true
+        type: boolean
+      create_ingress:
+        description: Will the service provide a HTTP API that requires access from MOJ Cloud Platform?
+        default: false
+        required: true
+        type: boolean
 
 jobs:
   auth-setup:
     runs-on: ubuntu-latest
+    if: ${{ inputs.create_oauth_client }}
     steps:
       - run: |
           echo Request HMPPS Auth credentials: https://mojdt.slack.com/archives/C02S71KUBED
@@ -22,6 +43,7 @@ jobs:
 
   db-secrets-setup:
     runs-on: ubuntu-latest
+    if: ${{ inputs.create_database_credentials }}
     steps:
       - uses: actions/checkout@v3
 
@@ -65,8 +87,13 @@ jobs:
           path: hmpps-delius-core-terraform
           repository: ministryofjustice/hmpps-delius-core-terraform
 
-      - name: Render Terraform template
+      - name: Render Terraform service template
+        if: ${{ ! inputs.create_ingress }}
         run: sed 's/$SERVICE_NAME/${{ inputs.project_name }}/' templates/service.tf > 'hmpps-delius-core-terraform/application/probation-integration-services/${{ inputs.project_name }}.tf'
+
+      - name: Render Terraform service with load-balancer template
+        if: ${{ inputs.create_ingress }}
+        run: sed 's/$SERVICE_NAME/${{ inputs.project_name }}/' templates/service-with-load-balancer.tf > 'hmpps-delius-core-terraform/application/probation-integration-services/${{ inputs.project_name }}.tf'
 
       - name: Create pull request
         id: pr
@@ -86,6 +113,7 @@ jobs:
 
   sentry-setup:
     runs-on: ubuntu-latest
+    if: ${{ inputs.create_sentry_project }}
     steps:
       # convert project name to environment variable (e.g. 'hello-world' -> 'HELLO_WORLD')
       - id: project_name

--- a/templates/service-with-load-balancer.tf
+++ b/templates/service-with-load-balancer.tf
@@ -33,10 +33,6 @@ resource "aws_iam_role_policy_attachment" "$SERVICE_NAME" {
   policy_arn = aws_iam_policy.access_ssm_parameters.arn
 }
 
-resource "random_id" "$SERVICE_NAME" {
-  byte_length = 8
-}
-
 resource "aws_lb" "$SERVICE_NAME" {
   internal = false
   subnets = [

--- a/templates/service-with-load-balancer.tf
+++ b/templates/service-with-load-balancer.tf
@@ -1,0 +1,140 @@
+module "$SERVICE_NAME" {
+  source                   = "../../modules/ecs_service"
+  region                   = var.region
+  environment_name         = var.environment_name
+  short_environment_name   = var.short_environment_name
+  remote_state_bucket_name = var.remote_state_bucket_name
+  tags                     = var.tags
+
+  # Application Container
+  service_name                   = "$SERVICE_NAME"
+  health_check_path              = "/health"
+  ignore_task_definition_changes = true
+
+  # Security & Networking
+  task_role_arn      = aws_iam_role.ecs_sqs_task.arn
+  target_group_count = 1
+  security_groups = [
+    aws_security_group.$SERVICE_NAME-instances.id,
+    data.terraform_remote_state.delius_core_security_groups.outputs.sg_common_out_id,
+    data.terraform_remote_state.delius_core_security_groups.outputs.sg_delius_db_access_id,
+  ]
+
+  # Monitoring
+  notification_arn = data.terraform_remote_state.alerts.outputs.aws_sns_topic_alarm_notification_arn
+
+  # Scaling
+  min_capacity = local.min_capacity
+  max_capacity = local.max_capacity
+}
+
+resource "aws_iam_role_policy_attachment" "$SERVICE_NAME" {
+  role       = module.$SERVICE_NAME.exec_role.name
+  policy_arn = aws_iam_policy.access_ssm_parameters.arn
+}
+
+resource "random_id" "$SERVICE_NAME" {
+  byte_length = 8
+}
+
+resource "aws_lb" "$SERVICE_NAME" {
+  internal = false
+  subnets = [
+    data.terraform_remote_state.vpc.outputs.vpc_public-subnet-az1,
+    data.terraform_remote_state.vpc.outputs.vpc_public-subnet-az2,
+    data.terraform_remote_state.vpc.outputs.vpc_public-subnet-az3
+  ]
+  security_groups = [aws_security_group.$SERVICE_NAME-lb.id]
+  tags            = merge(var.tags, { Name = "${var.short_environment_name}-$SERVICE_NAME-lb" })
+
+  access_logs {
+    enabled = true
+    bucket  = data.terraform_remote_state.access_logs.outputs.bucket_name
+    prefix  = "$SERVICE_NAME"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_lb_listener" "$SERVICE_NAME" {
+  load_balancer_arn = aws_lb.$SERVICE_NAME.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
+  certificate_arn   = local.certificate_arn
+  default_action {
+    type = "forward"
+    forward {
+      target_group {
+        arn = module.$SERVICE_NAME.primary_target_group["arn"]
+      }
+    }
+  }
+}
+
+resource "aws_route53_record" "$SERVICE_NAME" {
+  zone_id = local.route53_zone_id
+  name    = "$SERVICE_NAME"
+  type    = "CNAME"
+  ttl     = 300
+  records = [aws_lb.$SERVICE_NAME.dns_name]
+}
+
+resource "aws_security_group" "$SERVICE_NAME-lb" {
+  name        = "${var.environment_name}-$SERVICE_NAME-lb"
+  vpc_id      = data.terraform_remote_state.vpc.outputs.vpc_id
+  description = "$SERVICE_NAME load balancer"
+  tags        = merge(var.tags, { Name = "${var.environment_name}-$SERVICE_NAME-lb" })
+  lifecycle {
+    create_before_destroy = true
+  }
+  ingress {
+    from_port   = 443
+    protocol    = "tcp"
+    to_port     = 443
+    cidr_blocks = concat(var.internal_moj_access_cidr_blocks, local.bastion_public_ip, local.natgateway_public_ips_cidr_blocks)
+    description = "Ingress from VPNs and Bastion hosts"
+  }
+  ingress {
+    from_port   = 443
+    protocol    = "tcp"
+    to_port     = 443
+    cidr_blocks = var.moj_cloud_platform_cidr_blocks
+    description = "Ingress from MOJ Cloud Platform"
+  }
+  egress {
+    from_port       = 8080
+    protocol        = "tcp"
+    to_port         = 8080
+    security_groups = [aws_security_group.$SERVICE_NAME-instances.id]
+    description     = "Egress to instances"
+  }
+}
+
+resource "aws_security_group" "$SERVICE_NAME-instances" {
+  name        = "${var.environment_name}-$SERVICE_NAME-instances"
+  vpc_id      = data.terraform_remote_state.vpc.outputs.vpc_id
+  description = "$SERVICE_NAME instances"
+  tags        = merge(var.tags, { Name = "${var.environment_name}-$SERVICE_NAME-instances" })
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group_rule" "$SERVICE_NAME" {
+  security_group_id        = aws_security_group.$SERVICE_NAME-instances.id
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = 8080
+  to_port                  = 8080
+  source_security_group_id = aws_security_group.$SERVICE_NAME-lb.id
+  description              = "Ingress from load balancer"
+}
+
+output "$SERVICE_NAME" {
+  value = {
+    url = "https://${aws_route53_record.$SERVICE_NAME.fqdn}"
+  }
+}


### PR DESCRIPTION
This adds an extra toggle to the bootstrap workflow: 
> **Will the service provide a HTTP API that requires access from MOJ Cloud Platform?**


When enabled, the bootstrap workflow will automatically add a load balancer to the Terraform code.  It's off-by-default, as most of our services so far are message listeners, rather than API providers.

<img src="https://user-images.githubusercontent.com/39557241/191936772-3e3a17ec-f8dd-4231-b38d-44d7dd608cf6.png" data-canonical-src="https://user-images.githubusercontent.com/39557241/191936772-3e3a17ec-f8dd-4231-b38d-44d7dd608cf6.png" width="400" />
