### PR TITLE
Remove explicit /buildSrc dependabot location

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-  - package-ecosystem: "gradle"
-    directory: "/buildSrc"
-    schedule:
-      interval: "daily"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
This is no longer needed (and results in duplicate PRs), following this issue being closed: https://github.com/dependabot/dependabot-core/issues/2180