### PR TITLE
PI-1082 Fix potential duplicate appointment creation

### DIFF
--- a/projects/refer-and-monitor-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/AppointmentService.kt
+++ b/projects/refer-and-monitor-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/AppointmentService.kt
@@ -70,6 +70,7 @@ class AppointmentService(
         }
         val appointment = find() ?: mergeAppointment.deliusId?.let { contactRepository.findByIdOrNull(it) } ?: run {
             nsiRepository.findForUpdate(nsi.id)
+            nsi.lastUpdatedDatetime = now()
             find() ?: createContact(mergeAppointment, assignation, nsi)
         }
 


### PR DESCRIPTION
Previously we were selecting the NSI for update, but not making any changes to it. This meant parallel requests could succeed in creating contacts with the same external_reference.