### PR TITLE
PI-1185 Suppress CVE-2023-34455 in Logstash image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,7 @@ updates:
     directory: "/templates"
     schedule:
       interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/projects/person-search-index-from-delius"
+    schedule:
+      interval: "daily"

--- a/projects/person-search-index-from-delius/.trivyignore
+++ b/projects/person-search-index-from-delius/.trivyignore
@@ -7,3 +7,6 @@ CVE-2022-1471
 #   Logstash versions 8.4.0 and 7.17.6 that are released on 2022-08-24 bundle unaffected JDK versions. Namely, Logstash version 8.4.0 bundles JDK 17.0.4 and Logstash version 7.17.6 bundles JDK 11.0.16.
 #   - https://discuss.elastic.co/t/elastic-stack-8-4-0-7-17-6-security-statement/312823
 CVE-2022-25647
+
+# Reason: snappy compression only used for trusted inputs
+CVE-2023-34455

--- a/projects/person-search-index-from-delius/container/Dockerfile
+++ b/projects/person-search-index-from-delius/container/Dockerfile
@@ -4,7 +4,7 @@ COPY --chown=yq /pipelines /pipelines
 RUN find /pipelines -type f -name '*.yml' | xargs -n1 -I{} sh -c 'f={}; yq -o=json "$f" > "${f%.yml}.json"'
 
 
-FROM logstash:8.7.1
+FROM logstash:8.8.1
 
 USER root
 RUN apt-get update && apt-get upgrade -y \


### PR DESCRIPTION
Also upgrade Logstash and include it in Dependabot config.