### PR TITLE
Add some additional seed data for CAS

### DIFF
--- a/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/DataLoader.kt
+++ b/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/DataLoader.kt
@@ -156,6 +156,9 @@ class DataLoader(
         staffRepository.save(StaffGenerator.DEFAULT_STAFF)
         staffUserRepository.save(StaffGenerator.DEFAULT_STAFF_USER)
 
+        staffRepository.save(StaffGenerator.JIM_SNOW)
+        staffUserRepository.save(StaffGenerator.JIM_SNOW_USER)
+
         val personManagerStaff = StaffGenerator.generate(code = "N54A001")
         staffRepository.save(personManagerStaff)
         val person = PersonGenerator.DEFAULT

--- a/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/ProbationCaseDataLoader.kt
+++ b/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/ProbationCaseDataLoader.kt
@@ -44,11 +44,13 @@ class ProbationCaseDataLoader(
         staffRepository.save(ProbationCaseGenerator.COM_UNALLOCATED)
         probationCaseRepository.save(ProbationCaseGenerator.CASE_COMPLEX)
         probationCaseRepository.save(ProbationCaseGenerator.CASE_SIMPLE)
+        probationCaseRepository.save(ProbationCaseGenerator.CASE_X320741)
 
         personManagerRepository.saveAll(
             listOf(
                 ProbationCaseGenerator.generateManager(ProbationCaseGenerator.CASE_COMPLEX).asPersonManager(),
-                ProbationCaseGenerator.generateManager(ProbationCaseGenerator.CASE_SIMPLE).asPersonManager()
+                ProbationCaseGenerator.generateManager(ProbationCaseGenerator.CASE_SIMPLE).asPersonManager(),
+                ProbationCaseGenerator.generateManager(ProbationCaseGenerator.CASE_X320741).asPersonManager()
             )
         )
 

--- a/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/ProbationCaseGenerator.kt
+++ b/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/ProbationCaseGenerator.kt
@@ -34,6 +34,13 @@ object ProbationCaseGenerator {
         currentRestriction = true
     )
     val CASE_SIMPLE = generate("S517283", "Teresa", "Green", LocalDate.of(1987, 8, 2))
+    val CASE_X320741 = generate(
+        crn = "X320741",
+        forename = "Aadland",
+        surname = "Bertrand",
+        dateOfBirth = LocalDate.of(1987, 8, 2),
+        nomsId = "A1234AI"
+    )
 
     fun generate(
         crn: String,

--- a/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/StaffGenerator.kt
+++ b/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/StaffGenerator.kt
@@ -11,8 +11,12 @@ import java.util.concurrent.atomic.AtomicLong
 object StaffGenerator {
     private val staffCodeGenerator = AtomicLong(1)
     val DEFAULT_STAFF = generate()
+    val JIM_SNOW = generate(
+        name = "Jim Snow"
+    )
 
     val DEFAULT_STAFF_USER = generateStaffUser("john-smith", DEFAULT_STAFF)
+    val JIM_SNOW_USER = generateStaffUser("JIMSNOWLDAP", JIM_SNOW)
 
     fun generate(
         name: String = "TEST",


### PR DESCRIPTION
This adds some additional seed data to `approved-premises-and-delius` to allow us to run the service locally with some of our existing seed data on the other services.