### PR TITLE
PI-1191 Disable index auto-creation

### DIFF
--- a/projects/person-search-index-from-delius/container/scripts/startup.sh
+++ b/projects/person-search-index-from-delius/container/scripts/startup.sh
@@ -7,6 +7,13 @@ eval "$(sentry-cli bash-hook --no-environ)"
 if [ -z "$SEARCH_INDEX_HOST" ]; then fail 'Missing environment variable: SEARCH_INDEX_HOST'; fi
 curl_json --retry 3 "$SEARCH_INDEX_HOST"
 
+# Configure cluster settings
+curl_json -XPUT "${SEARCH_INDEX_HOST}/_cluster/settings" --data '{
+  "persistent": {
+    "action.auto_create_index": "false"
+  }
+}'
+
 pipelines=$(grep 'pipeline.id' /usr/share/logstash/config/pipelines.yml | sed 's/.*: //')
 for pipeline in $pipelines; do
   if grep -v -q "$pipeline" <<<"$PIPELINES_ENABLED"; then


### PR DESCRIPTION
This configures the cluster settings any time a container starts, to ensure the settings are always up to date.