### PR TITLE
PI-1607 Handle missing history for historical POM allocations

### DIFF
--- a/projects/prison-custody-status-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/person/manager/prison/PrisonManagerService.kt
+++ b/projects/prison-custody-status-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/person/manager/prison/PrisonManagerService.kt
@@ -61,6 +61,7 @@ class PrisonManagerService(
         // end-date the previous prison manager
         val activePrisonManager = prisonManagerRepository.findActiveManagerAtDate(person.id, allocationDate)
         val activePrisonManagerEndDate = activePrisonManager?.endDate
+            ?: prisonManagerRepository.findFirstManagerAfterDate(person.id, allocationDate).singleOrNull()?.date
         if (activePrisonManager != null) {
             activePrisonManager.active = false
             activePrisonManager.endDate = allocationDate

--- a/projects/prison-custody-status-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/person/manager/prison/entity/PrisonManager.kt
+++ b/projects/prison-custody-status-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/person/manager/prison/entity/PrisonManager.kt
@@ -15,6 +15,8 @@ import org.springframework.data.annotation.CreatedBy
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedBy
 import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
@@ -97,4 +99,15 @@ interface PrisonManagerRepository : JpaRepository<PrisonManager, Long> {
         """
     )
     fun findActiveManagerAtDate(personId: Long, date: ZonedDateTime): PrisonManager?
+
+    @Query(
+        """
+            select pm from PrisonManager pm
+            where pm.personId = :personId
+            and pm.softDeleted = false
+            and pm.date > :date
+            order by pm.date asc
+        """
+    )
+    fun findFirstManagerAfterDate(personId: Long, date: ZonedDateTime, pageable: Pageable = PageRequest.of(0, 1)): List<PrisonManager>
 }


### PR DESCRIPTION
We may also need to apply a similar change to Workforce COM allocations, although we seemingly haven't hit this issue there yet.  I'll try this out in the Custody Status integration for a while first, then if we want to apply it elsewhere we can put another ticket in.

Also I don't think MPC handles historical allocations at all, we might need to look at that.