### PR TITLE
PI-489 Implement Veracode static code scanning

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,7 +15,7 @@ jobs:
       - id: get-projects
         run: echo "projects=$(cd projects && ls | jq --raw-input . | jq --slurp --compact-output .)" >> $GITHUB_OUTPUT
 
-  scan:
+  trivy-scan:
     runs-on: ubuntu-latest
     needs:
       - get-projects
@@ -98,3 +98,32 @@ jobs:
             }
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+  veracode-scan:
+    runs-on: ubuntu-latest
+    needs:
+      - get-projects
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: temurin
+
+      - name: Build jars
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: jar
+
+      - name: Package jars
+        run: find . -name *.jar | zip -r package.zip -@
+
+      - name: Upload to Veracode
+        uses: veracode/veracode-uploadandscan-action@0.2.4
+        with:
+          appname: hmpps-probation-integration-services
+          createprofile: false
+          deleteincompletescan: 2 # force delete any incomplete scans
+          filepath: package.zip
+          vid: ${{ secrets.CYBERSECURITY_VERACODE_API_ID }}
+          vkey: ${{ secrets.CYBERSECURITY_VERACODE_API_KEY }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,5 @@
 
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import org.springframework.boot.gradle.tasks.bundling.BootJar
 import org.springframework.boot.gradle.tasks.run.BootRun
 import uk.gov.justice.digital.hmpps.plugins.ClassPathPlugin
 import uk.gov.justice.digital.hmpps.plugins.JibConfigPlugin
@@ -47,16 +46,6 @@ allprojects {
             kotlinOptions {
                 freeCompilerArgs = listOf("-Xjsr305=strict")
                 jvmTarget = "17"
-            }
-        }
-
-        withType<BootJar> {
-            enabled = false
-        }
-
-        if (!project.path.startsWith(":libs")) {
-            withType<Jar> {
-                enabled = false
             }
         }
     }


### PR DESCRIPTION
[View the report](https://analysiscenter.veracode.com/auth/index.jsp#ViewReportsDetailedReport:77328:1567873:21728097:21699554:21715204:::::4959212)

We're currently scoring 99/100 on this project, with the only "flaw" due to disabling CSRF.  I've proposed a mitigation, but I'm not sure how they get approved in the Veracode app. 

Note: I've re-enabled the Gradle jar creation as part of this PR.  It doesn't seem to add much time (if any) to the build, so I don't think this is a problem. 

<details>
<summary>The alternative was to extract the jars and class files from the Jib images like below, but that felt a bit messy.</summary>

```shell
for project in $(echo '${{ needs.get-projects.outputs.projects }}' | jq -r '.[]'); do
  mkdir -p package/{}
  docker pull ${DOCKER_PREFIX}/{}:latest
  container_id=$(docker create --rm ${DOCKER_PREFIX}/{}:latest)
  docker cp ${container_id}:/app/classes package/{} || echo "Failed to extract $project"
  docker cp ${container_id}:/app/*-plain.jar package/{} || echo "Failed to extract $project"
done
```

</details>