### PR TITLE
Remove auth config from message-listener template

### DIFF
--- a/templates/projects/message-listener/deploy/values-dev.yml
+++ b/templates/projects/message-listener/deploy/values-dev.yml
@@ -4,6 +4,4 @@ enabled: false # TODO set this to true when you're ready to deploy your service
 
 env:
   SENTRY_ENVIRONMENT: dev
-  SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_HMPPS-AUTH_TOKEN-URI: https://sign-in-dev.hmpps.service.justice.gov.uk/auth/oauth/token
-
   LOGGING_LEVEL_UK_GOV_DIGITAL_JUSTICE_HMPPS: DEBUG

--- a/templates/projects/message-listener/deploy/values-preprod.yml
+++ b/templates/projects/message-listener/deploy/values-preprod.yml
@@ -4,4 +4,3 @@ enabled: false # TODO set this to true when you're ready to deploy your service
 
 env:
   SENTRY_ENVIRONMENT: preprod
-  SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_HMPPS-AUTH_TOKEN-URI: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth/oauth/token

--- a/templates/projects/message-listener/deploy/values-prod.yml
+++ b/templates/projects/message-listener/deploy/values-prod.yml
@@ -4,4 +4,3 @@ enabled: false # TODO set this to true when you're ready to deploy your service
 
 env:
   SENTRY_ENVIRONMENT: prod
-  SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_HMPPS-AUTH_TOKEN-URI: https://sign-in.hmpps.service.justice.gov.uk/auth/oauth/token


### PR DESCRIPTION
There is no OAuth or API client configuration in this template, so the HMPPS Auth urls are not required