### PR TITLE
Increase max heap size for Gradle JVM

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 org.gradle.caching=true
 org.gradle.parallel=true
+org.gradle.jvmargs=-Xmx4g "-XX:MaxMetaspaceSize=384m"
 systemProp.sonar.host.url=https://sonarcloud.io
 systemProp.sonar.organization=ministryofjustice
 systemProp.sonar.projectKey=ministryofjustice_hmpps-probation-integration-services


### PR DESCRIPTION
to prevent OutOfMemory errors in IntelliJ since upgrading to Gradle 8.

4GB will be fine for CI, as GitHub-hosted runners come with 7GB RAM (https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources).