### PR TITLE
PI-1147 write notes in rescheduled appointments from scratch rather than copy

### DIFF
--- a/projects/refer-and-monitor-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/contact/entity/Contact.kt
+++ b/projects/refer-and-monitor-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/contact/entity/Contact.kt
@@ -175,7 +175,7 @@ class Contact(
                 staffId = staffId,
                 locationId = locationId,
                 externalReference = externalReference
-            ).addNotes(notes)
+            )
         } else {
             this.externalReference = externalReference
             null

--- a/projects/refer-and-monitor-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/AppointmentService.kt
+++ b/projects/refer-and-monitor-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/AppointmentService.kt
@@ -85,7 +85,7 @@ class AppointmentService(
             mergeAppointment.urn,
             mergeAppointment.start,
             mergeAppointment.end
-        )
+        )?.addNotes(mergeAppointment.notes)
         replacement?.also {
             appointment.outcome = outcomeRepository.getByCode(Code.RESCHEDULED_SERVICE_REQUEST.value)
             contactRepository.save(it)


### PR DESCRIPTION
This means the `Comment added by` line isn't duplicated for each reschedule