### PR TITLE
PI-511 Update Trivy suppressions

### DIFF
--- a/projects/approved-premises-and-delius/.trivyignore
+++ b/projects/approved-premises-and-delius/.trivyignore
@@ -1,3 +1,6 @@
-# Suppression for apache common-text 1.9 as bundled with application insights
-#   can be suppressed for the time being as it will be fixed in next version of application insights
-CVE-2022-42889 exp:2022-10-26
+# Reason: snakeyaml only used for internal (controlled) objects
+CVE-2022-25857 exp:2022-12-01
+
+# Reason: jackson-databind:2.13.3 - The UNWRAP_SINGLE_VALUE_ARRAYS feature is not enabled
+CVE-2022-42003 exp:2022-12-01
+CVE-2022-42004 exp:2022-12-01

--- a/projects/approved-premises-and-oasys/.trivyignore
+++ b/projects/approved-premises-and-oasys/.trivyignore
@@ -1,3 +1,6 @@
-# Suppression for apache common-text 1.9 as bundled with application insights
-#   can be suppressed for the time being as it will be fixed in next version of application insights
-CVE-2022-42889 exp:2022-10-26
+# Reason: snakeyaml only used for internal (controlled) objects
+CVE-2022-25857 exp:2022-12-01
+
+# Reason: jackson-databind:2.13.3 - The UNWRAP_SINGLE_VALUE_ARRAYS feature is not enabled
+CVE-2022-42003 exp:2022-12-01
+CVE-2022-42004 exp:2022-12-01

--- a/projects/pre-sentence-reports-to-delius/.trivyignore
+++ b/projects/pre-sentence-reports-to-delius/.trivyignore
@@ -1,10 +1,6 @@
 # Reason: snakeyaml only used for internal (controlled) objects
-CVE-2022-25857
+CVE-2022-25857 exp:2022-12-01
 
 # Reason: jackson-databind:2.13.3 - The UNWRAP_SINGLE_VALUE_ARRAYS feature is not enabled
-CVE-2022-42003
-CVE-2022-42004
-
-# Suppression for apache common-text 1.9 as bundled with application insights
-#   can be suppressed for the time being as it will be fixed in next version of application insights
-CVE-2022-42889 exp:2022-10-26
+CVE-2022-42003 exp:2022-12-01
+CVE-2022-42004 exp:2022-12-01

--- a/projects/prison-case-notes-to-probation/.trivyignore
+++ b/projects/prison-case-notes-to-probation/.trivyignore
@@ -1,10 +1,6 @@
 # Reason: snakeyaml only used for internal (controlled) objects
-CVE-2022-25857
+CVE-2022-25857 exp:2022-12-01
 
 # Reason: jackson-databind:2.13.3 - The UNWRAP_SINGLE_VALUE_ARRAYS feature is not enabled
-CVE-2022-42003
-CVE-2022-42004
-
-# Suppression for apache common-text 1.9 as bundled with application insights
-#   can be suppressed for the time being as it will be fixed in next version of application insights
-CVE-2022-42889 exp:2022-10-26
+CVE-2022-42003 exp:2022-12-01
+CVE-2022-42004 exp:2022-12-01

--- a/projects/prison-custody-status-to-delius/.trivyignore
+++ b/projects/prison-custody-status-to-delius/.trivyignore
@@ -1,10 +1,6 @@
 # Reason: snakeyaml only used for internal (controlled) objects
-CVE-2022-25857
+CVE-2022-25857 exp:2022-12-01
 
 # Reason: jackson-databind:2.13.3 - The UNWRAP_SINGLE_VALUE_ARRAYS feature is not enabled
-CVE-2022-42003
-CVE-2022-42004
-
-# Suppression for apache common-text 1.9 as bundled with application insights
-#   can be suppressed for the time being as it will be fixed in next version of application insights
-CVE-2022-42889 exp:2022-10-26
+CVE-2022-42003 exp:2022-12-01
+CVE-2022-42004 exp:2022-12-01

--- a/projects/risk-assessment-scores-to-delius/.trivyignore
+++ b/projects/risk-assessment-scores-to-delius/.trivyignore
@@ -1,10 +1,6 @@
 # Reason: snakeyaml only used for internal (controlled) objects
-CVE-2022-25857
+CVE-2022-25857 exp:2022-12-01
 
 # Reason: jackson-databind:2.13.3 - The UNWRAP_SINGLE_VALUE_ARRAYS feature is not enabled
-CVE-2022-42003
-CVE-2022-42004
-
-# Suppression for apache common-text 1.9 as bundled with application insights
-#   can be suppressed for the time being as it will be fixed in next version of application insights
-CVE-2022-42889 exp:2022-10-26
+CVE-2022-42003 exp:2022-12-01
+CVE-2022-42004 exp:2022-12-01

--- a/projects/tier-to-delius/.trivyignore
+++ b/projects/tier-to-delius/.trivyignore
@@ -1,10 +1,6 @@
 # Reason: snakeyaml only used for internal (controlled) objects
-CVE-2022-25857
+CVE-2022-25857 exp:2022-12-01
 
 # Reason: jackson-databind:2.13.3 - The UNWRAP_SINGLE_VALUE_ARRAYS feature is not enabled
-CVE-2022-42003
-CVE-2022-42004
-
-# Suppression for apache common-text 1.9 as bundled with application insights
-#   can be suppressed for the time being as it will be fixed in next version of application insights
-CVE-2022-42889 exp:2022-10-26
+CVE-2022-42003 exp:2022-12-01
+CVE-2022-42004 exp:2022-12-01

--- a/projects/workforce-allocations-to-delius/.trivyignore
+++ b/projects/workforce-allocations-to-delius/.trivyignore
@@ -1,10 +1,6 @@
 # Reason: snakeyaml only used for internal (controlled) objects
-CVE-2022-25857
+CVE-2022-25857 exp:2022-12-01
 
 # Reason: jackson-databind:2.13.3 - The UNWRAP_SINGLE_VALUE_ARRAYS feature is not enabled
-CVE-2022-42003
-CVE-2022-42004
-
-# Suppression for apache common-text 1.9 as bundled with application insights
-#   can be suppressed for the time being as it will be fixed in next version of application insights
-CVE-2022-42889 exp:2022-10-26
+CVE-2022-42003 exp:2022-12-01
+CVE-2022-42004 exp:2022-12-01


### PR DESCRIPTION
* Removes commons-text:1.9 suppression following app insights upgrade
* Adds expiry date for existing suppressions
* Adds suppressions for approved-premises projects