### PR TITLE
PI-879 Only switch indexes after all rows have been loaded

### DIFF
--- a/projects/person-search-index-from-delius/container/scripts/startup.sh
+++ b/projects/person-search-index-from-delius/container/scripts/startup.sh
@@ -6,7 +6,7 @@ pipelines=$(grep 'pipeline.id' /usr/share/logstash/config/pipelines.yml | sed 's
 for pipeline in $pipelines; do
   if grep -v -q "$pipeline" <<<"$PIPELINES_ENABLED"; then
     # pipeline not enabled, remove from pipelines.yml
-    sed -i "/$pipeline/,/^- /{/$pipeline/!d}" /usr/share/logstash/config/pipelines.yml
+    sed -i "/$pipeline/,+1d" /usr/share/logstash/config/pipelines.yml
   fi
 done
 

--- a/projects/person-search-index-from-delius/deploy/values.yaml
+++ b/projects/person-search-index-from-delius/deploy/values.yaml
@@ -10,6 +10,9 @@ generic-service:
     repository: ghcr.io/ministryofjustice/hmpps-probation-integration-services/person-search-index-from-delius
     port: 9600
 
+  startupProbe:
+    httpGet:
+      path: /
   readinessProbe:
     httpGet:
       path: /


### PR DESCRIPTION
This change ensures the monitor-reindexing.sh script only switches indexes after 'indexReady' is set to true in the metadata document (id=-1), which will only happen when :sql_last_value is higher than the maximum id of the table (i.e. when Logstash has processed every row).