### PR TITLE
PI-1314 Upgrade generic-prometheus-alerts Helm chart to 1.3.2

### DIFF
--- a/projects/approved-premises-and-delius/deploy/Chart.yaml
+++ b/projects/approved-premises-and-delius/deploy/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 2.6.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 1.3.0
+    version: 1.3.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/projects/approved-premises-and-oasys/deploy/Chart.yaml
+++ b/projects/approved-premises-and-oasys/deploy/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 2.6.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 1.3.0
+    version: 1.3.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/projects/court-case-and-delius/deploy/Chart.yaml
+++ b/projects/court-case-and-delius/deploy/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 2.6.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 1.3.0
+    version: 1.3.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/projects/create-and-vary-a-licence-and-delius/deploy/Chart.yaml
+++ b/projects/create-and-vary-a-licence-and-delius/deploy/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 2.6.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 1.3.0
+    version: 1.3.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/projects/custody-key-dates-and-delius/deploy/Chart.yaml
+++ b/projects/custody-key-dates-and-delius/deploy/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 2.6.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 1.3.0
+    version: 1.3.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/projects/domain-events-and-delius/deploy/Chart.yaml
+++ b/projects/domain-events-and-delius/deploy/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 2.6.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 1.3.0
+    version: 1.3.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/projects/effective-proposal-framework-and-delius/deploy/Chart.yaml
+++ b/projects/effective-proposal-framework-and-delius/deploy/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 2.6.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 1.3.0
+    version: 1.3.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/projects/external-api-and-delius/deploy/Chart.yaml
+++ b/projects/external-api-and-delius/deploy/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 2.6.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 1.3.0
+    version: 1.3.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/projects/make-recall-decisions-and-delius/deploy/Chart.yaml
+++ b/projects/make-recall-decisions-and-delius/deploy/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 2.6.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 1.3.0
+    version: 1.3.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/projects/manage-pom-cases-and-delius/deploy/Chart.yaml
+++ b/projects/manage-pom-cases-and-delius/deploy/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 2.6.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 1.3.0
+    version: 1.3.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/projects/offender-events-and-delius/deploy/Chart.yaml
+++ b/projects/offender-events-and-delius/deploy/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 2.6.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 1.3.0
+    version: 1.3.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/projects/pathfinder-and-delius/deploy/Chart.yaml
+++ b/projects/pathfinder-and-delius/deploy/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 2.6.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 1.3.0
+    version: 1.3.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/projects/person-search-index-from-delius/deploy/Chart.yaml
+++ b/projects/person-search-index-from-delius/deploy/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 2.6.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 1.3.0
+    version: 1.3.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/projects/pre-sentence-reports-to-delius/deploy/Chart.yaml
+++ b/projects/pre-sentence-reports-to-delius/deploy/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 2.6.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 1.3.0
+    version: 1.3.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/projects/prison-case-notes-to-probation/deploy/Chart.yaml
+++ b/projects/prison-case-notes-to-probation/deploy/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 2.6.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 1.3.0
+    version: 1.3.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/projects/prison-custody-status-to-delius/deploy/Chart.yaml
+++ b/projects/prison-custody-status-to-delius/deploy/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 2.6.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 1.3.0
+    version: 1.3.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/projects/refer-and-monitor-and-delius/deploy/Chart.yaml
+++ b/projects/refer-and-monitor-and-delius/deploy/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 2.6.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 1.3.0
+    version: 1.3.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/projects/risk-assessment-scores-to-delius/deploy/Chart.yaml
+++ b/projects/risk-assessment-scores-to-delius/deploy/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 2.6.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 1.3.0
+    version: 1.3.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/projects/sentence-plan-and-delius/deploy/Chart.yaml
+++ b/projects/sentence-plan-and-delius/deploy/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 2.6.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 1.3.0
+    version: 1.3.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/projects/sentence-plan-and-oasys/deploy/Chart.yaml
+++ b/projects/sentence-plan-and-oasys/deploy/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 2.6.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 1.3.0
+    version: 1.3.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/projects/soc-and-delius/deploy/Chart.yaml
+++ b/projects/soc-and-delius/deploy/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 2.6.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 1.3.0
+    version: 1.3.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/projects/tier-to-delius/deploy/Chart.yaml
+++ b/projects/tier-to-delius/deploy/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 2.6.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 1.3.0
+    version: 1.3.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/projects/unpaid-work-and-delius/deploy/Chart.yaml
+++ b/projects/unpaid-work-and-delius/deploy/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 2.6.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 1.3.0
+    version: 1.3.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/projects/workforce-allocations-to-delius/deploy/Chart.yaml
+++ b/projects/workforce-allocations-to-delius/deploy/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 2.6.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 1.3.0
+    version: 1.3.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/templates/projects/api-client-and-server/deploy/Chart.yaml
+++ b/templates/projects/api-client-and-server/deploy/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 2.6.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 1.3.0
+    version: 1.3.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/templates/projects/api-server/deploy/Chart.yaml
+++ b/templates/projects/api-server/deploy/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 2.6.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 1.3.0
+    version: 1.3.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/templates/projects/message-listener-with-api-client-and-server/deploy/Chart.yaml
+++ b/templates/projects/message-listener-with-api-client-and-server/deploy/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 2.6.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 1.3.0
+    version: 1.3.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/templates/projects/message-listener-with-api-client/deploy/Chart.yaml
+++ b/templates/projects/message-listener-with-api-client/deploy/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 2.6.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 1.3.0
+    version: 1.3.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/templates/projects/message-listener/deploy/Chart.yaml
+++ b/templates/projects/message-listener/deploy/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 2.6.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 1.3.0
+    version: 1.3.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/tools/feature-flags/deploy/Chart.yaml
+++ b/tools/feature-flags/deploy/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 2.6.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 1.3.0
+    version: 1.3.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts


### PR DESCRIPTION
v1.3.2 contains fixes for the out-of-hours alert suppression