### PR TITLE
PI-994 Attempt to fix cleanup job failures

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -31,9 +31,9 @@ jobs:
           fetch-depth: 0
       - name: Delete Playwright reports older than 1 week
         run: |
-          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          brew install git-filter-repo
-          git-filter-repo \
+          wget https://raw.githubusercontent.com/newren/git-filter-repo/main/git-filter-repo
+          git pull origin gh-pages
+          python3 git-filter-repo \
             --path 'tech-docs' \
             --path 'tech-docs-drafts' \
             --path 'schema-spy-report' \
@@ -47,4 +47,5 @@ jobs:
             --path "playwright-report/test/main/$(date '+%Y-%m-%d')" \
             --refs gh-pages \
             --force
+          git gc --prune=now
           git push origin gh-pages --force


### PR DESCRIPTION
It takes a while to install git-filter-repo via homebrew, as it installs a bunch of dependencies including another copy of python. This should speed things up and minimise the amount of time between pulling and pushing, which will hopefully reduce the amount of ref lock errors we've seen.