### PR TITLE
PI-1130 Increase batch frequency and reduce batch size

### DIFF
--- a/projects/person-search-index-from-delius/container/pipelines/contact/logstash-full-load.conf
+++ b/projects/person-search-index-from-delius/container/pipelines/contact/logstash-full-load.conf
@@ -12,12 +12,12 @@ input {
         statement_filepath => "/pipelines/contact/statement.sql"
         parameters => {
             contact_id => 0
-            batch_size => 1000000
+            batch_size => "${JDBC_BATCH_SIZE}"
         }
         use_column_value => true
         tracking_column => "sql_next_value"
         tracking_column_type => "numeric"
-        schedule => "* * * * *"
+        schedule => "* * * * * *"
     }
 }
 

--- a/projects/person-search-index-from-delius/container/pipelines/person/logstash-full-load.conf
+++ b/projects/person-search-index-from-delius/container/pipelines/person/logstash-full-load.conf
@@ -12,12 +12,12 @@ input {
         statement_filepath => "/pipelines/person/statement.sql"
         parameters => {
             offender_id => 0
-            batch_size => 100000000
+            batch_size => "${JDBC_BATCH_SIZE}"
         }
         use_column_value => true
         tracking_column => "sql_next_value"
         tracking_column_type => "numeric"
-        schedule => "* * * * *"
+        schedule => "* * * * * *"
     }
 }
 

--- a/projects/person-search-index-from-delius/container/scripts/monitor-reindexing.sh
+++ b/projects/person-search-index-from-delius/container/scripts/monitor-reindexing.sh
@@ -31,7 +31,7 @@ if [ -z "$REINDEXING_TIMEOUT" ]; then help; fail 'Missing -t'; fi
 function stop_logstash() {
     exit_code=$?
     echo 'Printing final stats...'
-    curl localhost:9600/_node/stats
+    curl --silent localhost:9600/_node/stats
     if [ "$exit_code" = '0' ]; then
       echo 'Gracefully stopping Logstash process...'
       pgrep java | xargs -n1 kill -TERM
@@ -87,6 +87,9 @@ function switch_aliases() {
   track_custom_event 'ProbationSearchIndexCompleted' '{"indexName": "'"$STANDBY_INDEX"'", "duration": "'"$SECONDS"'", "count": "'"$COUNT"'"}'
 }
 
-get_current_indices && delete_ready_for_reindex && wait_for_index_to_complete && switch_aliases
+get_current_indices
+delete_ready_for_reindex
+wait_for_index_to_complete
+switch_aliases
 
 exit 0

--- a/projects/person-search-index-from-delius/deploy/templates/contact-reindex-cronjob.yml
+++ b/projects/person-search-index-from-delius/deploy/templates/contact-reindex-cronjob.yml
@@ -14,8 +14,8 @@ spec:
               image: ghcr.io/ministryofjustice/hmpps-probation-integration-services/person-search-index-from-delius:{{ .Values.version }}
               resources:
                 requests:
-                  memory: 4Gi
-                  cpu: 2
+                  memory: 2Gi
+                  cpu: 1
                 limits:
                   memory: 4Gi
                   cpu: 2
@@ -32,8 +32,10 @@ spec:
                   value: '172800' # 48 hours
                 - name: PIPELINES_ENABLED
                   value: contact-full-load,contact-dlq
-                - name: PIPELINE_BATCH_SIZE
+                - name: PIPELINE_BATCH_SIZE # Maximum number of in-memory events per worker
                   value: '10000'
+                - name: JDBC_BATCH_SIZE # Maximum number of results to return from DB at a time
+                  value: '1000000'
                 - name: APPLICATIONINSIGHTS_CONNECTION_STRING
                   valueFrom:
                     secretKeyRef:

--- a/projects/person-search-index-from-delius/deploy/templates/person-reindex-cronjob.yml
+++ b/projects/person-search-index-from-delius/deploy/templates/person-reindex-cronjob.yml
@@ -14,8 +14,8 @@ spec:
               image: ghcr.io/ministryofjustice/hmpps-probation-integration-services/person-search-index-from-delius:{{ .Values.version }}
               resources:
                 requests:
-                  memory: 4Gi
-                  cpu: 2
+                  memory: 2Gi
+                  cpu: 1
                 limits:
                   memory: 4Gi
                   cpu: 2
@@ -32,8 +32,10 @@ spec:
                   value: '7200' # 3 hours
                 - name: PIPELINES_ENABLED
                   value: person-full-load,person-dlq
-                - name: PIPELINE_BATCH_SIZE
-                  value: '500'
+                - name: PIPELINE_BATCH_SIZE # Maximum number of in-memory events per worker
+                  value: '5000'
+                - name: JDBC_BATCH_SIZE # Maximum number of results to return from DB at a time
+                  value: '5000'
                 - name: APPLICATIONINSIGHTS_CONNECTION_STRING
                   valueFrom:
                     secretKeyRef:


### PR DESCRIPTION
Previously the person-reindex job was trying to fetch too much from the database, and only ran the query once per-minute. This meant that, towards the end of the indexing process, by the time the SQL finished running more records had been created in the database - so it got stuck in a cat-and-mouse loop of trying to get to the end of the offender table.

The reason for fetching so much from the database was to ensure that there were enough records to keep Logstash busy for a full minute until the next query ran, to avoid quiet periods.  However, Logstash supports seconds in its cron syntax - so we can make this more efficient by setting a smaller batch size and running more often. This also means queries will complete in a few 100ms, rather than a few minutes, which drastically reduces the chance of records being created while the queries are still running.

I've tested this in preprod, and it works as expected - throughput is more consistent, and doesn't get stuck at the end.

This PR also sets the CPU/Memory requests to the observed values from the running cron jobs.