### PR TITLE
Run end-to-end tests from a branch

### DIFF
--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -5,12 +5,22 @@ on:
     - cron: "0 8 * * MON-FRI" # Every weekday at 08:00 UTC
   workflow_call:
     inputs:
+      test-branch:
+        description: The branch to run in the e2e repo
+        default: main
+        type: string
+        required: true
       projects:
         description: A JSON array of projects to deploy
         type: string
         required: true
   workflow_dispatch:
     inputs:
+      test-branch:
+        description: Test branch
+        default: main
+        type: string
+        required: true
       projects:
         description: Project
         type: choice
@@ -39,6 +49,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: ministryofjustice/hmpps-probation-integration-e2e-tests
+          ref: ${{ inputs.test-branch }}
       - name: Check tests are present
         if: github.event_name != 'schedule'
         run: |


### PR DESCRIPTION
Adds an option to specify the test branch when manually running e2e tests.

![image](https://user-images.githubusercontent.com/39557241/206201682-35c97fa3-4f63-4a10-90dd-0d72685bcb2c.png)

Testing here: https://github.com/ministryofjustice/hmpps-probation-integration-services/actions/runs/3639675571/jobs/6143358704
