### PR TITLE
PI-983 Replace jobs that have failed to start

### DIFF
--- a/projects/person-search-index-from-delius/container/pipelines/contact/logstash-full-load.conf
+++ b/projects/person-search-index-from-delius/container/pipelines/contact/logstash-full-load.conf
@@ -7,6 +7,7 @@ input {
         jdbc_user => "${JDBC_USER}"
         jdbc_password => "${JDBC_PASSWORD}"
         jdbc_validate_connection => true
+        sql_log_level => "error"
         lowercase_column_names => false
         statement_filepath => "/pipelines/contact/statement.sql"
         parameters => {

--- a/projects/person-search-index-from-delius/container/pipelines/person/logstash-full-load.conf
+++ b/projects/person-search-index-from-delius/container/pipelines/person/logstash-full-load.conf
@@ -7,6 +7,7 @@ input {
         jdbc_user => "${JDBC_USER}"
         jdbc_password => "${JDBC_PASSWORD}"
         jdbc_validate_connection => true
+        sql_log_level => "error"
         lowercase_column_names => false
         statement_filepath => "/pipelines/person/statement.sql"
         parameters => {

--- a/projects/person-search-index-from-delius/container/scripts/monitor-reindexing.sh
+++ b/projects/person-search-index-from-delius/container/scripts/monitor-reindexing.sh
@@ -66,7 +66,7 @@ function wait_for_index_to_complete() {
   echo 'Waiting for indexing to complete ...'
   SECONDS=0
   until [ "$(curl_json --no-show-error "${SEARCH_URL}/${STANDBY_INDEX}/_doc/-1" | jq '._source.indexReady')" = 'true' ]; do
-    if [ "$SECONDS" -gt "$REINDEXING_TIMEOUT" ]; then fail "Indexing process timed out." 'ProbationSearchIndexFailure'; fi
+    if [ "$SECONDS" -gt "$REINDEXING_TIMEOUT" ]; then fail "Indexing process timed out after ${SECONDS}s." 'ProbationSearchIndexFailure'; fi
     sleep 60
   done
   COUNT=$(curl_json "${SEARCH_URL}/${STANDBY_INDEX}/_count" | jq '.count')

--- a/projects/person-search-index-from-delius/deploy/templates/contact-reindex-cronjob.yml
+++ b/projects/person-search-index-from-delius/deploy/templates/contact-reindex-cronjob.yml
@@ -4,12 +4,9 @@ metadata:
   name: contact-reindex
 spec:
   schedule: {{ .Values.reindexing.contact_schedule }}
-  concurrencyPolicy: Forbid
-  failedJobsHistoryLimit: 3
-  successfulJobsHistoryLimit: 1
+  concurrencyPolicy: Replace
   jobTemplate:
     spec:
-      backoffLimit: 0
       template:
         spec:
           containers:

--- a/projects/person-search-index-from-delius/deploy/templates/person-reindex-cronjob.yml
+++ b/projects/person-search-index-from-delius/deploy/templates/person-reindex-cronjob.yml
@@ -4,12 +4,9 @@ metadata:
   name: person-reindex
 spec:
   schedule: {{ .Values.reindexing.person_schedule }}
-  concurrencyPolicy: Forbid
-  failedJobsHistoryLimit: 3
-  successfulJobsHistoryLimit: 1
+  concurrencyPolicy: Replace
   jobTemplate:
     spec:
-      backoffLimit: 0
       template:
         spec:
           containers:


### PR DESCRIPTION
This ensures that ImagePullBackOff errors don't block subsequent image builds from running.

Also removes SQL logging, as it's just noise.