### PR TITLE
Disable fail-fast for deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,6 +55,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         project: ${{ fromJson(inputs.projects) }}
     environment:


### PR DESCRIPTION
This allows other deployments to complete when a single one fails.