### PR TITLE
PI-983 Disable provenance for Docker builds

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -44,6 +44,7 @@ runs:
         cache-to: type=gha,mode=max
         context: projects/${{ inputs.project }}/container
         push: ${{ inputs.push }}
+        provenance: false
         tags: |
           ghcr.io/ministryofjustice/hmpps-probation-integration-services/${{ inputs.project }}:latest
           ghcr.io/ministryofjustice/hmpps-probation-integration-services/${{ inputs.project }}:${{ inputs.version }}


### PR DESCRIPTION
Workaround for corrupted images due to https://github.com/snok/container-retention-policy/issues/63