### PR TITLE
Remove BusinessInteractionCode class from templates

### DIFF
--- a/templates/projects/api-client-and-server/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/audit/BusinessInteractionCode.kt
+++ b/templates/projects/api-client-and-server/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/audit/BusinessInteractionCode.kt
@@ -1,8 +1,0 @@
-package uk.gov.justice.digital.hmpps.integrations.delius.audit
-
-import uk.gov.justice.digital.hmpps.audit.InteractionCode
-
-enum class BusinessInteractionCode(override val code: String) : InteractionCode {
-    // TODO Add any Delius interaction codes used by the service here
-    EXAMPLE_INTERACTION("EXAMPLEBI001")
-}

--- a/templates/projects/api-server/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/audit/BusinessInteractionCode.kt
+++ b/templates/projects/api-server/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/audit/BusinessInteractionCode.kt
@@ -1,8 +1,0 @@
-package uk.gov.justice.digital.hmpps.integrations.delius.audit
-
-import uk.gov.justice.digital.hmpps.audit.InteractionCode
-
-enum class BusinessInteractionCode(override val code: String) : InteractionCode {
-    // TODO Add any Delius interaction codes used by the service here
-    EXAMPLE_INTERACTION("EXAMPLEBI001")
-}

--- a/templates/projects/message-listener-with-api-client-and-server/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/audit/BusinessInteractionCode.kt
+++ b/templates/projects/message-listener-with-api-client-and-server/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/audit/BusinessInteractionCode.kt
@@ -1,8 +1,0 @@
-package uk.gov.justice.digital.hmpps.integrations.delius.audit
-
-import uk.gov.justice.digital.hmpps.audit.InteractionCode
-
-enum class BusinessInteractionCode(override val code: String) : InteractionCode {
-    // TODO Add any Delius interaction codes used by the service here
-    EXAMPLE_INTERACTION("EXAMPLEBI001")
-}

--- a/templates/projects/message-listener-with-api-client/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/audit/BusinessInteractionCode.kt
+++ b/templates/projects/message-listener-with-api-client/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/audit/BusinessInteractionCode.kt
@@ -1,8 +1,0 @@
-package uk.gov.justice.digital.hmpps.integrations.delius.audit
-
-import uk.gov.justice.digital.hmpps.audit.InteractionCode
-
-enum class BusinessInteractionCode(override val code: String) : InteractionCode {
-    // TODO Add any Delius interaction codes used by the service here
-    EXAMPLE_INTERACTION("EXAMPLEBI001")
-}


### PR DESCRIPTION
It's rarely used in our projects and reduces code coverage.