### PR TITLE
PI-1378 Update to use district table for LAU

### DIFF
--- a/projects/manage-pom-cases-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/DataLoader.kt
+++ b/projects/manage-pom-cases-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/DataLoader.kt
@@ -23,7 +23,7 @@ import uk.gov.justice.digital.hmpps.integrations.delius.person.entity.PersonMana
 import uk.gov.justice.digital.hmpps.integrations.delius.person.entity.PersonRepository
 import uk.gov.justice.digital.hmpps.integrations.delius.person.entity.registration.entity.RegisterType
 import uk.gov.justice.digital.hmpps.integrations.delius.person.entity.registration.entity.RegistrationRepository
-import uk.gov.justice.digital.hmpps.integrations.delius.provider.entity.LocalDeliveryUnit
+import uk.gov.justice.digital.hmpps.integrations.delius.provider.entity.District
 import uk.gov.justice.digital.hmpps.integrations.delius.provider.entity.Staff
 import uk.gov.justice.digital.hmpps.integrations.delius.provider.entity.StaffUser
 import uk.gov.justice.digital.hmpps.integrations.delius.provider.entity.Team
@@ -40,7 +40,7 @@ class DataLoader(
     private val referenceDataSetRepository: ReferenceDataSetRepository,
     private val referenceDataRepository: ReferenceDataRepository,
     private val registerTypeRepository: RegisterTypeRepository,
-    private val lduRepository: LocalDeliveryUnitRepository,
+    private val districtRepository: DistrictRepository,
     private val teamRepository: TeamRepository,
     private val staffRepository: StaffRepository,
     private val personRepository: PersonRepository,
@@ -68,7 +68,7 @@ class DataLoader(
                 RegistrationGenerator.TYPE_DASO
             )
         )
-        lduRepository.save(ProviderGenerator.DEFAULT_LDU)
+        districtRepository.save(ProviderGenerator.DEFAULT_DISTRICT)
         teamRepository.saveAll(PersonManagerGenerator.ALL.map { it.team })
         staffRepository.saveAll(PersonManagerGenerator.ALL.map { it.staff })
         staffUserRepository.save(UserGenerator.DEFAULT_STAFF_USER)
