### PR TITLE
PI-830 Increase batch size for person-full-load pipeline

### DIFF
--- a/projects/person-search-index-from-delius/container/pipelines/person/logstash-full-load.conf
+++ b/projects/person-search-index-from-delius/container/pipelines/person/logstash-full-load.conf
@@ -11,7 +11,7 @@ input {
         statement_filepath => "/pipelines/person/statement.sql"
         parameters => {
             offender_id => 0
-            batch_size => 1000000
+            batch_size => 100000000
         }
         use_column_value => true
         tracking_column => "sql_next_value"


### PR DESCRIPTION
Due to the sparseness of the OFFENDER table, a batch size of 100mil will result in 15 batches of ~150k records.  Whereas before with a batch_size of 1mil, we would get around 45 batches of ~50k records.  The higher batch size should result in a more consistent throughput, as Logstash will have more records to process while each DB query is running. 

| "COUNT(OFFENDER_ID)" | "FLOOR(OFFENDER_ID/100000000)" |
|----------------------|--------------------------------|
| 64964                | 0                              |
| 94544                | 1                              |
| 18206                | 2                              |
| 134219               | 3                              |
| 127759               | 4                              |
| 295008               | 5                              |
| 52315                | 6                              |
| 106796               | 7                              |
| 36377                | 8                              |
| 67183                | 9                              |
| 114892               | 10                             |
| 165101               | 11                             |
| 65918                | 12                             |
| 78385                | 13                             |
| 789345               | 15                             |