### PR TITLE
PI-923 Add support for publishing draft tech docs

### DIFF
--- a/.github/actions/render-project-template/action.yml
+++ b/.github/actions/render-project-template/action.yml
@@ -30,6 +30,7 @@ runs:
         sed -i '/add new projects here/a \    "${{ inputs.project_name }}",' settings.gradle.kts
         sed -i '/add new projects here/i \          - '"'"'["${{ inputs.project_name }}"]'"'"'' .github/workflows/access.yml
         sed -i '/add new projects here/i \          - '"'"'["${{ inputs.project_name }}"]'"'"'' .github/workflows/deploy.yml
+        sed -i '/add new projects here/i \          - '"'"'["${{ inputs.project_name }}"]'"'"'' .github/workflows/docs.yml
         sed -i '/add new projects here/i \          - '"'"'["${{ inputs.project_name }}"]'"'"'' .github/workflows/end-to-end-tests.yml
         sed -i '/add new projects here/i \          - ${{ inputs.project_name }}' .github/workflows/suppress-trivy.yml
         sed -i '/add new projects here/i \* [${{ steps.project_name.outputs.title_case }}](https://ministryofjustice.github.io/hmpps-probation-integration-services/tech-docs/projects/${{ inputs.project_name }})' doc/tech-docs/source/index.html.md.erb

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -35,6 +35,7 @@ jobs:
           brew install git-filter-repo
           git-filter-repo \
             --path 'tech-docs' \
+            --path 'tech-doc-drafts' \
             --path 'schema-spy-report' \
             --path "playwright-report/test/main/$(date -d '-7 days' '+%Y-%m-%d')" \
             --path "playwright-report/test/main/$(date -d '-6 days' '+%Y-%m-%d')" \

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -143,4 +143,4 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: projects/${{ matrix.project }}/tech-docs/build
-          target-folder: tech-docs/drafts/${{ matrix.project }}
+          target-folder: tech-docs-drafts/${{ matrix.project }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,16 +9,51 @@ on:
   schedule:
     - cron: "30 5 * * MON-FRI" # Every weekday at 05:30 UTC
   workflow_dispatch:
+    inputs:
+      projects:
+        description: Project
+        type: choice
+        required: true
+        options:
+          - 'All'
+          - '["approved-premises-and-oasys"]'
+          - '["approved-premises-and-delius"]'
+          - '["person-search-index-from-delius"]'
+          - '["pre-sentence-reports-to-delius"]'
+          - '["prison-case-notes-to-probation"]'
+          - '["prison-custody-status-to-delius"]'
+          - '["risk-assessment-scores-to-delius"]'
+          - '["tier-to-delius"]'
+          - '["workforce-allocations-to-delius"]'
+          - '["offender-events-and-delius"]'
+          - '["custody-key-dates-and-delius"]'
+          - '["make-recall-decisions-and-delius"]'
+          - '["unpaid-work-and-delius"]'
+          - '["manage-pom-cases-and-delius"]'
+          - '["refer-and-monitor-and-delius"]'
+          - '["create-and-vary-a-licence-and-delius"]'
+          # ^ add new projects here
+          # GitHub Actions doesn't support dynamic choices, we must add each project here to enable manual deployments
+          # See https://github.com/community/community/discussions/11795
+      deploy:
+        description: Deploy?
+        type: boolean
 
 jobs:
   get-projects:
     runs-on: ubuntu-latest
     outputs:
-      projects: ${{ steps.get-projects.outputs.projects }}
+      projects: ${{ steps.output.outputs.projects }}
     steps:
       - uses: actions/checkout@v3
-      - id: get-projects
-        run: echo "projects=$(cd projects && ls | jq --raw-input . | jq --slurp --compact-output .)" >> $GITHUB_OUTPUT
+      - name: Get projects - all
+        if: github.event_name != 'workflow_dispatch' || inputs.projects == 'All'
+        run: echo "projects=$(cd projects && ls | jq --raw-input . | jq --slurp --compact-output .)" >> $GITHUB_ENV
+      - name: Get projects - selected
+        if: github.event_name == 'workflow_dispatch' && inputs.projects != 'All'
+        run: echo 'projects=${{ inputs.projects }}' >> $GITHUB_ENV
+      - id: output
+        run: echo 'projects=${{ env.projects }}' >> $GITHUB_OUTPUT
 
   tech-docs-index:
     runs-on: ubuntu-latest
@@ -65,16 +100,16 @@ jobs:
         id: check_config
         run: echo "api_path=$(yq '.api_path' 'projects/${{ matrix.project }}/tech-docs/config/tech-docs.yml')" >> $GITHUB_OUTPUT
       - uses: actions/setup-java@v3
-        if: steps.check_config.outputs.api_path != 'null'
+        if: startsWith(steps.check_config.outputs.api_path, 'http')
         with:
           java-version: '17'
           distribution: 'temurin'
       - uses: gradle/gradle-build-action@v2 # enables caching
-        if: steps.check_config.outputs.api_path != 'null'
+        if: startsWith(steps.check_config.outputs.api_path, 'http')
         with:
           arguments: ${{ matrix.project }}:assemble
       - name: Host OpenAPI spec
-        if: steps.check_config.outputs.api_path != 'null'
+        if: startsWith(steps.check_config.outputs.api_path, 'http')
         run: |
           ./gradlew '${{ matrix.project }}:bootRun' &
           timeout 120 sh -c 'until curl -s localhost:8080/v3/api-docs.yaml; do sleep 5; done'
@@ -97,8 +132,15 @@ jobs:
         working-directory: projects/${{ matrix.project }}/tech-docs
 
       - name: Deploy
-        if: github.ref == 'refs/heads/main'
+        if: github.ref_name == 'main'
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: projects/${{ matrix.project }}/tech-docs/build
           target-folder: tech-docs/projects/${{ matrix.project }}
+
+      - name: Branch deploy
+        if: github.ref_name != 'main' && github.event_name == 'workflow_dispatch' && inputs.deploy
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: projects/${{ matrix.project }}/tech-docs/build
+          target-folder: tech-docs/drafts/${{ matrix.project }}


### PR DESCRIPTION
To publish draft tech docs from a branch, run the [Documentation workflow](https://github.com/ministryofjustice/hmpps-probation-integration-services/actions/workflows/docs.yml) with the "Deploy" option enabled.

The URL will start with `https://ministryofjustice.github.io/hmpps-probation-integration-services/**tech-docs-drafts**/`.

For example,
https://ministryofjustice.github.io/hmpps-probation-integration-services/tech-docs-drafts/make-recall-decisions-and-delius