@@ -145,7 +145,7 @@ class DataLoader(
 
 interface ReferenceDataSetRepository : JpaRepository<ReferenceDataSet, Long>
 interface StaffUserRepository : JpaRepository<StaffUser, Long>
-interface LocalDeliveryUnitRepository : JpaRepository<LocalDeliveryUnit, Long>
+interface DistrictRepository : JpaRepository<District, Long>
 interface TeamRepository : JpaRepository<Team, Long>
 interface StaffRepository : JpaRepository<Staff, Long>
 interface PersonManagerRepository : JpaRepository<PersonManager, Long>

--- a/projects/manage-pom-cases-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/ProviderGenerator.kt
+++ b/projects/manage-pom-cases-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/ProviderGenerator.kt
@@ -1,25 +1,25 @@
 package uk.gov.justice.digital.hmpps.data.generator
 
-import uk.gov.justice.digital.hmpps.integrations.delius.provider.entity.LocalDeliveryUnit
+import uk.gov.justice.digital.hmpps.integrations.delius.provider.entity.District
 import uk.gov.justice.digital.hmpps.integrations.delius.provider.entity.Staff
 import uk.gov.justice.digital.hmpps.integrations.delius.provider.entity.StaffUser
 import uk.gov.justice.digital.hmpps.integrations.delius.provider.entity.Team
 import uk.gov.justice.digital.hmpps.set
 
 object ProviderGenerator {
-    val DEFAULT_LDU = generateLdu("N03LDU1")
-    val DEFAULT_TEAM = generateTeam("N03DEF", ldu = DEFAULT_LDU)
+    val DEFAULT_DISTRICT = generateDistrict("N03LDU1")
+    val DEFAULT_TEAM = generateTeam("N03DEF", district = DEFAULT_DISTRICT)
     val DEFAULT_STAFF = generateStaff("N03DEF0", "Default", "Staff", user = UserGenerator.DEFAULT_STAFF_USER)
 
-    fun generateLdu(code: String, description: String = "LDU $code", id: Long = IdGenerator.getAndIncrement()) =
-        LocalDeliveryUnit(code, description, id)
+    fun generateDistrict(code: String, description: String = "LDU $code", id: Long = IdGenerator.getAndIncrement()) =
+        District(code, description, id)
 
     fun generateTeam(
         code: String,
         description: String = "Team $code",
-        ldu: LocalDeliveryUnit? = DEFAULT_LDU,
+        district: District? = DEFAULT_DISTRICT,
         id: Long = IdGenerator.getAndIncrement()
-    ) = Team(code, description, ldu, id)
+    ) = Team(code, description, district, id)
 
     fun generateStaff(
         code: String,

--- a/projects/manage-pom-cases-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/ApiIntegrationTest.kt
+++ b/projects/manage-pom-cases-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/ApiIntegrationTest.kt
@@ -46,7 +46,7 @@ internal class ApiIntegrationTest {
             .andReturn().response.contentAsString
 
         val record = objectMapper.readValue<ProbationRecord>(res)
-        val ldu = ProviderGenerator.DEFAULT_LDU
+        val district = ProviderGenerator.DEFAULT_DISTRICT
         val team = ProviderGenerator.DEFAULT_TEAM
         val staff = ProviderGenerator.DEFAULT_STAFF
         assertThat(
@@ -61,7 +61,7 @@ internal class ApiIntegrationTest {
                         Team(
                             team.code,
                             team.description,
-                            LocalDeliveryUnit(ldu.code, ldu.description)
+                            LocalDeliveryUnit(district.code, district.description)
                         ),
                         ProviderGenerator.DEFAULT_STAFF.code,
                         Name(staff.forename, staff.surname),

--- a/projects/manage-pom-cases-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/person/entity/Person.kt
+++ b/projects/manage-pom-cases-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/person/entity/Person.kt
@@ -78,7 +78,7 @@ class PersonManager(
 )
 
 interface PersonRepository : JpaRepository<Person, Long> {
-    @EntityGraph(attributePaths = ["currentTier", "managers.team.ldu", "managers.staff.user"])
+    @EntityGraph(attributePaths = ["currentTier", "managers.team.district", "managers.staff.user"])
     fun findByNomsId(nomsId: String): Person?
 
     @Query("select p.id from Person p where p.nomsId = :nomsId and p.softDeleted = false")

--- a/projects/manage-pom-cases-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/provider/entity/Team.kt
+++ b/projects/manage-pom-cases-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/provider/entity/Team.kt
@@ -19,8 +19,8 @@ class Team(
     val description: String,
 
     @ManyToOne
-    @JoinColumn(name = "local_delivery_unit_id")
-    val ldu: LocalDeliveryUnit?,
+    @JoinColumn(name = "district_id")
+    val district: District?,
 
     @Id
     @Column(name = "team_id")
@@ -29,8 +29,7 @@ class Team(
 
 @Immutable
 @Entity
-@Table(name = "local_delivery_unit")
-class LocalDeliveryUnit(
+class District(
 
     @Column(name = "code")
     val code: String,
@@ -38,6 +37,6 @@ class LocalDeliveryUnit(
     val description: String,
 
     @Id
-    @Column(name = "local_delivery_unit_id")
+    @Column(name = "district_id")
     val id: Long
 )

--- a/projects/manage-pom-cases-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/services/mapping/ProbationRecordMapping.kt
+++ b/projects/manage-pom-cases-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/services/mapping/ProbationRecordMapping.kt
@@ -7,7 +7,7 @@ import uk.gov.justice.digital.hmpps.api.model.Resourcing
 import uk.gov.justice.digital.hmpps.integrations.delius.person.entity.Person
 import uk.gov.justice.digital.hmpps.integrations.delius.person.entity.PersonManager
 import uk.gov.justice.digital.hmpps.integrations.delius.person.entity.registration.entity.Registration
-import uk.gov.justice.digital.hmpps.integrations.delius.provider.entity.LocalDeliveryUnit
+import uk.gov.justice.digital.hmpps.integrations.delius.provider.entity.District
 import uk.gov.justice.digital.hmpps.integrations.delius.provider.entity.Staff
 import uk.gov.justice.digital.hmpps.integrations.delius.provider.entity.Team
 import uk.gov.justice.digital.hmpps.integrations.delius.reference.entity.ReferenceData
@@ -29,11 +29,11 @@ fun ReferenceData?.resourcing() = when (this?.code) {
     else -> null
 }
 
-fun LocalDeliveryUnit.forManager() =
+fun District.forManager() =
     uk.gov.justice.digital.hmpps.api.model.LocalDeliveryUnit(code, description)
 
 fun Team.forManager() =
-    uk.gov.justice.digital.hmpps.api.model.Team(code, description, ldu?.forManager())
+    uk.gov.justice.digital.hmpps.api.model.Team(code, description, district?.forManager())
 
 fun Staff.name() = Name(listOfNotNull(forename, middleName).joinToString(" "), surname)
 fun PersonManager.manager() =

--- a/projects/manage-pom-cases-and-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/services/mapping/ProbationRecordMappingKtTest.kt
+++ b/projects/manage-pom-cases-and-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/services/mapping/ProbationRecordMappingKtTest.kt
@@ -40,9 +40,9 @@ internal class ProbationRecordMappingKtTest {
     }
 
     @Test
-    fun `team mapping handles null ldu`() {
+    fun `team mapping handles null district`() {
         assertThat(
-            ProviderGenerator.generateTeam("TEST", ldu = null).forManager(),
+            ProviderGenerator.generateTeam("TEST", district = null).forManager(),
             equalTo(Team("TEST", "Team TEST", null))
         )
     }


### PR DESCRIPTION
`local_delivery_unit_id` corresponds to Team Type, which isn't really used. `district_id` corresponds to what Delius now calls "Local Admin Unit", but what Community API called `localDeliveryUnit`.  MPC still expect the field to be called `localDeliveryUnit` in the response, even though what they really want is Local Admin Unit.  Hooray for Community API naming inconsistencies.