### PR TITLE
PI-492 Update risk assessment scores consumer to use eventType from message body

### DIFF
--- a/projects/risk-assessment-scores-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/IntegrationTest.kt
+++ b/projects/risk-assessment-scores-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/IntegrationTest.kt
@@ -28,7 +28,10 @@ internal class IntegrationTest {
 
     @Test
     fun `successfully update RSR scores`() {
-        val notification = Notification(message = MessageGenerator.RSR_SCORES_DETERMINED, attributes = MessageAttributes("risk-assessment.scores.rsr.determined"))
+        val notification = Notification(
+            message = MessageGenerator.RSR_SCORES_DETERMINED,
+            attributes = MessageAttributes("risk-assessment.scores.determined")
+        )
         jmsTemplate.convertSendAndWait(queueName, notification)
         verify(telemetryService).trackEvent("RsrScoresUpdated", notification.message.telemetryProperties())
     }

--- a/projects/risk-assessment-scores-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/listener/MessageListener.kt
+++ b/projects/risk-assessment-scores-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/listener/MessageListener.kt
@@ -19,7 +19,7 @@ class MessageListener(
     fun receive(notification: Notification<HmppsDomainEvent>) {
         telemetryService.notificationReceived(notification)
         val hmppsEvent = notification.message
-        when (notification.eventType) {
+        when (hmppsEvent.eventType) {
             "risk-assessment.scores.rsr.determined" -> {
                 riskScoreService.updateRsrScores(
                     hmppsEvent.personReference.findCrn() ?: throw IllegalArgumentException("Missing CRN in ${hmppsEvent.personReference}"),

--- a/projects/risk-assessment-scores-to-delius/src/test/kotlin/uk/gov/justice/hmpps/listener/MessageListenerTest.kt
+++ b/projects/risk-assessment-scores-to-delius/src/test/kotlin/uk/gov/justice/hmpps/listener/MessageListenerTest.kt
@@ -47,7 +47,7 @@ internal class MessageListenerTest {
         // Given an RSR message
         val message = Notification(
             message = MessageGenerator.RSR_SCORES_DETERMINED,
-            attributes = MessageAttributes("risk-assessment.scores.rsr.determined")
+            attributes = MessageAttributes("risk-assessment.scores.determined")
         )
 
         // When it is received
@@ -70,7 +70,7 @@ internal class MessageListenerTest {
         // Given an OGRS message
         val message = Notification(
             message = MessageGenerator.OGRS_SCORES_DETERMINED,
-            attributes = MessageAttributes("risk-assessment.scores.ogrs.determined")
+            attributes = MessageAttributes("risk-assessment.scores.determined")
         )
 
         // When it is received
@@ -86,8 +86,8 @@ internal class MessageListenerTest {
         assertThrows<IllegalArgumentException> {
             messageListener.receive(
                 Notification(
-                    message = MessageGenerator.RSR_SCORES_DETERMINED,
-                    attributes = MessageAttributes("unknown")
+                    message = MessageGenerator.RSR_SCORES_DETERMINED.copy(eventType = "unknown"),
+                    attributes = MessageAttributes("risk-assessment.scores.determined")
                 )
             )
         }
@@ -99,7 +99,7 @@ internal class MessageListenerTest {
             messageListener.receive(
                 Notification(
                     message = MessageGenerator.RSR_SCORES_DETERMINED.copy(personReference = PersonReference()),
-                    attributes = MessageAttributes("risk-assessment.scores.rsr.determined")
+                    attributes = MessageAttributes("risk-assessment.scores.determined")
                 )
             )
         }


### PR DESCRIPTION
Both RSR and OGRS messages will use "risk-assessment.scores.determined" as the eventType in the attributes, and will use the eventType in the message body to specify which scores (RSR or OGRS) were sent.