### PR TITLE
PI-451 Include timestamp for allocations and contacts

### DIFF
--- a/projects/prison-custody-status-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/recall/RecallService.kt
+++ b/projects/prison-custody-status-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/recall/RecallService.kt
@@ -38,6 +38,7 @@ import uk.gov.justice.digital.hmpps.integrations.delius.referencedata.wellknown.
 import uk.gov.justice.digital.hmpps.integrations.delius.referencedata.wellknown.ReleaseTypeCode
 import uk.gov.justice.digital.hmpps.integrations.delius.release.Release
 import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit.DAYS
 
 @Service
 class RecallService(
@@ -61,13 +62,13 @@ class RecallService(
         nomsNumber: String,
         prisonId: String,
         reason: String,
-        recallDate: ZonedDateTime,
+        recallDateTime: ZonedDateTime,
     ) {
         val recallReason = recallReasonRepository.getByCodeAndSelectableIsTrue(mapToRecallReason(reason).code)
         val institution = institutionRepository.getByNomisCdeCodeAndIdEstablishmentIsTrue(prisonId)
 
         eventService.getActiveCustodialEvents(nomsNumber).forEach {
-            addRecallToEvent(it, institution, recallReason, recallDate)
+            addRecallToEvent(it, institution, recallReason, recallDateTime)
         }
     }
 
@@ -75,7 +76,7 @@ class RecallService(
         event: Event,
         toInstitution: Institution,
         recallReason: RecallReason,
-        recallDate: ZonedDateTime
+        recallDateTime: ZonedDateTime
     ) = audit(BusinessInteractionCode.ADD_RECALL) {
         it["eventId"] = event.id
         OptimisationContext.offenderId.set(event.person.id)
@@ -84,6 +85,7 @@ class RecallService(
         val disposal = event.disposal ?: throw NotFoundException("Disposal", "eventId", event.id)
         val custody = disposal.custody ?: throw NotFoundException("Custody", "disposalId", disposal.id)
         val latestRelease = custody.mostRecentRelease() ?: throw IgnorableMessageException("MissingRelease")
+        val recallDate = recallDateTime.truncatedTo(DAYS)
 
         // perform validation
         validateRecall(custody, latestRelease, recallDate)
@@ -108,7 +110,7 @@ class RecallService(
 
         // allocate a prison manager if institution has changed and institution is linked to a provider
         if (toInstitution.id != latestRelease.institutionId && toInstitution.probationArea != null) {
-            prisonManagerService.allocateToProbationArea(disposal, toInstitution.probationArea, recallDate)
+            prisonManagerService.allocateToProbationArea(disposal, toInstitution.probationArea, recallDateTime)
         }
 
         // terminate any licence conditions
@@ -124,7 +126,7 @@ class RecallService(
         val contact = contactRepository.save(
             Contact(
                 type = contactTypeRepository.getByCode(ContactTypeCode.BREACH_PRISON_RECALL.code),
-                date = recallDate,
+                date = recallDateTime,
                 event = event,
                 person = person,
                 notes = "Reason for Recall: ${recallReason.description}",

--- a/projects/prison-custody-status-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/release/ReleaseService.kt
+++ b/projects/prison-custody-status-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/release/ReleaseService.kt
@@ -30,6 +30,7 @@ import uk.gov.justice.digital.hmpps.integrations.delius.referencedata.wellknown.
 import uk.gov.justice.digital.hmpps.integrations.delius.referencedata.wellknown.InstitutionCode
 import uk.gov.justice.digital.hmpps.integrations.delius.referencedata.wellknown.ReleaseTypeCode
 import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit.DAYS
 
 @Service
 class ReleaseService(
@@ -50,13 +51,13 @@ class ReleaseService(
         nomsNumber: String,
         prisonId: String,
         reason: String,
-        releaseDate: ZonedDateTime,
+        releaseDateTime: ZonedDateTime,
     ) {
         val releaseType = referenceDataRepository.getReleaseType(mapToReleaseType(reason).code)
         val institution = institutionRepository.getByNomisCdeCode(prisonId)
 
         eventService.getActiveCustodialEvents(nomsNumber).forEach {
-            addReleaseToEvent(it, institution, releaseType, releaseDate)
+            addReleaseToEvent(it, institution, releaseType, releaseDateTime)
         }
     }
 
@@ -64,13 +65,14 @@ class ReleaseService(
         event: Event,
         fromInstitution: Institution,
         releaseType: ReferenceData,
-        releaseDate: ZonedDateTime
+        releaseDateTime: ZonedDateTime
     ) = audit(BusinessInteractionCode.ADD_RELEASE) {
         it["eventId"] = event.id
         OptimisationContext.offenderId.set(event.person.id)
 
         val disposal = event.disposal ?: throw NotFoundException("Disposal", "eventId", event.id)
         val custody = disposal.custody ?: throw NotFoundException("Custody", "disposalId", disposal.id)
+        val releaseDate = releaseDateTime.truncatedTo(DAYS)
 
         // perform validation
         validateRelease(custody, fromInstitution, releaseDate)
@@ -101,7 +103,7 @@ class ReleaseService(
         contactRepository.save(
             Contact(
                 type = contactTypeRepository.getByCode(ContactTypeCode.RELEASE_FROM_CUSTODY.code),
-                date = releaseDate,
+                date = releaseDateTime,
                 event = event,
                 person = event.person,
                 notes = "Release Type: ${releaseType.description}",

--- a/projects/prison-custody-status-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/listener/MessageListener.kt
+++ b/projects/prison-custody-status-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/listener/MessageListener.kt
@@ -11,7 +11,6 @@ import uk.gov.justice.digital.hmpps.integrations.delius.release.ReleaseService
 import uk.gov.justice.digital.hmpps.message.AdditionalInformation
 import uk.gov.justice.digital.hmpps.message.HmppsEvent
 import uk.gov.justice.digital.hmpps.telemetry.TelemetryService
-import java.time.temporal.ChronoUnit.DAYS
 
 @Component
 @EnableJms
@@ -37,7 +36,7 @@ class MessageListener(
                         hmppsEvent.additionalInformation.nomsNumber(),
                         hmppsEvent.additionalInformation.prisonId(),
                         hmppsEvent.additionalInformation.reason(),
-                        hmppsEvent.occurredAt.truncatedTo(DAYS),
+                        hmppsEvent.occurredAt,
                     )
                     telemetryService.trackEvent("PrisonerReleased", hmppsEvent.telemetryProperties())
                 }
@@ -47,7 +46,7 @@ class MessageListener(
                         hmppsEvent.additionalInformation.nomsNumber(),
                         hmppsEvent.additionalInformation.prisonId(),
                         hmppsEvent.additionalInformation.reason(),
-                        hmppsEvent.occurredAt.truncatedTo(DAYS),
+                        hmppsEvent.occurredAt,
                     )
                     telemetryService.trackEvent("PrisonerRecalled", hmppsEvent.telemetryProperties())
                 }

--- a/projects/prison-custody-status-to-delius/src/test/kotlin/uk/gov/justice/hmpps/listener/MessageListenerTest.kt
+++ b/projects/prison-custody-status-to-delius/src/test/kotlin/uk/gov/justice/hmpps/listener/MessageListenerTest.kt
@@ -14,7 +14,6 @@ import uk.gov.justice.digital.hmpps.message.AdditionalInformation
 import uk.gov.justice.digital.hmpps.message.HmppsEvent
 import uk.gov.justice.digital.hmpps.telemetry.TelemetryService
 import java.time.ZonedDateTime
-import java.time.temporal.ChronoUnit.DAYS
 
 @ExtendWith(MockitoExtension::class)
 internal class MessageListenerTest {
@@ -52,14 +51,14 @@ internal class MessageListenerTest {
     fun releaseMessagesAreHandled() {
         messageListener.receive(testEvent.copy(eventType = "prison-offender-events.prisoner.released"))
 
-        verify(releaseService).release("Z0001ZZ", "ZZZ", "Test data", testEvent.occurredAt.truncatedTo(DAYS))
+        verify(releaseService).release("Z0001ZZ", "ZZZ", "Test data", testEvent.occurredAt)
     }
 
     @Test
     fun recallMessagesAreHandled() {
         messageListener.receive(testEvent.copy(eventType = "prison-offender-events.prisoner.received"))
 
-        verify(recallService).recall("Z0001ZZ", "ZZZ", "Test data", testEvent.occurredAt.truncatedTo(DAYS))
+        verify(recallService).recall("Z0001ZZ", "ZZZ", "Test data", testEvent.occurredAt)
     }
 
     @Test


### PR DESCRIPTION
Previously only the truncated date was being recorded, which can cause the check for a currently active responsible officer to fail.

This maintains the truncated date on the release/recall/custody/licence records, so there should be no impact on Delius functionality.