### PR TITLE
PI-1684 Workaround for thread-safety bug in Spring streaming response

### DIFF
--- a/projects/dps-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/config/security/StreamingHeadersSecurityConfigurer.kt
+++ b/projects/dps-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/config/security/StreamingHeadersSecurityConfigurer.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.config.security
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.ObjectPostProcessor
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.web.header.HeaderWriterFilter
+
+/**
+ * Workaround for Spring issue with streaming responses:
+ *  * https://github.com/spring-projects/spring-security/issues/9175
+ *  * https://github.com/spring-projects/spring-framework/issues/31543
+ */
+@Configuration
+class StreamingHeadersSecurityConfigurer : SecurityConfigurer {
+    override fun configure(http: HttpSecurity): HttpSecurity {
+        http.headers {
+            it.withObjectPostProcessor(object : ObjectPostProcessor<HeaderWriterFilter> {
+                override fun <T : HeaderWriterFilter> postProcess(filter: T) = filter.also {
+                    filter.setShouldWriteHeadersEagerly(true)
+                }
+            })
+        }
+        return http
+    }
+}

--- a/projects/dps-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/DocumentService.kt
+++ b/projects/dps-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/DocumentService.kt
@@ -1,10 +1,11 @@
 package uk.gov.justice.digital.hmpps.service
 
-import feign.Response
 import jakarta.transaction.Transactional
 import org.springframework.http.ContentDisposition
-import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpHeaders.CONTENT_DISPOSITION
+import org.springframework.http.HttpHeaders.CONTENT_LENGTH
+import org.springframework.http.HttpHeaders.ETAG
+import org.springframework.http.HttpHeaders.LAST_MODIFIED
 import org.springframework.http.MediaType.APPLICATION_OCTET_STREAM
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
@@ -36,8 +37,10 @@ class DocumentService(
         val input = response.body().asInputStream()
         return when (response.status()) {
             200 -> ResponseEntity.ok()
-                .headers { it.putAll(response.sanitisedHeaders()) }
                 .header(CONTENT_DISPOSITION, ContentDisposition.attachment().filename(filename, UTF_8).build().toString())
+                .header(CONTENT_LENGTH, response.headers()[CONTENT_LENGTH]?.first())
+                .header(LAST_MODIFIED, response.headers()[LAST_MODIFIED]?.first())
+                .header(ETAG, response.headers()[ETAG]?.first())
                 .contentType(APPLICATION_OCTET_STREAM)
                 .body(StreamingResponseBody { output -> input.use { it.copyTo(output) } })
 
@@ -93,11 +96,4 @@ class DocumentService(
     private val Disposal.description get() = "${type.description}${lengthString?.let { " ($it)" } ?: ""}"
     private val Disposal.lengthString get() = length?.let { "$length ${lengthUnits!!.description}" }
     private fun List<CourtAppearance>.latestOutcome() = filter { it.outcome != null }.maxByOrNull { it.date }?.outcome
-    private fun Response.sanitisedHeaders(): Map<String, List<String>> = headers().filterKeys { key ->
-        key in listOf(
-            HttpHeaders.CONTENT_LENGTH,
-            HttpHeaders.ETAG,
-            HttpHeaders.LAST_MODIFIED
-        ).map { it.lowercase() }
-    }.mapValues { it.value.toList() }
 }


### PR DESCRIPTION
Fixes intermittent errors:
```
NullPointerException
Cannot invoke "org.apache.tomcat.util.http.MimeHeaderField.getName()" because "this.headers[i]" is null
```