### PR TITLE
Add multiplatform OpenJDK image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,10 @@ updates:
     schedule:
       interval: "daily"
   - package-ecosystem: "docker"
+    directory: "/tools/eclipse-temurin/19-jre-jammy"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "docker"
     directory: "/tools/opensearch-logstash/8"
     schedule:
       interval: "daily"

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -15,6 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1
+      - uses: docker/setup-buildx-action@v2
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2

--- a/tools/eclipse-temurin/19-jre-jammy/Dockerfile
+++ b/tools/eclipse-temurin/19-jre-jammy/Dockerfile
@@ -1,0 +1,2 @@
+FROM --platform=$BUILDPLATFORM eclipse-temurin:19-jre-jammy
+RUN apt-get update && apt-get upgrade -y && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/tools/eclipse-temurin/19-jre-jammy/build.gradle.kts
+++ b/tools/eclipse-temurin/19-jre-jammy/build.gradle.kts
@@ -1,0 +1,10 @@
+apply(plugin = "com.palantir.docker")
+
+tasks {
+    configure<com.palantir.gradle.docker.DockerExtension> {
+        name = "ghcr.io/ministryofjustice/hmpps-probation-integration-services/eclipse-temurin:19-jre-jammy"
+        tag("19-jre-jammy", "ghcr.io/ministryofjustice/hmpps-probation-integration-services/eclipse-temurin:19-jre-jammy")
+        buildx(true)
+        platform("linux/arm64", "linux/amd64")
+    }
+}

--- a/tools/settings.gradle.kts
+++ b/tools/settings.gradle.kts
@@ -1,4 +1,5 @@
 include(
     "eclipse-temurin:17-jre",
-    "opensearch-logstash:8",
+    "eclipse-temurin:19-jre-jammy",
+    "opensearch-logstash:8"
 )


### PR DESCRIPTION
After trying in https://github.com/ministryofjustice/community-api/pull/732 to switch to a multiplatform build, it became apparent that there are no arm64 17 jre alpine Docker images, and also the underlying image in this repo is not multiplatform. This adds a new multiplatform image based on the version 18 Eclipse Temurin image, which is multiplatform, and used in production via the Kotlin template.