### PR TITLE
PI-442 Added a set of shared tools and base images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,10 @@ updates:
     schedule:
       interval: "daily"
   - package-ecosystem: "docker"
-    directory: "/projects/person-search-index-from-delius/container"
+    directory: "/tools/eclipse-temurin/17-jre"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/tools/opensearch-logstash/8"
     schedule:
       interval: "daily"

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -1,0 +1,35 @@
+name: Tools
+# Rebuild shared Docker images
+
+on:
+  push:
+    paths:
+      - tools/**
+  schedule:
+    - cron: "30 5 * * MON-FRI" # Every weekday at 05:30 UTC
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: gradle/wrapper-validation-action@v1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: -p tools docker
+
+      - name: Push images
+        if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: -p tools dockerTagsPush

--- a/buildSrc/src/main/kotlin/uk/gov/justice/digital/hmpps/plugins/JibConfigPlugin.kt
+++ b/buildSrc/src/main/kotlin/uk/gov/justice/digital/hmpps/plugins/JibConfigPlugin.kt
@@ -18,7 +18,7 @@ class JibConfigPlugin : Plugin<Project> {
                     user = "2000:2000"
                 }
                 from {
-                    image = "eclipse-temurin:17-jre-alpine"
+                    image = "ghcr.io/ministryofjustice/hmpps-probation-integration-services/eclipse-temurin:17-jre-alpine"
                 }
                 to {
                     image = "ghcr.io/ministryofjustice/hmpps-probation-integration-services/${project.name}:${project.version}"

--- a/projects/person-search-index-from-delius/container/Dockerfile
+++ b/projects/person-search-index-from-delius/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/logstash-oss-with-opensearch-output-plugin:8.4.0
+FROM ghcr.io/ministryofjustice/hmpps-probation-integration-services/opensearch-logstash:8
 
 COPY --chown=logstash ojdbc11.jar statement.sql /etc/logstash/
 COPY --chown=logstash logstash-full-load.conf /usr/share/logstash/full-load/logstash.conf
@@ -10,7 +10,7 @@ COPY --chown=logstash logstash.yml pipelines.yml /usr/share/logstash/config/
 COPY --chown=logstash management/* /search-management/
 
 USER root
-RUN apt-get update && apt-get upgrade -y && apt-get -y install \
+RUN apt-get update && apt-get -y install \
   cron \
   jq \
   && rm -rf /var/lib/apt/lists/* \

--- a/tools/build.gradle.kts
+++ b/tools/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    id("com.palantir.docker") version "0.34.0" apply false
+}

--- a/tools/eclipse-temurin/17-jre/Dockerfile
+++ b/tools/eclipse-temurin/17-jre/Dockerfile
@@ -1,0 +1,2 @@
+FROM eclipse-temurin:17-jre-alpine
+RUN apk upgrade --no-cache && rm -rf /var/cache/apk/*

--- a/tools/eclipse-temurin/17-jre/build.gradle.kts
+++ b/tools/eclipse-temurin/17-jre/build.gradle.kts
@@ -1,0 +1,7 @@
+apply(plugin = "com.palantir.docker")
+
+tasks {
+    configure<com.palantir.gradle.docker.DockerExtension> {
+        name = "ghcr.io/ministryofjustice/hmpps-probation-integration-services/eclipse-temurin:17-jre-alpine"
+    }
+}

--- a/tools/opensearch-logstash/8/Dockerfile
+++ b/tools/opensearch-logstash/8/Dockerfile
@@ -1,0 +1,4 @@
+FROM opensearchproject/logstash-oss-with-opensearch-output-plugin:8.4.0
+USER root
+RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
+USER logstash

--- a/tools/opensearch-logstash/8/build.gradle.kts
+++ b/tools/opensearch-logstash/8/build.gradle.kts
@@ -1,0 +1,7 @@
+apply(plugin = "com.palantir.docker")
+
+tasks {
+    configure<com.palantir.gradle.docker.DockerExtension> {
+        name = "ghcr.io/ministryofjustice/hmpps-probation-integration-services/opensearch-logstash:8"
+    }
+}

--- a/tools/settings.gradle.kts
+++ b/tools/settings.gradle.kts
@@ -1,0 +1,4 @@
+include(
+    "eclipse-temurin:17-jre",
+    "opensearch-logstash:8",
+)


### PR DESCRIPTION
This allows us to upgrade dependencies in our base images without waiting for upstream changes. It also gives us a place to add any common images for dev tooling etc, that don't correspond to deployable services.

Happy to discuss whether or not this is a useful idea.  I'm not tied to it so would be keen to get other people's thoughts.

Note: the branch build failure is expected, as the base image hasn't been pushed to ghcr.io yet.  It'll be pushed when this branch is merged to main.