### PR TITLE
PI-919 Add Sentry cron monitoring

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -180,10 +180,11 @@ jobs:
           echo "dsn=$dsn" >> $GITHUB_OUTPUT
 
       - name: Store DSN as Kubernetes secret
-        run: kubectl create secret generic "$PROJECT-sentry" --from-literal "SENTRY_DSN=$VALUE"
+        run: kubectl create secret generic "$PROJECT-sentry" --from-literal "SENTRY_DSN=$VALUE" --from-literal "SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN"
         env:
           PROJECT: ${{ inputs.project_name }}
           VALUE: ${{ steps.client_key.outputs.dsn }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
   sqs-queue-setup:
     runs-on: ubuntu-latest

--- a/projects/person-search-index-from-delius/container/scripts/startup.sh
+++ b/projects/person-search-index-from-delius/container/scripts/startup.sh
@@ -15,17 +15,17 @@ for pipeline in $pipelines; do
   fi
 done
 
-if grep --q 'person' <<<"$PIPELINES_ENABLED"; then
+if grep -q 'person' <<<"$PIPELINES_ENABLED"; then
   /scripts/setup-index.sh -i "$PERSON_INDEX_PREFIX" -p /pipelines/person/index/person-search-pipeline.json -t /pipelines/person/index/person-search-template.json
-  if grep --q 'person-full-load' <<<"$PIPELINES_ENABLED"; then
-    /scripts/monitor-reindexing.sh -i "$PERSON_INDEX_PREFIX" -t "$PERSON_REINDEXING_TIMEOUT" &
+  if grep -q 'person-full-load' <<<"$PIPELINES_ENABLED"; then
+    sentry-cli monitors run "$PERSON_REINDEXING_SENTRY_MONITOR_ID" -- /scripts/monitor-reindexing.sh -i "$PERSON_INDEX_PREFIX" -t "$PERSON_REINDEXING_TIMEOUT" &
   fi
 fi
 
-if grep --q 'contact' <<<"$PIPELINES_ENABLED"; then
+if grep -q 'contact' <<<"$PIPELINES_ENABLED"; then
   /scripts/setup-index.sh -i "$CONTACT_INDEX_PREFIX" -t /pipelines/contact/index/contact-search-template.json
-  if grep --q 'contact-full-load' <<<"$PIPELINES_ENABLED"; then
-    /scripts/monitor-reindexing.sh -i "$CONTACT_INDEX_PREFIX" -t "$CONTACT_REINDEXING_TIMEOUT" &
+  if grep -q 'contact-full-load' <<<"$PIPELINES_ENABLED"; then
+    sentry-cli monitors run "$CONTACT_REINDEXING_SENTRY_MONITOR_ID" -- /scripts/monitor-reindexing.sh -i "$CONTACT_INDEX_PREFIX" -t "$CONTACT_REINDEXING_TIMEOUT" &
   fi
 fi
 

--- a/projects/person-search-index-from-delius/deploy/templates/contact-reindex-cronjob.yml
+++ b/projects/person-search-index-from-delius/deploy/templates/contact-reindex-cronjob.yml
@@ -36,7 +36,7 @@ spec:
                 - name: PIPELINES_ENABLED
                   value: contact-full-load,contact-dlq
                 - name: PIPELINE_BATCH_SIZE
-                  value: '5000'
+                  value: '10000'
                 - name: SEARCH_INDEX_HOST
                   value: {{ .Values.reindexing.host }}
                 - name: APPLICATIONINSIGHTS_CONNECTION_STRING
@@ -68,6 +68,18 @@ spec:
                     secretKeyRef:
                       name: person-search-index-from-delius-sentry
                       key: SENTRY_DSN
+                      optional: false
+                - name: SENTRY_AUTH_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: person-search-index-from-delius-sentry
+                      key: SENTRY_AUTH_TOKEN
+                      optional: false
+                - name: CONTACT_REINDEXING_SENTRY_MONITOR_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: person-search-index-from-delius-sentry
+                      key: CONTACT_REINDEXING_SENTRY_MONITOR_ID
                       optional: false
                 - name: CONTACT_SQS_DLQ_NAME
                   valueFrom:

--- a/projects/person-search-index-from-delius/deploy/templates/person-reindex-cronjob.yml
+++ b/projects/person-search-index-from-delius/deploy/templates/person-reindex-cronjob.yml
@@ -69,6 +69,18 @@ spec:
                       name: person-search-index-from-delius-sentry
                       key: SENTRY_DSN
                       optional: false
+                - name: SENTRY_AUTH_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: person-search-index-from-delius-sentry
+                      key: SENTRY_AUTH_TOKEN
+                      optional: false
+                - name: PERSON_REINDEXING_SENTRY_MONITOR_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: person-search-index-from-delius-sentry
+                      key: PERSON_REINDEXING_SENTRY_MONITOR_ID
+                      optional: false
                 - name: PERSON_SQS_DLQ_NAME
                   valueFrom:
                     secretKeyRef:


### PR DESCRIPTION
Also doubled the contact reindexing batch size, to make better use of the available memory.

View the status of our cron jobs here: https://ministryofjustice.sentry.io/crons/