### PR TITLE
PI-1558 Update PSR extension to PDF when complete

### DIFF
--- a/projects/pre-sentence-reports-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/document/DocumentService.kt
+++ b/projects/pre-sentence-reports-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/document/DocumentService.kt
@@ -47,14 +47,15 @@ class DocumentService(
                 throw ConflictException("Court report ${courtReport.id} not for ${hmppsEvent.personReference.findCrn()}")
             }
 
+            document.name = document.name.replace(Regex("\\.doc$"), ".pdf")
+            document.lastSaved = ZonedDateTime.now()
+            document.lastUpdatedUserId = ServiceContext.servicePrincipal()!!.userId
+
             alfrescoClient.releaseDocument(document.alfrescoId)
             alfrescoClient.updateDocument(
                 document.alfrescoId,
                 populateBodyValues(hmppsEvent, document, file)
             )
-
-            document.lastSaved = ZonedDateTime.now()
-            document.lastUpdatedUserId = ServiceContext.servicePrincipal()!!.userId
         }
 
     private fun populateBodyValues(


### PR DESCRIPTION
Previously, an empty PDF would be uploaded to the Alfresco when the initial draft was started.  Following the recent changes, Delius now uploads a .doc file instead as the draft.  However, the filename remains the same after the report is completed.

So we end up with a PDF document saved as e.g.
```
Nat Short format pre-sentence report_13102023_112036_Larson_D_X729742.doc
```

This PR updates the extension to .pdf before saving