### PR TITLE
PI-648 Improve regular expression and add event number message

### DIFF
--- a/projects/risk-assessment-scores-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/RiskScoreService.kt
+++ b/projects/risk-assessment-scores-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/RiskScoreService.kt
@@ -62,7 +62,7 @@ class RiskScoreService(jdbcTemplate: JdbcTemplate) {
 
     private fun parseValidationMessage(e: SQLException) = if (!isValidationMessage(e)) null else e.message
         ?.replace(Regex("\\n.*"), "") // take the first line
-        ?.replace(Regex("\\[.+?]"), "") // remove anything inside square brackets
+        ?.replace(Regex("\\[[^]]++]"), "") // remove anything inside square brackets
         ?.removePrefix("ORA-20000: INTERNAL ERROR: An unexpected error in PL/SQL: ERROR : ") // remove Oracle prefix
         ?.trim()
 

--- a/projects/risk-assessment-scores-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/RiskScoreService.kt
+++ b/projects/risk-assessment-scores-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/RiskScoreService.kt
@@ -70,6 +70,7 @@ class RiskScoreService(jdbcTemplate: JdbcTemplate) {
         private val KNOWN_VALIDATION_MESSAGES = listOf(
             "The existing CAS Assessment Date is greater than a specified P_ASSESSMENT_DATE value",
             "The Event is Soft Deleted",
+            "The event number does not exist against the specified Offender",
             "CRN/Offender does not exist",
         )
     }


### PR DESCRIPTION
Switches from a reluctant qualifier (`.+?`) to a character class exclusion (`[^]]++`) to prevent potentially inefficient backtracking.

Fixes Sonar issue: https://sonarcloud.io/project/issues?issues=AYUV9eDqLOACD6LyoOAG&open=AYUV9eDqLOACD6LyoOAG&id=ministryofjustice_hmpps-probation-integration-services