### PR TITLE
PI-759 Fix team membership SQL

### DIFF
--- a/projects/workforce-allocations-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/allocations/AllocationValidator.kt
+++ b/projects/workforce-allocations-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/allocations/AllocationValidator.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.exceptions.StaffNotInTeamException
 import uk.gov.justice.digital.hmpps.integrations.delius.provider.StaffRepository
 import uk.gov.justice.digital.hmpps.integrations.delius.provider.TeamRepository
 import uk.gov.justice.digital.hmpps.integrations.delius.provider.TeamStaffContainer
+import uk.gov.justice.digital.hmpps.integrations.delius.provider.verifyTeamMembership
 import uk.gov.justice.digital.hmpps.integrations.workforceallocations.AllocationDetail
 
 @Component

--- a/projects/workforce-allocations-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/provider/StaffRepository.kt
+++ b/projects/workforce-allocations-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/provider/StaffRepository.kt
@@ -16,13 +16,13 @@ interface StaffRepository : JpaRepository<StaffRecord, Long> {
 
     @Query(
         """
-        select case when count(team_id) > 0 then true else false end
+        select count(team_id)
         from staff_team
         where staff_id = :staffId and team_id = :teamId
         """,
         nativeQuery = true
     )
-    fun verifyTeamMembership(staffId: Long, teamId: Long): Boolean
+    fun countTeamMembership(staffId: Long, teamId: Long): Int
 
     @Query("select s from StaffWithUser s join s.teams t where t.code = :teamCode")
     fun findAllByTeamsCode(teamCode: String): List<StaffWithUser>
@@ -102,3 +102,5 @@ fun StaffRepository.getWithUserByCode(code: String): StaffWithUser =
 
 fun StaffRepository.getByCode(code: String): Staff =
     findByCode(code) ?: throw NotFoundException("Staff", "code", code)
+
+fun StaffRepository.verifyTeamMembership(staffId: Long, teamId: Long) = countTeamMembership(staffId, teamId) > 0

--- a/projects/workforce-allocations-to-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/allocations/AllocationValidatorTest.kt
+++ b/projects/workforce-allocations-to-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/allocations/AllocationValidatorTest.kt
@@ -95,7 +95,7 @@ class AllocationValidatorTest {
             )
         )
             .thenReturn(INITIAL_OM_ALLOCATION)
-        whenever(staffRepository.verifyTeamMembership(staff.id, team.id)).thenReturn(true)
+        whenever(staffRepository.countTeamMembership(staff.id, team.id)).thenReturn(1)
         whenever(staffRepository.findByCode(allocationDetail.staffCode)).thenReturn(staff)
         assertDoesNotThrow {
             allocationValidator.initialValidations(
@@ -182,7 +182,7 @@ class AllocationValidatorTest {
         )
             .thenReturn(INITIAL_OM_ALLOCATION)
         val futureEndDatedStaff = Staff(1L, "code", "old", "staff", "", ZonedDateTime.now().plusYears(5))
-        whenever(staffRepository.verifyTeamMembership(futureEndDatedStaff.id, team.id)).thenReturn(true)
+        whenever(staffRepository.countTeamMembership(futureEndDatedStaff.id, team.id)).thenReturn(1)
         whenever(staffRepository.findByCode(allocationDetail.staffCode)).thenReturn(futureEndDatedStaff)
         assertDoesNotThrow {
             allocationValidator.initialValidations(
@@ -205,7 +205,7 @@ class AllocationValidatorTest {
         )
             .thenReturn(INITIAL_OM_ALLOCATION)
         whenever(staffRepository.findByCode(allocationDetail.staffCode)).thenReturn(staff)
-        whenever(staffRepository.verifyTeamMembership(staff.id, team.id)).thenReturn(false)
+        whenever(staffRepository.countTeamMembership(staff.id, team.id)).thenReturn(0)
         val exception =
             assertThrows<StaffNotInTeamException> {
                 allocationValidator.initialValidations(


### PR DESCRIPTION
Apparently Oracle doesn't have boolean types... discovered while investigating DLQ messages: [AppInsights Transaction](https://portal.azure.com/#blade/AppInsightsExtension/DetailsV2Blade/DataModel/%7B%22eventId%22:%224e96d902-51a4-4a7c-8acd-3ddb74b05721%22,%22timestamp%22:%222023-02-08T09:20:48.447Z%22%7D/ComponentId/%7B%22Name%22:%22nomisapi-t3%22,%22ResourceGroup%22:%22nomisapi-t3-rg%22,%22SubscriptionId%22:%22c27cfedb-f5e9-45e6-9642-0fad1a5c94e7%22%7D)
```
Caused by: Error : 904, Position : 60, Sql =
        select case when count(team_id) > 0 then true else false end
        from staff_team
        where staff_id = :1  and team_id = :2
        , OriginalSql =
        select case when count(team_id) > 0 then true else false end
        from staff_team
        where staff_id = ? and team_id = ?
        , Error Msg = ORA-00904: "FALSE": invalid identifier
```