### PR TITLE
Revert upgrade to actions/download-artifact@v4

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -175,7 +175,7 @@ jobs:
       - build-projects
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           path: artifacts
 


### PR DESCRIPTION
Fixes tech-docs deployment: https://github.com/ministryofjustice/hmpps-probation-integration-services/actions/runs/7354088094/job/20020884326