### PR TITLE
PI-1091 Run integration tests against OracleDB

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,8 +55,13 @@ jobs:
       - name: Set Gradle properties
         run: echo -e "\norg.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m" >> gradle.properties
 
+      - name: Cache OracleDB image
+        run: docker pull gvenzl/oracle-xe:slim-faststart
+
       - name: Build and test
         run: ./gradlew check
+        env:
+          SPRING_PROFILES_ACTIVE: oracle
 
       - name: Sonar analysis
         if: github.actor != 'dependabot[bot]'

--- a/buildSrc/src/main/kotlin/uk/gov/justice/digital/hmpps/plugins/ClassPathPlugin.kt
+++ b/buildSrc/src/main/kotlin/uk/gov/justice/digital/hmpps/plugins/ClassPathPlugin.kt
@@ -55,6 +55,7 @@ class ClassPathPlugin : Plugin<Project> {
             project.tasks.create("integrationTest", Test::class.java) {
                 testClassesDirs = getByName("integrationTest").output.classesDirs
                 classpath = getByName("integrationTest").runtimeClasspath
+                systemProperty("spring.profiles.active", "integration-test,${System.getenv("SPRING_PROFILES_ACTIVE")}")
             }
             project.tasks.withType(Test::class.java) {
                 useJUnitPlatform()

--- a/libs/audit/src/main/kotlin/uk/gov/justice/digital/hmpps/audit/config/ConnectionProviderConfig.kt
+++ b/libs/audit/src/main/kotlin/uk/gov/justice/digital/hmpps/audit/config/ConnectionProviderConfig.kt
@@ -23,6 +23,6 @@ class ConnectionProviderConfig {
 class OracleCondition : Condition {
     override fun matches(context: ConditionContext, metadata: AnnotatedTypeMetadata): Boolean {
         val url = context.environment.getProperty("spring.datasource.url")
-        return url?.startsWith("jdbc:oracle") ?: false
+        return url?.startsWith("jdbc:oracle") ?: false && !context.environment.acceptsProfiles { it.test("oracle") }
     }
 }

--- a/projects/approved-premises-and-delius/build.gradle.kts
+++ b/projects/approved-premises-and-delius/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
+    dev(libs.testcontainers.oracle)
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/approved-premises-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/MessagingIntegrationTest.kt
+++ b/projects/approved-premises-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/MessagingIntegrationTest.kt
@@ -16,7 +16,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.data.generator.AddressGenerator
 import uk.gov.justice.digital.hmpps.data.generator.PersonGenerator
 import uk.gov.justice.digital.hmpps.datetime.EuropeLondon
@@ -38,7 +37,6 @@ import uk.gov.justice.digital.hmpps.telemetry.notificationReceived
 import uk.gov.justice.digital.hmpps.test.CustomMatchers.isCloseTo
 
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @TestMethodOrder(OrderAnnotation::class)
 internal class MessagingIntegrationTest {

--- a/projects/approved-premises-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/StaffControllerIntegrationTest.kt
+++ b/projects/approved-premises-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/StaffControllerIntegrationTest.kt
@@ -7,7 +7,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
@@ -16,7 +15,6 @@ import uk.gov.justice.digital.hmpps.data.generator.ApprovedPremisesGenerator
 import uk.gov.justice.digital.hmpps.security.withOAuth2Token
 
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 class StaffControllerIntegrationTest {
     @Autowired lateinit var mockMvc: MockMvc

--- a/projects/approved-premises-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/TeamControllerIntegrationTest.kt
+++ b/projects/approved-premises-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/TeamControllerIntegrationTest.kt
@@ -7,7 +7,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
@@ -17,7 +16,6 @@ import uk.gov.justice.digital.hmpps.data.generator.TeamGenerator
 import uk.gov.justice.digital.hmpps.security.withOAuth2Token
 
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 class TeamControllerIntegrationTest {
     @Autowired lateinit var mockMvc: MockMvc

--- a/projects/approved-premises-and-delius/src/main/resources/application.yml
+++ b/projects/approved-premises-and-delius/src/main/resources/application.yml
@@ -68,16 +68,7 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring:
-  datasource:
-    url: 'jdbc:oracle:thin:@//localhost:1521/XEPDB1'
-    username: delius_pool
-    password: NDelius1
-  jpa:
-    properties:
-      hibernate.dialect: org.hibernate.dialect.OracleDialect
-    hibernate.ddl-auto: validate
-delius.db.username: NationalUser
+spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
 
 ---
 spring.config.activate.on-profile: localstack

--- a/projects/approved-premises-and-oasys/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/AssessmentTimelineTest.kt
+++ b/projects/approved-premises-and-oasys/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/AssessmentTimelineTest.kt
@@ -8,7 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -18,7 +17,6 @@ import uk.gov.justice.digital.hmpps.security.withOAuth2Token
 import java.time.ZonedDateTime
 
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 internal class AssessmentTimelineTest {
 

--- a/projects/approved-premises-and-oasys/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/HealthDetailsTest.kt
+++ b/projects/approved-premises-and-oasys/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/HealthDetailsTest.kt
@@ -8,7 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -19,7 +18,6 @@ import uk.gov.justice.digital.hmpps.security.withOAuth2Token
 import java.time.ZonedDateTime
 
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 internal class HealthDetailsTest {
 

--- a/projects/approved-premises-and-oasys/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/NeedsDetailTest.kt
+++ b/projects/approved-premises-and-oasys/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/NeedsDetailTest.kt
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
@@ -17,7 +16,6 @@ import uk.gov.justice.digital.hmpps.security.withOAuth2Token
 import java.time.ZonedDateTime
 
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class NeedsDetailTest {
 

--- a/projects/approved-premises-and-oasys/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/OffenceDetailsTest.kt
+++ b/projects/approved-premises-and-oasys/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/OffenceDetailsTest.kt
@@ -8,7 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -18,7 +17,6 @@ import uk.gov.justice.digital.hmpps.security.withOAuth2Token
 import java.time.ZonedDateTime
 
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 internal class OffenceDetailsTest {
 

--- a/projects/approved-premises-and-oasys/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/RiskAssessmentDetailsTest.kt
+++ b/projects/approved-premises-and-oasys/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/RiskAssessmentDetailsTest.kt
@@ -8,7 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -18,7 +17,6 @@ import uk.gov.justice.digital.hmpps.security.withOAuth2Token
 import java.time.ZonedDateTime
 
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 internal class RiskAssessmentDetailsTest {
 

--- a/projects/approved-premises-and-oasys/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/RiskManagementPlanDetailsTest.kt
+++ b/projects/approved-premises-and-oasys/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/RiskManagementPlanDetailsTest.kt
@@ -8,7 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -18,7 +17,6 @@ import uk.gov.justice.digital.hmpps.security.withOAuth2Token
 import java.time.ZonedDateTime
 
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 internal class RiskManagementPlanDetailsTest {
 

--- a/projects/approved-premises-and-oasys/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/RiskToTheIndividualDetailsTest.kt
+++ b/projects/approved-premises-and-oasys/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/RiskToTheIndividualDetailsTest.kt
@@ -8,7 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -18,7 +17,6 @@ import uk.gov.justice.digital.hmpps.security.withOAuth2Token
 import java.time.ZonedDateTime
 
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 internal class RiskToTheIndividualDetailsTest {
 

--- a/projects/approved-premises-and-oasys/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/RoshDetailsTest.kt
+++ b/projects/approved-premises-and-oasys/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/RoshDetailsTest.kt
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
@@ -18,7 +17,6 @@ import uk.gov.justice.digital.hmpps.security.withOAuth2Token
 import java.time.ZonedDateTime
 
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class RoshDetailsTest {
 

--- a/projects/approved-premises-and-oasys/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/RoshSummaryDetailsTest.kt
+++ b/projects/approved-premises-and-oasys/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/RoshSummaryDetailsTest.kt
@@ -8,7 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -18,7 +17,6 @@ import uk.gov.justice.digital.hmpps.security.withOAuth2Token
 import java.time.ZonedDateTime
 
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 internal class RoshSummaryDetailsTest {
 

--- a/projects/court-case-and-delius/build.gradle.kts
+++ b/projects/court-case-and-delius/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
+    dev(libs.testcontainers.oracle)
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/court-case-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/IntegrationTest.kt
+++ b/projects/court-case-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/IntegrationTest.kt
@@ -9,7 +9,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
@@ -22,7 +21,6 @@ import uk.gov.justice.digital.hmpps.telemetry.TelemetryService
 import java.time.LocalDate
 
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 internal class IntegrationTest {
     @Autowired

--- a/projects/court-case-and-delius/src/main/resources/application.yml
+++ b/projects/court-case-and-delius/src/main/resources/application.yml
@@ -48,13 +48,4 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring:
-  datasource:
-    url: 'jdbc:oracle:thin:@//localhost:1521/XEPDB1'
-    username: delius_pool
-    password: NDelius1
-  jpa:
-    properties:
-      hibernate.dialect: org.hibernate.dialect.OracleDialect
-    hibernate.ddl-auto: validate
-delius.db.username: NationalUser
+spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'

--- a/projects/create-and-vary-a-licence-and-delius/build.gradle.kts
+++ b/projects/create-and-vary-a-licence-and-delius/build.gradle.kts
@@ -24,8 +24,9 @@ dependencies {
     implementation(libs.opentelemetry.annotations)
 
     dev(project(":libs:dev-tools"))
-    dev("com.h2database:h2")
     dev("com.unboundid:unboundid-ldapsdk")
+    dev("com.h2database:h2")
+    dev(libs.testcontainers.oracle)
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/create-and-vary-a-licence-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/IntegrationTest.kt
+++ b/projects/create-and-vary-a-licence-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/IntegrationTest.kt
@@ -10,7 +10,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -20,7 +19,6 @@ import uk.gov.justice.digital.hmpps.security.withOAuth2Token
 import uk.gov.justice.digital.hmpps.service.asManager
 
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 internal class IntegrationTest {
     @Autowired

--- a/projects/create-and-vary-a-licence-and-delius/src/main/resources/application.yml
+++ b/projects/create-and-vary-a-licence-and-delius/src/main/resources/application.yml
@@ -50,13 +50,4 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring:
-  datasource:
-    url: 'jdbc:oracle:thin:@//localhost:1521/XEPDB1'
-    username: delius_pool
-    password: NDelius1
-  jpa:
-    properties:
-      hibernate.dialect: org.hibernate.dialect.OracleDialect
-    hibernate.ddl-auto: validate
-delius.db.username: NationalUser
+spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'

--- a/projects/custody-key-dates-and-delius/build.gradle.kts
+++ b/projects/custody-key-dates-and-delius/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
+    dev(libs.testcontainers.oracle)
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/custody-key-dates-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/IntegrationTest.kt
+++ b/projects/custody-key-dates-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/IntegrationTest.kt
@@ -10,7 +10,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.data.generator.MessageGenerator
 import uk.gov.justice.digital.hmpps.data.generator.PersonGenerator
 import uk.gov.justice.digital.hmpps.data.generator.SentenceGenerator.DEFAULT_CUSTODY
@@ -27,7 +26,6 @@ import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
 
 @SpringBootTest
-@ActiveProfiles("integration-test")
 internal class IntegrationTest {
     @Value("\${messaging.consumer.queue}")
     lateinit var queueName: String

--- a/projects/custody-key-dates-and-delius/src/main/resources/application.yml
+++ b/projects/custody-key-dates-and-delius/src/main/resources/application.yml
@@ -65,16 +65,7 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring:
-  datasource:
-    url: 'jdbc:oracle:thin:@//localhost:1521/XEPDB1'
-    username: delius_pool
-    password: NDelius1
-  jpa:
-    properties:
-      hibernate.dialect: org.hibernate.dialect.OracleDialect
-    hibernate.ddl-auto: validate
-delius.db.username: NationalUser
+spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
 
 ---
 spring.config.activate.on-profile: localstack

--- a/projects/effective-proposal-framework-and-delius/build.gradle.kts
+++ b/projects/effective-proposal-framework-and-delius/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
+    dev(libs.testcontainers.oracle)
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/effective-proposal-framework-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/IntegrationTest.kt
+++ b/projects/effective-proposal-framework-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/IntegrationTest.kt
@@ -10,7 +10,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -26,7 +25,6 @@ import uk.gov.justice.digital.hmpps.security.withOAuth2Token
 import uk.gov.justice.digital.hmpps.telemetry.TelemetryService
 
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 internal class IntegrationTest {
     @Autowired

--- a/projects/effective-proposal-framework-and-delius/src/main/resources/application.yml
+++ b/projects/effective-proposal-framework-and-delius/src/main/resources/application.yml
@@ -48,13 +48,4 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring:
-  datasource:
-    url: 'jdbc:oracle:thin:@//localhost:1521/XEPDB1'
-    username: delius_pool
-    password: NDelius1
-  jpa:
-    properties:
-      hibernate.dialect: org.hibernate.dialect.OracleDialect
-    hibernate.ddl-auto: validate
-delius.db.username: NationalUser
+spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'

--- a/projects/make-recall-decisions-and-delius/build.gradle.kts
+++ b/projects/make-recall-decisions-and-delius/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
+    dev(libs.testcontainers.oracle)
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/make-recall-decisions-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/CaseSummaryIntegrationTest.kt
+++ b/projects/make-recall-decisions-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/CaseSummaryIntegrationTest.kt
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.ResultActions
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
@@ -23,7 +22,6 @@ import uk.gov.justice.digital.hmpps.integrations.delius.casesummary.Person
 import uk.gov.justice.digital.hmpps.security.withOAuth2Token
 
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 internal class CaseSummaryIntegrationTest {
     @Autowired lateinit var mockMvc: MockMvc

--- a/projects/make-recall-decisions-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/DocumentIntegrationTest.kt
+++ b/projects/make-recall-decisions-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/DocumentIntegrationTest.kt
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
@@ -15,7 +14,6 @@ import org.springframework.util.ResourceUtils
 import uk.gov.justice.digital.hmpps.security.withOAuth2Token
 
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 internal class DocumentIntegrationTest {
     @Autowired lateinit var mockMvc: MockMvc

--- a/projects/make-recall-decisions-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/RecommendationIntegrationTest.kt
+++ b/projects/make-recall-decisions-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/RecommendationIntegrationTest.kt
@@ -12,7 +12,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.data.generator.PersonGenerator
 import uk.gov.justice.digital.hmpps.data.generator.UserGenerator
 import uk.gov.justice.digital.hmpps.integrations.delius.recommendation.contact.entity.Contact
@@ -21,7 +20,6 @@ import uk.gov.justice.digital.hmpps.telemetry.TelemetryService
 import uk.gov.justice.digital.hmpps.telemetry.notificationReceived
 
 @SpringBootTest
-@ActiveProfiles("integration-test")
 internal class RecommendationIntegrationTest {
     @Value("\${messaging.consumer.queue}")
     lateinit var queueName: String

--- a/projects/make-recall-decisions-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/UserAccessIntegrationTest.kt
+++ b/projects/make-recall-decisions-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/UserAccessIntegrationTest.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
@@ -17,7 +16,6 @@ import uk.gov.justice.digital.hmpps.security.withOAuth2Token
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 internal class UserAccessIntegrationTest {
     @Autowired lateinit var mockMvc: MockMvc
 

--- a/projects/make-recall-decisions-and-delius/src/main/resources/application.yml
+++ b/projects/make-recall-decisions-and-delius/src/main/resources/application.yml
@@ -60,16 +60,7 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring:
-  datasource:
-    url: 'jdbc:oracle:thin:@//localhost:1521/XEPDB1'
-    username: delius_pool
-    password: NDelius1
-  jpa:
-    properties:
-      hibernate.dialect: org.hibernate.dialect.OracleDialect
-    hibernate.ddl-auto: validate
-delius.db.username: NationalUser
+spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
 
 ---
 spring.config.activate.on-profile: localstack

--- a/projects/manage-pom-cases-and-delius/build.gradle.kts
+++ b/projects/manage-pom-cases-and-delius/build.gradle.kts
@@ -26,8 +26,9 @@ dependencies {
     implementation(libs.opentelemetry.annotations)
 
     dev(project(":libs:dev-tools"))
-    dev("com.h2database:h2")
     dev("com.unboundid:unboundid-ldapsdk")
+    dev("com.h2database:h2")
+    dev(libs.testcontainers.oracle)
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/manage-pom-cases-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/ApiIntegrationTest.kt
+++ b/projects/manage-pom-cases-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/ApiIntegrationTest.kt
@@ -10,7 +10,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -26,7 +25,6 @@ import uk.gov.justice.digital.hmpps.data.generator.ReferenceDataGenerator
 import uk.gov.justice.digital.hmpps.security.withOAuth2Token
 
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 internal class ApiIntegrationTest {
 

--- a/projects/manage-pom-cases-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/MessagingIntegrationTest.kt
+++ b/projects/manage-pom-cases-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/MessagingIntegrationTest.kt
@@ -9,7 +9,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.data.generator.PersonGenerator
 import uk.gov.justice.digital.hmpps.integrations.delius.allocation.entity.event.CustodyRepository
 import uk.gov.justice.digital.hmpps.integrations.delius.allocation.entity.event.keydate.KeyDate
@@ -22,7 +21,6 @@ import uk.gov.justice.digital.hmpps.telemetry.TelemetryService
 import java.time.LocalDate
 
 @SpringBootTest
-@ActiveProfiles("integration-test")
 internal class MessagingIntegrationTest {
     @Value("\${messaging.consumer.queue}")
     lateinit var queueName: String

--- a/projects/manage-pom-cases-and-delius/src/main/resources/application.yml
+++ b/projects/manage-pom-cases-and-delius/src/main/resources/application.yml
@@ -60,13 +60,4 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring:
-  datasource:
-    url: 'jdbc:oracle:thin:@//localhost:1521/XEPDB1'
-    username: delius_pool
-    password: NDelius1
-  jpa:
-    properties:
-      hibernate.dialect: org.hibernate.dialect.OracleDialect
-    hibernate.ddl-auto: validate
-delius.db.username: NationalUser
+spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'

--- a/projects/offender-events-and-delius/build.gradle.kts
+++ b/projects/offender-events-and-delius/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
+    dev(libs.testcontainers.oracle)
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/offender-events-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/IntegrationTest.kt
+++ b/projects/offender-events-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/IntegrationTest.kt
@@ -11,7 +11,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.data.generator.OffenderDeltaGenerator
 import uk.gov.justice.digital.hmpps.integrations.delius.offender.OffenderDelta
 import uk.gov.justice.digital.hmpps.integrations.delius.offender.OffenderDeltaRepository
@@ -19,7 +18,6 @@ import uk.gov.justice.digital.hmpps.messaging.HmppsChannelManager
 import uk.gov.justice.digital.hmpps.telemetry.TelemetryService
 
 @SpringBootTest
-@ActiveProfiles("integration-test")
 internal class IntegrationTest {
     @Value("\${messaging.producer.topic}")
     lateinit var topicName: String

--- a/projects/offender-events-and-delius/src/main/resources/application.yml
+++ b/projects/offender-events-and-delius/src/main/resources/application.yml
@@ -43,16 +43,7 @@ offender-events:
 
 ---
 spring.config.activate.on-profile: oracle
-spring:
-  datasource:
-    url: 'jdbc:oracle:thin:@//localhost:1521/XEPDB1'
-    username: delius_pool
-    password: NDelius1
-  jpa:
-    properties:
-      hibernate.dialect: org.hibernate.dialect.OracleDialect
-    hibernate.ddl-auto: validate
-delius.db.username: NationalUser
+spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
 
 ---
 spring.config.activate.on-profile: localstack

--- a/projects/pathfinder-and-delius/build.gradle.kts
+++ b/projects/pathfinder-and-delius/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
+    dev(libs.testcontainers.oracle)
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/pathfinder-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/IntegrationTest.kt
+++ b/projects/pathfinder-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/IntegrationTest.kt
@@ -7,7 +7,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -15,7 +14,6 @@ import uk.gov.justice.digital.hmpps.security.withOAuth2Token
 import uk.gov.justice.digital.hmpps.telemetry.TelemetryService
 
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 internal class IntegrationTest {
     @Autowired lateinit var mockMvc: MockMvc

--- a/projects/pathfinder-and-delius/src/main/resources/application.yml
+++ b/projects/pathfinder-and-delius/src/main/resources/application.yml
@@ -48,13 +48,4 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring:
-  datasource:
-    url: 'jdbc:oracle:thin:@//localhost:1521/XEPDB1'
-    username: delius_pool
-    password: NDelius1
-  jpa:
-    properties:
-      hibernate.dialect: org.hibernate.dialect.OracleDialect
-    hibernate.ddl-auto: validate
-delius.db.username: NationalUser
+spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'

--- a/projects/pre-sentence-reports-to-delius/build.gradle.kts
+++ b/projects/pre-sentence-reports-to-delius/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
+    dev(libs.testcontainers.oracle)
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/pre-sentence-reports-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/PsrCompletedIntegrationTest.kt
+++ b/projects/pre-sentence-reports-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/PsrCompletedIntegrationTest.kt
@@ -12,7 +12,6 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.boot.test.mock.mockito.SpyBean
-import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.data.generator.DocumentGenerator
 import uk.gov.justice.digital.hmpps.integrations.alfresco.AlfrescoClient
 import uk.gov.justice.digital.hmpps.integrations.delius.document.DocumentRepository
@@ -20,7 +19,6 @@ import uk.gov.justice.digital.hmpps.messaging.HmppsChannelManager
 import uk.gov.justice.digital.hmpps.telemetry.TelemetryService
 import uk.gov.justice.digital.hmpps.telemetry.notificationReceived
 
-@ActiveProfiles("integration-test")
 @SpringBootTest
 class PsrCompletedIntegrationTest {
 

--- a/projects/pre-sentence-reports-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/PsrContextIntegrationTest.kt
+++ b/projects/pre-sentence-reports-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/PsrContextIntegrationTest.kt
@@ -12,7 +12,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.http.HttpHeaders
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -28,7 +27,6 @@ import uk.gov.justice.digital.hmpps.integrations.delius.presentencereport.PreSen
 import java.time.LocalDate
 import java.util.UUID
 
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
 class PsrContextIntegrationTest {

--- a/projects/pre-sentence-reports-to-delius/src/main/resources/application.yml
+++ b/projects/pre-sentence-reports-to-delius/src/main/resources/application.yml
@@ -78,18 +78,7 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring:
-  datasource:
-    url: 'jdbc:oracle:thin:@//localhost:1521/XEPDB1'
-    username: delius_pool
-    password: NDelius1
-  jpa:
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.Oracle12cDialect
-    hibernate:
-      ddl-auto: validate
-delius.db.username: NationalUser
+spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
 
 ---
 spring.config.activate.on-profile: localstack

--- a/projects/prison-case-notes-to-probation/build.gradle.kts
+++ b/projects/prison-case-notes-to-probation/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
+    dev(libs.testcontainers.oracle)
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/prison-case-notes-to-probation/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/CaseNotesIntegrationTest.kt
+++ b/projects/prison-case-notes-to-probation/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/CaseNotesIntegrationTest.kt
@@ -19,7 +19,6 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.boot.test.mock.mockito.SpyBean
-import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.audit.repository.AuditedInteractionRepository
 import uk.gov.justice.digital.hmpps.data.generator.CaseNoteMessageGenerator
 import uk.gov.justice.digital.hmpps.data.generator.CaseNoteNomisTypeGenerator
@@ -36,7 +35,6 @@ import uk.gov.justice.digital.hmpps.telemetry.TelemetryService
 
 const val CASE_NOTE_MERGED = "CaseNoteMerged"
 
-@ActiveProfiles("integration-test")
 @SpringBootTest
 class CaseNotesIntegrationTest {
 

--- a/projects/prison-case-notes-to-probation/src/main/resources/application.yml
+++ b/projects/prison-case-notes-to-probation/src/main/resources/application.yml
@@ -77,18 +77,7 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring:
-  datasource:
-    url: 'jdbc:oracle:thin:@//localhost:1521/XEPDB1'
-    username: delius_pool
-    password: NDelius1
-  jpa:
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.Oracle12cDialect
-    hibernate:
-      ddl-auto: validate
-delius.db.username: NationalUser
+spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
 
 ---
 spring.config.activate.on-profile: localstack

--- a/projects/prison-custody-status-to-delius/build.gradle.kts
+++ b/projects/prison-custody-status-to-delius/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
+    dev(libs.testcontainers.oracle)
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/prison-custody-status-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/PrisonCustodyStatusToDeliusIntegrationTest.kt
+++ b/projects/prison-custody-status-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/PrisonCustodyStatusToDeliusIntegrationTest.kt
@@ -14,7 +14,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.data.generator.MessageGenerator
 import uk.gov.justice.digital.hmpps.data.generator.PersonGenerator
 import uk.gov.justice.digital.hmpps.datetime.EuropeLondon
@@ -47,7 +46,6 @@ import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit.DAYS
 
 @SpringBootTest
-@ActiveProfiles("integration-test")
 internal class PrisonCustodyStatusToDeliusIntegrationTest {
 
     @Value("\${messaging.consumer.queue}")

--- a/projects/prison-custody-status-to-delius/src/main/resources/application.yml
+++ b/projects/prison-custody-status-to-delius/src/main/resources/application.yml
@@ -36,16 +36,7 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring:
-  datasource:
-    url: 'jdbc:oracle:thin:@//localhost:1521/XEPDB1'
-    username: delius_pool
-    password: NDelius1
-  jpa:
-    properties:
-      hibernate.dialect: org.hibernate.dialect.OracleDialect
-    hibernate.ddl-auto: validate
-delius.db.username: NationalUser
+spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
 
 ---
 spring.config.activate.on-profile: localstack

--- a/projects/refer-and-monitor-and-delius/build.gradle.kts
+++ b/projects/refer-and-monitor-and-delius/build.gradle.kts
@@ -26,8 +26,9 @@ dependencies {
     implementation(libs.opentelemetry.annotations)
 
     dev(project(":libs:dev-tools"))
-    dev("com.h2database:h2")
     dev("com.unboundid:unboundid-ldapsdk")
+    dev("com.h2database:h2")
+    dev(libs.testcontainers.oracle)
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/refer-and-monitor-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/MergeAppointmentIntegrationTest.kt
+++ b/projects/refer-and-monitor-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/MergeAppointmentIntegrationTest.kt
@@ -16,7 +16,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.ResultMatcher
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
@@ -35,7 +34,6 @@ import java.util.UUID
 import java.util.concurrent.CompletableFuture
 
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 internal class MergeAppointmentIntegrationTest {

--- a/projects/refer-and-monitor-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/NsiServiceTest.kt
+++ b/projects/refer-and-monitor-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/NsiServiceTest.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.api.model.ReferralStarted
 import uk.gov.justice.digital.hmpps.data.generator.PersonGenerator
 import uk.gov.justice.digital.hmpps.data.generator.SentenceGenerator
@@ -14,12 +13,12 @@ import uk.gov.justice.digital.hmpps.datetime.EuropeLondon
 import uk.gov.justice.digital.hmpps.integrations.delius.referral.NsiRepository
 import uk.gov.justice.digital.hmpps.service.ContractTypeNsiType
 import uk.gov.justice.digital.hmpps.service.NsiService
+import uk.gov.justice.digital.hmpps.test.CustomMatchers.isCloseTo
 import java.time.LocalDate
 import java.util.UUID
 import java.util.concurrent.CompletableFuture
 
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class NsiServiceTest {
 
@@ -51,8 +50,8 @@ class NsiServiceTest {
         val nsi = nsiRepository.findByPersonCrnAndExternalReference(
             PersonGenerator.SENTENCED_WITHOUT_NSI.crn,
             referralStarted.urn
-        )
-        assertThat(nsi?.externalReference, equalTo(referralStarted.urn))
-        assertThat(nsi?.createdDatetime, equalTo(nsi?.lastUpdatedDatetime))
+        )!!
+        assertThat(nsi.externalReference, equalTo(referralStarted.urn))
+        assertThat(nsi.createdDatetime, isCloseTo(nsi.lastUpdatedDatetime))
     }
 }

--- a/projects/refer-and-monitor-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/ProbationCaseResourceTest.kt
+++ b/projects/refer-and-monitor-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/ProbationCaseResourceTest.kt
@@ -16,7 +16,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
@@ -28,7 +27,6 @@ import uk.gov.justice.digital.hmpps.integrations.delius.person.entity.Person
 import uk.gov.justice.digital.hmpps.security.withOAuth2Token
 
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class ProbationCaseResourceTest {
     @Autowired

--- a/projects/refer-and-monitor-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/ReferAndMonitorIntegrationTest.kt
+++ b/projects/refer-and-monitor-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/ReferAndMonitorIntegrationTest.kt
@@ -17,7 +17,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.data.generator.ContactGenerator
 import uk.gov.justice.digital.hmpps.data.generator.NsiGenerator
 import uk.gov.justice.digital.hmpps.data.generator.PersonGenerator
@@ -40,7 +39,6 @@ import java.time.LocalDate
 import java.time.ZonedDateTime
 
 @SpringBootTest
-@ActiveProfiles("integration-test")
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 internal class ReferAndMonitorIntegrationTest {
     @Value("\${messaging.consumer.queue}")
@@ -266,7 +264,7 @@ internal class ReferAndMonitorIntegrationTest {
         assertThat(
             saved.actualEndDate?.withZoneSameInstant(EuropeLondon),
             equalTo(
-                ZonedDateTime.parse("2023-02-23T15:29:54Z").withZoneSameInstant(EuropeLondon)
+                ZonedDateTime.parse("2023-02-23T15:29:54.197Z").withZoneSameInstant(EuropeLondon)
             )
         )
         assertThat(saved.outcome?.code, equalTo(ReferralEndType.PREMATURELY_ENDED.outcome))
@@ -313,7 +311,7 @@ internal class ReferAndMonitorIntegrationTest {
         assertThat(
             saved.actualEndDate?.withZoneSameInstant(EuropeLondon),
             equalTo(
-                ZonedDateTime.parse("2023-02-23T15:29:54Z").withZoneSameInstant(EuropeLondon)
+                ZonedDateTime.parse("2023-02-23T15:29:54.197Z").withZoneSameInstant(EuropeLondon)
             )
         )
         assertThat(saved.outcome?.code, equalTo(ReferralEndType.CANCELLED.outcome))

--- a/projects/refer-and-monitor-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/ReferralStartedIntegrationTest.kt
+++ b/projects/refer-and-monitor-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/ReferralStartedIntegrationTest.kt
@@ -12,7 +12,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
@@ -31,7 +30,6 @@ import java.time.ZonedDateTime
 import java.util.UUID
 
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 internal class ReferralStartedIntegrationTest {
     @Autowired

--- a/projects/refer-and-monitor-and-delius/src/main/resources/application.yml
+++ b/projects/refer-and-monitor-and-delius/src/main/resources/application.yml
@@ -63,16 +63,7 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring:
-  datasource:
-    url: 'jdbc:oracle:thin:@//localhost:1521/XEPDB1'
-    username: delius_pool
-    password: NDelius1
-  jpa:
-    properties:
-      hibernate.dialect: org.hibernate.dialect.OracleDialect
-    hibernate.ddl-auto: validate
-delius.db.username: NationalUser
+spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
 
 ---
 spring.config.activate.on-profile: localstack

--- a/projects/risk-assessment-scores-to-delius/build.gradle.kts
+++ b/projects/risk-assessment-scores-to-delius/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
+    dev(libs.testcontainers.oracle)
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/risk-assessment-scores-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/FeatureFlagIntegrationTest.kt
+++ b/projects/risk-assessment-scores-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/FeatureFlagIntegrationTest.kt
@@ -7,14 +7,12 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.message.MessageAttributes
 import uk.gov.justice.digital.hmpps.message.Notification
 import uk.gov.justice.digital.hmpps.messaging.HmppsChannelManager
 import uk.gov.justice.digital.hmpps.telemetry.TelemetryService
 import uk.gov.justice.digital.hmpps.telemetry.notificationReceived
 
-@ActiveProfiles("integration-test")
 @SpringBootTest(properties = ["flipt.url=http://localhost:\${wiremock.port}/flipt-disabled"])
 internal class FeatureFlagIntegrationTest {
     @Value("\${messaging.consumer.queue}")

--- a/projects/risk-assessment-scores-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/IntegrationTest.kt
+++ b/projects/risk-assessment-scores-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/IntegrationTest.kt
@@ -13,7 +13,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.data.generator.PersonGenerator
 import uk.gov.justice.digital.hmpps.exception.ConflictException
 import uk.gov.justice.digital.hmpps.integrations.delius.RiskAssessmentService
@@ -33,7 +32,6 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
 
 @SpringBootTest
-@ActiveProfiles("integration-test")
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 internal class IntegrationTest {
     @Value("\${messaging.consumer.queue}")

--- a/projects/risk-assessment-scores-to-delius/src/main/resources/application.yml
+++ b/projects/risk-assessment-scores-to-delius/src/main/resources/application.yml
@@ -44,20 +44,6 @@ spring.config.activate.on-profile: integration-test
 spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH;DB_CLOSE_ON_EXIT=FALSE
 
 ---
-spring.config.activate.on-profile: oracle
-spring:
-  sql.init.mode: never
-  datasource:
-    url: 'jdbc:oracle:thin:@//localhost:1521/XEPDB1'
-    username: delius_pool
-    password: NDelius1
-  jpa:
-    properties:
-      hibernate.dialect: org.hibernate.dialect.OracleDialect
-    hibernate.ddl-auto: validate
-delius.db.username: NationalUser
-
----
 spring.config.activate.on-profile: localstack
 spring.cloud.aws:
   sqs.endpoint: http://localhost:4566

--- a/projects/sentence-plan-and-delius/build.gradle.kts
+++ b/projects/sentence-plan-and-delius/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
+    dev(libs.testcontainers.oracle)
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/sentence-plan-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/SentencePlanIntegrationTest.kt
+++ b/projects/sentence-plan-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/SentencePlanIntegrationTest.kt
@@ -10,7 +10,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -23,7 +22,6 @@ import uk.gov.justice.digital.hmpps.security.withOAuth2Token
 import uk.gov.justice.digital.hmpps.telemetry.TelemetryService
 
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 internal class SentencePlanIntegrationTest {
     @Autowired

--- a/projects/sentence-plan-and-delius/src/main/resources/application.yml
+++ b/projects/sentence-plan-and-delius/src/main/resources/application.yml
@@ -48,13 +48,4 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring:
-  datasource:
-    url: 'jdbc:oracle:thin:@//localhost:1521/XEPDB1'
-    username: delius_pool
-    password: NDelius1
-  jpa:
-    properties:
-      hibernate.dialect: org.hibernate.dialect.OracleDialect
-    hibernate.ddl-auto: validate
-delius.db.username: NationalUser
+spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'

--- a/projects/tier-to-delius/build.gradle.kts
+++ b/projects/tier-to-delius/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
+    dev(libs.testcontainers.oracle)
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/tier-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/IntegrationTest.kt
+++ b/projects/tier-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/IntegrationTest.kt
@@ -9,7 +9,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.data.repository.ContactDevRepository
 import uk.gov.justice.digital.hmpps.data.repository.ManagementTierDevRepository
 import uk.gov.justice.digital.hmpps.datetime.ZonedDateTimeDeserializer
@@ -21,7 +20,6 @@ import uk.gov.justice.digital.hmpps.messaging.HmppsChannelManager
 import uk.gov.justice.digital.hmpps.telemetry.TelemetryService
 
 @SpringBootTest
-@ActiveProfiles("integration-test")
 internal class IntegrationTest {
 
     @Value("\${messaging.consumer.queue}")

--- a/projects/tier-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/TierDetailsTest.kt
+++ b/projects/tier-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/TierDetailsTest.kt
@@ -8,7 +8,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
 import org.springframework.http.MediaType
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
@@ -20,7 +19,6 @@ import uk.gov.justice.digital.hmpps.data.generator.RegistrationGenerator
 import uk.gov.justice.digital.hmpps.security.withOAuth2Token
 
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 class TierDetailsTest {
     @Autowired lateinit var mockMvc: MockMvc

--- a/projects/tier-to-delius/src/main/resources/application.yml
+++ b/projects/tier-to-delius/src/main/resources/application.yml
@@ -63,16 +63,7 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring:
-  datasource:
-    url: 'jdbc:oracle:thin:@//localhost:1521/XEPDB1'
-    username: delius_pool
-    password: NDelius1
-  jpa:
-    properties:
-      hibernate.dialect: org.hibernate.dialect.OracleDialect
-    hibernate.ddl-auto: validate
-delius.db.username: NationalUser
+spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
 
 ---
 spring.config.activate.on-profile: localstack

--- a/projects/unpaid-work-and-delius/build.gradle.kts
+++ b/projects/unpaid-work-and-delius/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
+    dev(libs.testcontainers.oracle)
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/unpaid-work-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/AssessmentCompleteIntegrationTest.kt
+++ b/projects/unpaid-work-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/AssessmentCompleteIntegrationTest.kt
@@ -12,7 +12,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import uk.gov.justice.digital.hmpps.data.generator.CaseGenerator
 import uk.gov.justice.digital.hmpps.integrations.common.entity.contact.type.ContactTypeCode
@@ -23,7 +22,6 @@ import uk.gov.justice.digital.hmpps.telemetry.TelemetryService
 import uk.gov.justice.digital.hmpps.telemetry.notificationReceived
 
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 internal class AssessmentCompleteIntegrationTest {
     @Value("\${messaging.consumer.queue}")

--- a/projects/unpaid-work-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/CaseDetailsIntegrationTest.kt
+++ b/projects/unpaid-work-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/CaseDetailsIntegrationTest.kt
@@ -6,7 +6,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
@@ -29,7 +28,6 @@ import uk.gov.justice.digital.hmpps.data.generator.RegisterTypeGenerator
 import uk.gov.justice.digital.hmpps.security.withOAuth2Token
 
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 class CaseDetailsIntegrationTest {
     @Autowired lateinit var mockMvc: MockMvc

--- a/projects/unpaid-work-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/PersonalDetailsIntegrationTest.kt
+++ b/projects/unpaid-work-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/PersonalDetailsIntegrationTest.kt
@@ -6,7 +6,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
@@ -21,7 +20,6 @@ import uk.gov.justice.digital.hmpps.data.generator.PersonalContactGenerator
 import uk.gov.justice.digital.hmpps.security.withOAuth2Token
 
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 class PersonalDetailsIntegrationTest {
     @Autowired lateinit var mockMvc: MockMvc

--- a/projects/unpaid-work-and-delius/src/main/resources/application.yml
+++ b/projects/unpaid-work-and-delius/src/main/resources/application.yml
@@ -67,16 +67,7 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring:
-  datasource:
-    url: 'jdbc:oracle:thin:@//localhost:1521/XEPDB1'
-    username: delius_pool
-    password: NDelius1
-  jpa:
-    properties:
-      hibernate.dialect: org.hibernate.dialect.OracleDialect
-    hibernate.ddl-auto: validate
-delius.db.username: NationalUser
+spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
 
 ---
 spring.config.activate.on-profile: localstack

--- a/projects/workforce-allocations-to-delius/build.gradle.kts
+++ b/projects/workforce-allocations-to-delius/build.gradle.kts
@@ -27,8 +27,9 @@ dependencies {
     implementation(libs.opentelemetry.annotations)
 
     dev(project(":libs:dev-tools"))
-    dev("com.h2database:h2")
     dev("com.unboundid:unboundid-ldapsdk")
+    dev("com.h2database:h2")
+    dev(libs.testcontainers.oracle)
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/workforce-allocations-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/AllocateEventIntegrationTest.kt
+++ b/projects/workforce-allocations-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/AllocateEventIntegrationTest.kt
@@ -12,7 +12,6 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.data.generator.EventGenerator
 import uk.gov.justice.digital.hmpps.data.generator.OrderManagerGenerator
 import uk.gov.justice.digital.hmpps.data.repository.IapsEventRepository
@@ -28,7 +27,6 @@ import uk.gov.justice.digital.hmpps.telemetry.TelemetryService
 import uk.gov.justice.digital.hmpps.telemetry.notificationReceived
 import java.time.ZonedDateTime
 
-@ActiveProfiles("integration-test")
 @SpringBootTest
 class AllocateEventIntegrationTest {
 

--- a/projects/workforce-allocations-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/AllocatePersonIntegrationTest.kt
+++ b/projects/workforce-allocations-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/AllocatePersonIntegrationTest.kt
@@ -10,7 +10,6 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.data.generator.PersonGenerator
 import uk.gov.justice.digital.hmpps.data.generator.PersonManagerGenerator
 import uk.gov.justice.digital.hmpps.data.generator.ResponsibleOfficerGenerator
@@ -28,7 +27,6 @@ import uk.gov.justice.digital.hmpps.telemetry.notificationReceived
 import java.time.ZonedDateTime
 
 @SpringBootTest
-@ActiveProfiles("integration-test")
 class AllocatePersonIntegrationTest {
 
     @Value("\${messaging.consumer.queue}")

--- a/projects/workforce-allocations-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/AllocateRequirementIntegrationTest.kt
+++ b/projects/workforce-allocations-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/AllocateRequirementIntegrationTest.kt
@@ -10,7 +10,6 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.data.generator.RequirementGenerator
 import uk.gov.justice.digital.hmpps.data.generator.RequirementManagerGenerator
 import uk.gov.justice.digital.hmpps.data.repository.IapsRequirementRepository
@@ -24,7 +23,6 @@ import uk.gov.justice.digital.hmpps.telemetry.TelemetryService
 import uk.gov.justice.digital.hmpps.telemetry.notificationReceived
 import java.time.ZonedDateTime
 
-@ActiveProfiles("integration-test")
 @SpringBootTest
 class AllocateRequirementIntegrationTest {
 

--- a/projects/workforce-allocations-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/AllocationCompletedIntegrationTest.kt
+++ b/projects/workforce-allocations-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/AllocationCompletedIntegrationTest.kt
@@ -6,7 +6,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
@@ -18,7 +17,6 @@ import uk.gov.justice.digital.hmpps.data.generator.StaffGenerator
 import uk.gov.justice.digital.hmpps.security.withOAuth2Token
 
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 class AllocationCompletedIntegrationTest {
     @Autowired lateinit var mockMvc: MockMvc

--- a/projects/workforce-allocations-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/AllocationDemandIntegrationTest.kt
+++ b/projects/workforce-allocations-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/AllocationDemandIntegrationTest.kt
@@ -12,7 +12,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.http.MediaType
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
@@ -40,7 +39,6 @@ import uk.gov.justice.digital.hmpps.security.withOAuth2Token
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
 class AllocationDemandIntegrationTest {

--- a/projects/workforce-allocations-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/AllocationDetailIntegrationTest.kt
+++ b/projects/workforce-allocations-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/AllocationDetailIntegrationTest.kt
@@ -10,7 +10,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
@@ -24,7 +23,6 @@ import uk.gov.justice.digital.hmpps.data.generator.PersonGenerator
 import uk.gov.justice.digital.hmpps.data.generator.StaffGenerator
 import uk.gov.justice.digital.hmpps.security.withOAuth2Token
 
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
 class AllocationDetailIntegrationTest {

--- a/projects/workforce-allocations-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/AllocationRiskIntegrationTest.kt
+++ b/projects/workforce-allocations-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/AllocationRiskIntegrationTest.kt
@@ -6,7 +6,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
@@ -16,7 +15,6 @@ import uk.gov.justice.digital.hmpps.data.generator.RegisterTypeGenerator
 import uk.gov.justice.digital.hmpps.security.withOAuth2Token
 
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 class AllocationRiskIntegrationTest {
     @Autowired lateinit var mockMvc: MockMvc

--- a/projects/workforce-allocations-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/CaseViewIntegrationTest.kt
+++ b/projects/workforce-allocations-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/CaseViewIntegrationTest.kt
@@ -12,7 +12,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -28,7 +27,6 @@ import uk.gov.justice.digital.hmpps.data.generator.PersonGenerator
 import uk.gov.justice.digital.hmpps.security.withOAuth2Token
 import java.time.LocalDate
 
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
 class CaseViewIntegrationTest {

--- a/projects/workforce-allocations-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/ChoosePractitionerIntegrationTest.kt
+++ b/projects/workforce-allocations-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/ChoosePractitionerIntegrationTest.kt
@@ -6,7 +6,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
@@ -16,7 +15,6 @@ import uk.gov.justice.digital.hmpps.data.generator.TeamGenerator
 import uk.gov.justice.digital.hmpps.security.withOAuth2Token
 
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 class ChoosePractitionerIntegrationTest {
     @Autowired lateinit var mockMvc: MockMvc

--- a/projects/workforce-allocations-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/FindPersonIntegrationTest.kt
+++ b/projects/workforce-allocations-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/FindPersonIntegrationTest.kt
@@ -13,7 +13,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
@@ -23,7 +22,6 @@ import uk.gov.justice.digital.hmpps.api.model.name
 import uk.gov.justice.digital.hmpps.data.generator.PersonGenerator
 import uk.gov.justice.digital.hmpps.security.withOAuth2Token
 
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
 class FindPersonIntegrationTest {

--- a/projects/workforce-allocations-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/ImpactIntegrationTest.kt
+++ b/projects/workforce-allocations-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/ImpactIntegrationTest.kt
@@ -10,7 +10,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -21,7 +20,6 @@ import uk.gov.justice.digital.hmpps.data.generator.PersonGenerator
 import uk.gov.justice.digital.hmpps.data.generator.StaffGenerator
 import uk.gov.justice.digital.hmpps.security.withOAuth2Token
 
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
 class ImpactIntegrationTest {

--- a/projects/workforce-allocations-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/LimitedAccessIntegrationTest.kt
+++ b/projects/workforce-allocations-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/LimitedAccessIntegrationTest.kt
@@ -10,7 +10,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import uk.gov.justice.digital.hmpps.api.model.UserAccess
@@ -19,7 +18,6 @@ import uk.gov.justice.digital.hmpps.data.generator.UserGenerator
 import uk.gov.justice.digital.hmpps.security.withOAuth2Token
 
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class LimitedAccessIntegrationTest {
     @Autowired

--- a/projects/workforce-allocations-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/OfficerViewIntegrationTest.kt
+++ b/projects/workforce-allocations-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/OfficerViewIntegrationTest.kt
@@ -6,7 +6,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
@@ -15,7 +14,6 @@ import uk.gov.justice.digital.hmpps.data.generator.StaffGenerator
 import uk.gov.justice.digital.hmpps.security.withOAuth2Token
 
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 class OfficerViewIntegrationTest {
     @Autowired lateinit var mockMvc: MockMvc

--- a/projects/workforce-allocations-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/ProbationRecordIntegrationTest.kt
+++ b/projects/workforce-allocations-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/ProbationRecordIntegrationTest.kt
@@ -12,7 +12,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -28,7 +27,6 @@ import uk.gov.justice.digital.hmpps.data.generator.StaffGenerator
 import uk.gov.justice.digital.hmpps.security.withOAuth2Token
 import java.time.LocalDate
 
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
 class ProbationRecordIntegrationTest {

--- a/projects/workforce-allocations-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/StaffActiveCasesTest.kt
+++ b/projects/workforce-allocations-to-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/StaffActiveCasesTest.kt
@@ -8,7 +8,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
 import org.springframework.http.MediaType
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
@@ -18,7 +17,6 @@ import uk.gov.justice.digital.hmpps.data.generator.StaffGenerator
 import uk.gov.justice.digital.hmpps.security.withOAuth2Token
 
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 class StaffActiveCasesTest {
     @Autowired lateinit var mockMvc: MockMvc

--- a/projects/workforce-allocations-to-delius/src/main/resources/application.yml
+++ b/projects/workforce-allocations-to-delius/src/main/resources/application.yml
@@ -77,22 +77,9 @@ spring.config.activate.on-profile: dev
 spring.config.activate.on-profile: integration-test
 spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH;DB_CLOSE_ON_EXIT=FALSE
 
-
-
 ---
 spring.config.activate.on-profile: oracle
-spring:
-  datasource:
-    url: 'jdbc:oracle:thin:@//localhost:1521/XEPDB1'
-    username: delius_pool
-    password: NDelius1
-  jpa:
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.Oracle12cDialect
-    hibernate:
-      ddl-auto: validate
-delius.db.username: NationalUser
+spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
 
 ---
 spring.config.activate.on-profile: localstack

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -56,6 +56,7 @@ dependencyResolutionManagement {
             library("mapstruct", "org.mapstruct:mapstruct:1.5.5.Final")
             library("mapstructprocessor", "org.mapstruct:mapstruct-processor:1.5.5.Final")
             library("flipt", "io.flipt:flipt-java:0.1.8")
+            library("testcontainers-oracle", "org.testcontainers:oracle-xe:1.18.1")
         }
     }
 }

--- a/templates/projects/api-client-and-server/build.gradle.kts
+++ b/templates/projects/api-client-and-server/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
+    dev(libs.testcontainers.oracle)
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/templates/projects/api-client-and-server/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/IntegrationTest.kt
+++ b/templates/projects/api-client-and-server/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/IntegrationTest.kt
@@ -15,7 +15,6 @@ import uk.gov.justice.digital.hmpps.security.withOAuth2Token
 import uk.gov.justice.digital.hmpps.telemetry.TelemetryService
 
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 internal class IntegrationTest {
     @Autowired

--- a/templates/projects/api-client-and-server/src/main/resources/application.yml
+++ b/templates/projects/api-client-and-server/src/main/resources/application.yml
@@ -65,13 +65,4 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring:
-  datasource:
-    url: 'jdbc:oracle:thin:@//localhost:1521/XEPDB1'
-    username: delius_pool
-    password: NDelius1
-  jpa:
-    properties:
-      hibernate.dialect: org.hibernate.dialect.OracleDialect
-    hibernate.ddl-auto: validate
-delius.db.username: NationalUser
+spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'

--- a/templates/projects/api-server/build.gradle.kts
+++ b/templates/projects/api-server/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
+    dev(libs.testcontainers.oracle)
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/templates/projects/api-server/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/IntegrationTest.kt
+++ b/templates/projects/api-server/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/IntegrationTest.kt
@@ -15,7 +15,6 @@ import uk.gov.justice.digital.hmpps.security.withOAuth2Token
 import uk.gov.justice.digital.hmpps.telemetry.TelemetryService
 
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 internal class IntegrationTest {
     @Autowired lateinit var mockMvc: MockMvc

--- a/templates/projects/api-server/src/main/resources/application.yml
+++ b/templates/projects/api-server/src/main/resources/application.yml
@@ -48,13 +48,4 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring:
-  datasource:
-    url: 'jdbc:oracle:thin:@//localhost:1521/XEPDB1'
-    username: delius_pool
-    password: NDelius1
-  jpa:
-    properties:
-      hibernate.dialect: org.hibernate.dialect.OracleDialect
-    hibernate.ddl-auto: validate
-delius.db.username: NationalUser
+spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'

--- a/templates/projects/message-listener-with-api-client-and-server/build.gradle.kts
+++ b/templates/projects/message-listener-with-api-client-and-server/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
+    dev(libs.testcontainers.oracle)
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/templates/projects/message-listener-with-api-client-and-server/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/IntegrationTest.kt
+++ b/templates/projects/message-listener-with-api-client-and-server/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/IntegrationTest.kt
@@ -23,7 +23,6 @@ import uk.gov.justice.digital.hmpps.telemetry.notificationReceived
 import java.util.concurrent.TimeoutException
 
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 internal class IntegrationTest {
     @Value("\${messaging.consumer.queue}")

--- a/templates/projects/message-listener-with-api-client-and-server/src/main/resources/application.yml
+++ b/templates/projects/message-listener-with-api-client-and-server/src/main/resources/application.yml
@@ -67,16 +67,7 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring:
-  datasource:
-    url: 'jdbc:oracle:thin:@//localhost:1521/XEPDB1'
-    username: delius_pool
-    password: NDelius1
-  jpa:
-    properties:
-      hibernate.dialect: org.hibernate.dialect.OracleDialect
-    hibernate.ddl-auto: validate
-delius.db.username: NationalUser
+spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
 
 ---
 spring.config.activate.on-profile: localstack

--- a/templates/projects/message-listener-with-api-client/build.gradle.kts
+++ b/templates/projects/message-listener-with-api-client/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
+    dev(libs.testcontainers.oracle)
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/templates/projects/message-listener-with-api-client/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/IntegrationTest.kt
+++ b/templates/projects/message-listener-with-api-client/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/IntegrationTest.kt
@@ -16,7 +16,6 @@ import uk.gov.justice.digital.hmpps.telemetry.notificationReceived
 import java.util.concurrent.TimeoutException
 
 @SpringBootTest
-@ActiveProfiles("integration-test")
 internal class IntegrationTest {
     @Value("\${messaging.consumer.queue}")
     lateinit var queueName: String

--- a/templates/projects/message-listener-with-api-client/src/main/resources/application.yml
+++ b/templates/projects/message-listener-with-api-client/src/main/resources/application.yml
@@ -65,16 +65,7 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring:
-  datasource:
-    url: 'jdbc:oracle:thin:@//localhost:1521/XEPDB1'
-    username: delius_pool
-    password: NDelius1
-  jpa:
-    properties:
-      hibernate.dialect: org.hibernate.dialect.OracleDialect
-    hibernate.ddl-auto: validate
-delius.db.username: NationalUser
+spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
 
 ---
 spring.config.activate.on-profile: localstack

--- a/templates/projects/message-listener/build.gradle.kts
+++ b/templates/projects/message-listener/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
+    dev(libs.testcontainers.oracle)
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/templates/projects/message-listener/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/IntegrationTest.kt
+++ b/templates/projects/message-listener/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/IntegrationTest.kt
@@ -16,7 +16,6 @@ import uk.gov.justice.digital.hmpps.telemetry.notificationReceived
 import java.util.concurrent.TimeoutException
 
 @SpringBootTest
-@ActiveProfiles("integration-test")
 internal class IntegrationTest {
     @Value("\${messaging.consumer.queue}")
     lateinit var queueName: String

--- a/templates/projects/message-listener/src/main/resources/application.yml
+++ b/templates/projects/message-listener/src/main/resources/application.yml
@@ -36,16 +36,7 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring:
-  datasource:
-    url: 'jdbc:oracle:thin:@//localhost:1521/XEPDB1'
-    username: delius_pool
-    password: NDelius1
-  jpa:
-    properties:
-      hibernate.dialect: org.hibernate.dialect.OracleDialect
-    hibernate.ddl-auto: validate
-delius.db.username: NationalUser
+spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
 
 ---
 spring.config.activate.on-profile: localstack


### PR DESCRIPTION
Since we last looked at this, there appear to be a few slimmer/faster OracleDB images available:
* Oracle official: https://container-registry.oracle.com/
* Cut-down version: https://hub.docker.com/r/gvenzl/oracle-xe

This PR updates the main GitHub Actions build workflow to run with the `oracle` profile, which will start an OracleDB container and run the tests against it.

To test against an OracleDB locally, make sure you have Docker running then run Gradle with the `oracle` profile:
```shell
SPRING_PROFILES_ACTIVE=oracle ./gradlew check
```
By default, without setting the `oracle` profile, the tests will continue to run against H2 as before.

Note: Oracle still doesn’t support ARM architecture, so it won't work out of the box on M1 Macs, but they provide instructions for running via colima here: https://github.com/gvenzl/oci-oracle-xe#oracle-xe-on-apple-m-chips.