### PR TITLE
PI-515 Enable parallel Gradle build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 org.gradle.caching=true
+org.gradle.parallel=true
 systemProp.sonar.host.url=https://sonarcloud.io
 systemProp.sonar.organization=ministryofjustice
 systemProp.sonar.projectKey=ministryofjustice_hmpps-probation-integration-services

--- a/projects/approved-premises-and-delius/src/main/resources/application.yml
+++ b/projects/approved-premises-and-delius/src/main/resources/application.yml
@@ -49,7 +49,7 @@ logging.level:
 
 ---
 spring.config.activate.on-profile: integration-test
-spring.datasource.url: jdbc:h2:file:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH;AUTO_SERVER=true;AUTO_SERVER_PORT=9092
+spring.datasource.url: jdbc:h2:file:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle

--- a/projects/pre-sentence-reports-to-delius/src/main/resources/application.yml
+++ b/projects/pre-sentence-reports-to-delius/src/main/resources/application.yml
@@ -77,7 +77,7 @@ spring.config.activate.on-profile: dev
 
 ---
 spring.config.activate.on-profile: integration-test
-spring.datasource.url: jdbc:h2:file:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH;AUTO_SERVER=true;AUTO_SERVER_PORT=9092
+spring.datasource.url: jdbc:h2:file:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle

--- a/projects/prison-case-notes-to-probation/src/main/resources/application.yml
+++ b/projects/prison-case-notes-to-probation/src/main/resources/application.yml
@@ -78,7 +78,7 @@ spring.config.activate.on-profile: dev
 
 ---
 spring.config.activate.on-profile: integration-test
-spring.datasource.url: jdbc:h2:file:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH;AUTO_SERVER=true;AUTO_SERVER_PORT=9092
+spring.datasource.url: jdbc:h2:file:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 
 

--- a/projects/prison-custody-status-to-delius/src/main/resources/application.yml
+++ b/projects/prison-custody-status-to-delius/src/main/resources/application.yml
@@ -36,7 +36,7 @@ logging.level:
 
 ---
 spring.config.activate.on-profile: integration-test
-spring.datasource.url: jdbc:h2:file:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH;AUTO_SERVER=true;AUTO_SERVER_PORT=9092
+spring.datasource.url: jdbc:h2:file:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle

--- a/projects/risk-assessment-scores-to-delius/src/main/resources/application.yml
+++ b/projects/risk-assessment-scores-to-delius/src/main/resources/application.yml
@@ -32,7 +32,7 @@ logging.level:
 
 ---
 spring.config.activate.on-profile: integration-test
-spring.datasource.url: jdbc:h2:file:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH;AUTO_SERVER=true;AUTO_SERVER_PORT=9092
+spring.datasource.url: jdbc:h2:file:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle

--- a/projects/tier-to-delius/src/main/resources/application.yml
+++ b/projects/tier-to-delius/src/main/resources/application.yml
@@ -61,7 +61,7 @@ logging.level:
 
 ---
 spring.config.activate.on-profile: integration-test
-spring.datasource.url: jdbc:h2:file:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH;AUTO_SERVER=true;AUTO_SERVER_PORT=9092
+spring.datasource.url: jdbc:h2:file:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle

--- a/projects/workforce-allocations-to-delius/src/main/resources/application.yml
+++ b/projects/workforce-allocations-to-delius/src/main/resources/application.yml
@@ -78,7 +78,7 @@ spring.config.activate.on-profile: dev
 
 ---
 spring.config.activate.on-profile: integration-test
-spring.datasource.url: jdbc:h2:file:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH;AUTO_SERVER=true;AUTO_SERVER_PORT=9092
+spring.datasource.url: jdbc:h2:file:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 
 

--- a/templates/projects/api-client-and-server/src/main/resources/application.yml
+++ b/templates/projects/api-client-and-server/src/main/resources/application.yml
@@ -60,7 +60,7 @@ logging.level:
 
 ---
 spring.config.activate.on-profile: integration-test
-spring.datasource.url: jdbc:h2:file:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH;AUTO_SERVER=true;AUTO_SERVER_PORT=9092
+spring.datasource.url: jdbc:h2:file:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle

--- a/templates/projects/message-listener-with-api-client-and-server/src/main/resources/application.yml
+++ b/templates/projects/message-listener-with-api-client-and-server/src/main/resources/application.yml
@@ -68,7 +68,7 @@ logging.level:
 
 ---
 spring.config.activate.on-profile: integration-test
-spring.datasource.url: jdbc:h2:file:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH;AUTO_SERVER=true;AUTO_SERVER_PORT=9092
+spring.datasource.url: jdbc:h2:file:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle

--- a/templates/projects/message-listener-with-api-client/src/main/resources/application.yml
+++ b/templates/projects/message-listener-with-api-client/src/main/resources/application.yml
@@ -67,7 +67,7 @@ logging.level:
 
 ---
 spring.config.activate.on-profile: integration-test
-spring.datasource.url: jdbc:h2:file:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH;AUTO_SERVER=true;AUTO_SERVER_PORT=9092
+spring.datasource.url: jdbc:h2:file:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle

--- a/templates/projects/message-listener/src/main/resources/application.yml
+++ b/templates/projects/message-listener/src/main/resources/application.yml
@@ -37,7 +37,7 @@ logging.level:
 
 ---
 spring.config.activate.on-profile: integration-test
-spring.datasource.url: jdbc:h2:file:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH;AUTO_SERVER=true;AUTO_SERVER_PORT=9092
+spring.datasource.url: jdbc:h2:file:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle


### PR DESCRIPTION
Note: The H2 port 9092 is still enabled when running in the "dev" profile, so you can still connect to the database during local development.  This PR just disables the port while integration tests are running.