### PR TITLE
PI-811 Build OpenAPI spec during tech-docs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
         run: echo "projects=$(cd projects && ls | jq --raw-input . | jq --slurp --compact-output .)" >> $GITHUB_OUTPUT
 
   tech-docs-index:
-    runs-on: moj-cloud-platform
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
@@ -46,14 +46,11 @@ jobs:
             tech-docs/projects
 
   tech-docs-project:
-    runs-on: moj-cloud-platform
+    runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs:
-      - get-projects
-      - tech-docs-index
+    needs: get-projects
     strategy:
       fail-fast: false
-      max-parallel: 1
       matrix:
         project: ${{ fromJson(needs.get-projects.outputs.projects) }}
     steps:
@@ -63,11 +60,34 @@ jobs:
           ruby-version: 3.1
           bundler-cache: true
           working-directory: projects/${{ matrix.project }}/tech-docs
+
+      - name: Check if OpenAPI is configured
+        id: check_config
+        run: echo "api_path=$(yq '.api_path' 'projects/${{ matrix.project }}/tech-docs/config/tech-docs.yml')" >> $GITHUB_OUTPUT
+      - uses: actions/setup-java@v3
+        if: steps.check_config.outputs.api_path != 'null'
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - uses: gradle/gradle-build-action@v2 # enables caching
+        if: steps.check_config.outputs.api_path != 'null'
+        with:
+          arguments: ${{ matrix.project }}:assemble
+      - name: Host OpenAPI spec
+        if: steps.check_config.outputs.api_path != 'null'
+        run: |
+          ./gradlew '${{ matrix.project }}:bootRun' &
+          timeout 120 sh -c 'until curl -s localhost:8080/v3/api-docs.yaml; do sleep 5; done'
+          yq -i '.api_path = "http://localhost:8080/v3/api-docs.yaml"' 'projects/${{ matrix.project }}/tech-docs/config/tech-docs.yml'
+        env:
+          SPRING_PROFILES_ACTIVE: dev
+
       - name: Build
         run: |
           gem install middleman
           bundle exec middleman build --verbose
         working-directory: projects/${{ matrix.project }}/tech-docs
+
       - name: Deploy
         if: github.ref == 'refs/heads/main'
         uses: JamesIves/github-pages-deploy-action@v4


### PR DESCRIPTION
Removes the dependency on the dev environment, and means we can use GitHub-hosted runners instead of our own.