### PR TITLE
PI-1178 Ignore patch versions instead of having separate schedules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,14 +8,8 @@ updates:
     schedule:
       interval: "daily"
     ignore:
-      - dependency-name: "software.amazon.awssdk:*"
-
-  - package-ecosystem: "gradle"
-    directory: "/"
-    schedule:
-      interval: "monthly" # reduce the noise of frequent AWS SDK updates
-    allow:
-      - dependency-name: "software.amazon.awssdk:*"
+      - dependency-name: "software.amazon.awssdk:*" # reduce the noise of frequent AWS SDK updates
+        update-types: ["version-update:semver-patch"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Turns out having separate schedules for the same package manager isn't supported. See https://github.com/dependabot/dependabot-core/issues/1778.

![image](https://github.com/ministryofjustice/hmpps-probation-integration-services/assets/39557241/1a961cc5-b200-46e3-9f78-429a584529b3)
