### PR TITLE
Fix DB username formatting

### DIFF
--- a/.github/workflows/access.yml
+++ b/.github/workflows/access.yml
@@ -122,7 +122,7 @@ jobs:
           if ! kubectl get secret "$PROJECT-database" > /dev/null; then
             sudo apt-get install pwgen
             kubectl create secret generic "$PROJECT-database" \
-              --from-literal "DB_USERNAME=${PROJECT//-/_/}" \
+              --from-literal "DB_USERNAME=${PROJECT//-/_}" \
               --from-literal "DB_PASSWORD=$(pwgen -N1 16)"
           fi
         env:


### PR DESCRIPTION
Usernames are being created with extra "/" characters e.g. "project_/name" instead of "project_name".

Bug introduced in this commit: https://github.com/ministryofjustice/hmpps-probation-integration-services/commit/26f47829e1063e95160573cad2d881b994d2127a#diff-2b6be7268c958935f3ed5a7f4840ded6664b7d59bef9f46c09bb8223370537e2R124