### PR TITLE
Add `push` arg for Dockerx multi-platform images

### DIFF
--- a/tools/eclipse-temurin/19-jre-jammy/build.gradle.kts
+++ b/tools/eclipse-temurin/19-jre-jammy/build.gradle.kts
@@ -5,6 +5,7 @@ tasks {
         name = "ghcr.io/ministryofjustice/hmpps-probation-integration-services/eclipse-temurin:19-jre-jammy"
         tag("19-jre-jammy", "ghcr.io/ministryofjustice/hmpps-probation-integration-services/eclipse-temurin:19-jre-jammy")
         buildx(true)
+        push(true)
         platform("linux/arm64", "linux/amd64")
     }
 }


### PR DESCRIPTION
This ensures we only push the images we’ve built, as loading to local registry does not work with multi-platform builds.