### PR TITLE
PI-577 Return 404 for user access when case not found

### DIFF
--- a/projects/make-recall-decisions-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/UserAccessIntegrationTest.kt
+++ b/projects/make-recall-decisions-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/UserAccessIntegrationTest.kt
@@ -74,4 +74,12 @@ internal class UserAccessIntegrationTest {
             .andExpect(jsonPath("$.userRestricted", equalTo(true)))
             .andExpect(jsonPath("$.restrictionMessage", equalTo(person.restrictionMessage)))
     }
+
+    @Test
+    fun `case does not exist`() {
+        val user = UserGenerator.TEST_USER1
+
+        mockMvc.perform(get("/user/${user.username}/access/NOTFOUND").withOAuth2Token(wireMockserver))
+            .andExpect(status().isNotFound)
+    }
 }

--- a/projects/make-recall-decisions-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/api/controller/UserController.kt
+++ b/projects/make-recall-decisions-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/api/controller/UserController.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.api.controller
 
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
@@ -8,6 +9,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.api.model.Staff
 import uk.gov.justice.digital.hmpps.integrations.delius.user.access.UserAccessRepository
+import uk.gov.justice.digital.hmpps.integrations.delius.user.access.checkUserAccess
 import uk.gov.justice.digital.hmpps.integrations.delius.user.staff.UserStaffRepository
 
 @RestController
@@ -23,7 +25,8 @@ class UserController(
         description = "<p>Returns either an `exclusionMessage` or `restrictionMessage` if the user is not allowed to access the case. " +
             "<p>This can happen if the user is *excluded* from viewing the case (e.g. a family member), or if the case has been *restricted* to a subset of users that the user is not a part of (e.g. high profile cases)."
     )
-    fun checkUserAccess(@PathVariable username: String, @PathVariable crn: String) = userAccessRepository.findByUsernameAndCrn(username, crn)
+    @ApiResponse(responseCode = "404", description = "A case with the provided CRN does not exist in Delius. Note: this could be the result of a merge or a deletion.")
+    fun checkUserAccess(@PathVariable username: String, @PathVariable crn: String) = userAccessRepository.checkUserAccess(username, crn)
 
     @GetMapping("/user/{username}/staff")
     @Operation(summary = "Get the staff code for a user, if it exists")

--- a/projects/make-recall-decisions-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/user/access/UserAccessRepository.kt
+++ b/projects/make-recall-decisions-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/user/access/UserAccessRepository.kt
@@ -3,18 +3,23 @@ package uk.gov.justice.digital.hmpps.integrations.delius.user.access
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import uk.gov.justice.digital.hmpps.api.model.UserAccess
+import uk.gov.justice.digital.hmpps.exception.NotFoundException
 
 interface UserAccessRepository : JpaRepository<Person, Long> {
     @Query(
         """
         select new uk.gov.justice.digital.hmpps.api.model.UserAccess(
             (select p.exclusionMessage from UserAccessPerson p where p.crn = :crn
-                    and exists (select e from Exclusion e where e.user.username = :username and e.person.id = p.id)),
+                    and exists (select e from Exclusion e where upper(e.user.username) = upper(:username)and e.person.id = p.id)),
             (select p.restrictionMessage from UserAccessPerson p where p.crn = :crn
-                    and not exists (select r from Restriction r where r.user.username = :username and r.person.id = p.id)
+                    and not exists (select r from Restriction r where upper(r.user.username) = upper(:username) and r.person.id = p.id)
                     and exists (select r from Restriction r where r.person.id = p.id))
         )
         """
     )
-    fun findByUsernameAndCrn(username: String, crn: String): UserAccess?
+    fun findByUsernameAndCrn(username: String, crn: String): UserAccess
+    fun existsByCrn(crn: String): Boolean
 }
+
+fun UserAccessRepository.checkUserAccess(username: String, crn: String) =
+    if (existsByCrn(crn)) findByUsernameAndCrn(username, crn) else throw NotFoundException("Person", "crn", crn)

--- a/projects/make-recall-decisions-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/user/staff/UserStaffRepository.kt
+++ b/projects/make-recall-decisions-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/user/staff/UserStaffRepository.kt
@@ -5,6 +5,6 @@ import org.springframework.data.jpa.repository.Query
 import uk.gov.justice.digital.hmpps.integrations.delius.user.staff.entity.Staff
 
 interface UserStaffRepository : JpaRepository<Staff, Long> {
-    @Query("select s.code from Staff s where lower(s.user.username) = lower(:username)")
+    @Query("select s.code from Staff s where upper(s.user.username) = upper(:username)")
     fun findUserStaffCode(username: String): String?
 }

--- a/projects/workforce-allocations-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/user/access/UserAccessRepository.kt
+++ b/projects/workforce-allocations-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/user/access/UserAccessRepository.kt
@@ -9,12 +9,12 @@ interface UserAccessRepository : JpaRepository<User, Long> {
         """
         select new uk.gov.justice.digital.hmpps.integrations.delius.user.access.UserPersonAccess(p.crn, p.exclusionMessage, '')
         from Person p where p.crn in :crns
-        and exists (select e from Exclusion e where e.user.username = :username and e.person.id = p.id and (e.end is null or e.end > current_date ))
+        and exists (select e from Exclusion e where upper(e.user.username) = upper(:username) and e.person.id = p.id and (e.end is null or e.end > current_date ))
         union
         select new uk.gov.justice.digital.hmpps.integrations.delius.user.access.UserPersonAccess(p.crn, '', p.restrictionMessage)
         from Person p where p.crn in :crns
         and exists (select r from Restriction r where r.person.id = p.id and (r.end is null or r.end > current_date ))
-        and not exists (select r from Restriction r where r.user.username = :username and r.person.id = p.id and (r.end is null or r.end > current_date ))
+        and not exists (select r from Restriction r where upper(r.user.username) = upper(:username) and r.person.id = p.id and (r.end is null or r.end > current_date ))
     """
     )
     fun getAccessFor(username: String, crns: List<String>): List<UserPersonAccess>


### PR DESCRIPTION
Also makes username case-insensitive. Note: `upper` is used instead of `lower` because there is an index on `upper(distinguished_name)`.