### PR TITLE
PI-1174 Remove Sonar analysis from the pipeline

### DIFF
--- a/.github/workflows/analyse.yml
+++ b/.github/workflows/analyse.yml
@@ -1,0 +1,49 @@
+name: Analyse
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - Build
+    types:
+      - completed
+
+jobs:
+  analyse:
+    name: Analyse
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: test-results
+
+      - name: Publish test reports
+        uses: mikepenz/action-junit-report@4fa23552acda20a6a1d44f16224a90efbeb6c5f1 # v3.7.5
+        if: always() && github.actor != 'dependabot[bot]'
+        with:
+          check_name: |-
+            Unit test results
+            Integration test results
+          report_paths: |-
+            **/build/test-results/test/TEST-*.xml
+            **/build/test-results/integrationTest/TEST-*.xml
+
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: true
+
+      - name: Sonar analysis
+        if: github.actor != 'dependabot[bot]'
+        run: ./gradlew sonar
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,8 +138,8 @@ jobs:
           matrix-key: ${{ matrix.project }}
           outputs: ${{ steps.build.outputs.changes }}
 
-  analyse:
-    name: Analyse
+  post-build:
+    name: Post-build
     runs-on: ubuntu-latest
     needs:
       - build-gradle
@@ -147,39 +147,6 @@ jobs:
     outputs:
       changes: ${{ steps.check-changes.outputs.changes }}
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - uses: actions/download-artifact@v3
-        with:
-          name: test-results
-
-      - name: Publish test reports
-        uses: mikepenz/action-junit-report@4fa23552acda20a6a1d44f16224a90efbeb6c5f1 # v3.7.5
-        if: always() && github.actor != 'dependabot[bot]'
-        with:
-          check_name: |-
-            Unit test results
-            Integration test results
-          report_paths: |-
-            **/build/test-results/test/TEST-*.xml
-            **/build/test-results/integrationTest/TEST-*.xml
-
-      - uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
-      - name: Sonar analysis
-        if: github.actor != 'dependabot[bot]'
-        continue-on-error: true # don't fail the build when sonarcloud.io is down
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: sonar
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
       - uses: cloudposse/github-action-matrix-outputs-read@ea1c28d66c34b8400391ed74d510f66abc392d5e # v0.1.1
         id: read-changes
         with:


### PR DESCRIPTION
so it happens in parallel to the build/deployment


Unfortunately I can't test this from the branch because `workflow_run` only works after merge: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run
> Note: This event will only trigger a workflow run if the workflow file is on the default branch.