### PR TITLE
Set concurrency group for deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,6 +63,7 @@ jobs:
       fail-fast: false
       matrix:
         project: ${{ fromJson(inputs.projects) }}
+    concurrency: deploy-${{ matrix.project }}-${{ inputs.environment }}
     environment:
       name: ${{ inputs.environment }}
     steps:


### PR DESCRIPTION
Reduces timeouts/failures by ensuring deployments don't run in parallel for the same project + environment.