### PR TITLE
PI-482 Remove usage of deprecated CI features

### DIFF
--- a/.github/actions/build-and-test/action.yml
+++ b/.github/actions/build-and-test/action.yml
@@ -28,7 +28,7 @@ runs:
         version=$(date '+%Y-%m-%d').${{ github.run_number }}.$(echo ${{ github.sha }} | cut -c1-7)
         echo version=$version
         echo "ORG_GRADLE_PROJECT_version=$version" >> $GITHUB_ENV
-        echo "::set-output name=version::$version"
+        echo "version=$version" >> $GITHUB_OUTPUT
 
     - name: Compile and test
       uses: gradle/gradle-build-action@v2

--- a/.github/actions/check-changes/parse-changes.sh
+++ b/.github/actions/check-changes/parse-changes.sh
@@ -11,9 +11,9 @@ function topLevelChanges() {
 if [ "$COMMONS_CHANGED" == "true" ]; then
   projects=$(cd projects && echo * | xargs -n1 | toJsonArray)
   echo "Changes detected in common files, rebuild/deploy everything"
-  echo "::set-output name=projects::$projects"
+  echo "projects=$projects" >> $GITHUB_OUTPUT
 elif [ -n "$PROJECT_FILES" ]; then
   projects=$(echo $PROJECT_FILES | xargs -n1 | topLevelChanges | toJsonArray)
   echo "Changes detected in: $projects"
-  echo "::set-output name=projects::$projects"
+  echo "projects=$projects" >> $GITHUB_OUTPUT
 fi

--- a/.github/actions/delius-deploy/action.yml
+++ b/.github/actions/delius-deploy/action.yml
@@ -30,7 +30,7 @@ runs:
   using: composite
   steps:
     - uses: actions/checkout@v3
-    - uses: aws-actions/configure-aws-credentials@v1
+    - uses: aws-actions/configure-aws-credentials@v1-node16
       with:
         aws-region: eu-west-2
         aws-access-key-id: ${{ inputs.aws-access-key-id }}

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -61,8 +61,8 @@ jobs:
       # convert project name to environment variable (e.g. 'hello-world' -> 'HELLO_WORLD')
       - id: project_name
         run: |
-          echo "::set-output name=with_underscores::$(echo '${{ inputs.project_name }}' | sed 's/-/_/g')"
-          echo "::set-output name=with_underscores_uppercase::$(echo '${{ inputs.project_name }}' | sed 's/-/_/g' | tr '[:lower:]' '[:upper:]')"
+          echo "with_underscores=$(echo '${{ inputs.project_name }}' | sed 's/-/_/g')" >> $GITHUB_OUTPUT
+          echo "with_underscores_uppercase=$(echo '${{ inputs.project_name }}' | sed 's/-/_/g' | tr '[:lower:]' '[:upper:]')" >> $GITHUB_OUTPUT
 
       - name: Set database username
         run: gh secret set "$NAME" --body "$VALUE" --app actions
@@ -165,7 +165,7 @@ jobs:
     steps:
       # convert project name to environment variable (e.g. 'hello-world' -> 'HELLO_WORLD')
       - id: project_name
-        run: echo "::set-output name=with_underscores::$(echo '${{ inputs.project_name }}' | tr '[:lower:]' '[:upper:]' | sed 's/-/_/g')"
+        run: echo "with_underscores=$(echo '${{ inputs.project_name }}' | tr '[:lower:]' '[:upper:]' | sed 's/-/_/g')" >> $GITHUB_OUTPUT
 
       - name: Create project
         id: project
@@ -174,7 +174,7 @@ jobs:
             -H 'Authorization: Bearer ${{ secrets.SENTRY_AUTH_TOKEN }}' \
             -H 'Content-Type: application/json' \
             -d '{"name":"${{ inputs.project_name }}"}')
-          echo "::set-output name=slug::$(echo $response | jq -r '.slug')"
+          echo "slug=$(echo $response | jq -r '.slug')" >> $GITHUB_OUTPUT
 
       - name: Set platform to Kotlin
         run: |
@@ -191,8 +191,8 @@ jobs:
           id=$(echo $response | jq -r '.[0].id')
           dsn=$(echo $response | jq -r '.[0].dsn.public')
           echo "::add-mask::$dsn"
-          echo "::set-output name=dsn::$dsn"
-          echo "::set-output name=id::$id"
+          echo "dsn=$dsn" >> $GITHUB_OUTPUT
+          echo "id=$id" >> $GITHUB_OUTPUT
 
       - name: Store DSN as GitHub secret
         uses: mmercan/actions-set-secret@da197fb79d8c1ecedcde53fbd32a4b02ece5723a # v/4.0.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,9 +64,9 @@ jobs:
         id: values
         shell: bash
         run: |
-          if [ '${{ inputs.environment }}' == 'test' ];    then echo '::set-output name=filename::values-dev.yml'; fi
-          if [ '${{ inputs.environment }}' == 'preprod' ]; then echo '::set-output name=filename::values-preprod.yml'; fi
-          if [ '${{ inputs.environment }}' == 'prod' ];    then echo '::set-output name=filename::values-prod.yml'; fi
+          if [ '${{ inputs.environment }}' == 'test' ];    then echo 'filename=values-dev.yml' >> $GITHUB_OUTPUT; fi
+          if [ '${{ inputs.environment }}' == 'preprod' ]; then echo 'filename=values-preprod.yml' >> $GITHUB_OUTPUT; fi
+          if [ '${{ inputs.environment }}' == 'prod' ];    then echo 'filename=values-prod.yml' >> $GITHUB_OUTPUT; fi
 
       - name: Get enabled flag from values file
         id: enabled


### PR DESCRIPTION
* Replaces "::set-output" with $GITHUB_OUTPUT file - see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
* Updates configure-aws-credentials action to use Node v16 - see https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/