### PR TITLE
PI-1226 Update bootstrapping to handle new queue policy format

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -241,9 +241,12 @@ jobs:
 
       - name: Update IAM access to queues
         run: |
-          sed -i '/managed_sqs_queues = \[/a \    module.${{ inputs.project_name }}-queue,\n    module.${{ inputs.project_name }}-dlq,' 'cloud-platform-environments-dev/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-dev/resources/iam.tf'
-          sed -i '/managed_sqs_queues = \[/a \    module.${{ inputs.project_name }}-queue,\n    module.${{ inputs.project_name }}-dlq,' 'cloud-platform-environments-preprod/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-preprod/resources/iam.tf'
-          sed -i '/managed_sqs_queues = \[/a \    module.${{ inputs.project_name }}-queue,\n    module.${{ inputs.project_name }}-dlq,' 'cloud-platform-environments-prod/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-prod/resources/iam.tf'
+          sed -i '/queue = \[/a \      module.${{ inputs.project_name }}-queue,' 'cloud-platform-environments-dev/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-dev/resources/iam.tf'
+          sed -i '/queue = \[/a \      module.${{ inputs.project_name }}-queue,' 'cloud-platform-environments-preprod/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-preprod/resources/iam.tf'
+          sed -i '/queue = \[/a \      module.${{ inputs.project_name }}-queue,' 'cloud-platform-environments-prod/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-prod/resources/iam.tf'
+          sed -i '/dlq = \[/a \      module.${{ inputs.project_name }}-dlq,' 'cloud-platform-environments-dev/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-dev/resources/iam.tf'
+          sed -i '/dlq = \[/a \      module.${{ inputs.project_name }}-dlq,' 'cloud-platform-environments-preprod/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-preprod/resources/iam.tf'
+          sed -i '/dlq = \[/a \      module.${{ inputs.project_name }}-dlq,' 'cloud-platform-environments-prod/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-probation-integration-services-prod/resources/iam.tf'
 
       - name: Create dev pull request
         id: dev-pr


### PR DESCRIPTION
The SQS policy had to be separated into a `queue` and `dlq` policy, because the original policy exceeded the PolicySize quota (see https://github.com/ministryofjustice/cloud-platform-environments/pull/14540/files).  This PR ensures the bootstrap works with the new format.