### PR TITLE
Updated to ignore not finding person by noms

### DIFF
--- a/projects/manage-pom-cases-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/IgnorableMessageException.kt
+++ b/projects/manage-pom-cases-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/IgnorableMessageException.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.messaging
+
+class IgnorableMessageException(
+    override val message: String,
+    val additionalInformation: Map<String, String> = mapOf()
+) : RuntimeException(message)


### PR DESCRIPTION
Also if no detail url or incorrect number of custody sentences to avoid filling the dql since the information held by mpc is often out of date.