### PR TITLE
PI-1785: Added get user details by id

### DIFF
--- a/projects/hmpps-auth-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/DataLoader.kt
+++ b/projects/hmpps-auth-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/DataLoader.kt
@@ -7,22 +7,22 @@ import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.ApplicationListener
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.data.generator.UserGenerator
-import uk.gov.justice.digital.hmpps.user.AuditUserRepository
+import uk.gov.justice.digital.hmpps.entity.UserRepository
 
 @Component
 @ConditionalOnProperty("seed.database")
 class DataLoader(
-    private val auditUserRepository: AuditUserRepository
+    private val userRepository: UserRepository
 ) : ApplicationListener<ApplicationReadyEvent> {
 
     @PostConstruct
     fun saveAuditUser() {
-        auditUserRepository.save(UserGenerator.AUDIT_USER)
+        userRepository.save(UserGenerator.USER)
     }
 
     @Transactional
     override fun onApplicationEvent(are: ApplicationReadyEvent) {
-        auditUserRepository.save(UserGenerator.TEST_USER)
-        auditUserRepository.save(UserGenerator.INACTIVE_USER)
+        userRepository.save(UserGenerator.TEST_USER)
+        userRepository.save(UserGenerator.INACTIVE_USER)
     }
 }

--- a/projects/hmpps-auth-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/UserGenerator.kt
+++ b/projects/hmpps-auth-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/UserGenerator.kt
@@ -1,9 +1,9 @@
 package uk.gov.justice.digital.hmpps.data.generator
 
-import uk.gov.justice.digital.hmpps.user.AuditUser
+import uk.gov.justice.digital.hmpps.entity.User
 
 object UserGenerator {
-    val AUDIT_USER = AuditUser(IdGenerator.getAndIncrement(), "HmppsAuthAndDelius")
-    val TEST_USER = AuditUser(IdGenerator.getAndIncrement(), "test.user")
-    val INACTIVE_USER = AuditUser(IdGenerator.getAndIncrement(), "test.user.inactive")
+    val USER = User(IdGenerator.getAndIncrement(), "HmppsAuthAndDelius")
+    val TEST_USER = User(IdGenerator.getAndIncrement(), "test.user")
+    val INACTIVE_USER = User(IdGenerator.getAndIncrement(), "test.user.inactive")
 }

--- a/projects/hmpps-auth-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/UserDetailsIntegrationTest.kt
+++ b/projects/hmpps-auth-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/UserDetailsIntegrationTest.kt
@@ -43,6 +43,35 @@ internal class UserDetailsIntegrationTest {
     }
 
     @Test
+    fun `calling user by id without userId returns 400`() {
+        mockMvc.perform(get("/user").withToken())
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `missing user by id returns 404`() {
+        mockMvc.perform(get("/user/details/99999").withToken())
+            .andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun `get user by id`() {
+        mockMvc.perform(get("/user/details/" + TEST_USER.id).withToken())
+            .andExpect(status().isOk)
+            .andExpectJson(
+                UserDetails(
+                    userId = TEST_USER.id,
+                    username = "test.user",
+                    firstName = "Test",
+                    surname = "User",
+                    email = "test.user@example.com",
+                    enabled = true,
+                    roles = listOf("ABC001", "ABC002")
+                )
+            )
+    }
+
+    @Test
     fun `search by email`() {
         mockMvc.perform(get("/user?email=test.user@example.com").withToken())
             .andExpect(status().isOk)

--- a/projects/hmpps-auth-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/controller/UserController.kt
+++ b/projects/hmpps-auth-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/controller/UserController.kt
@@ -28,6 +28,12 @@ class UserController(private val userService: UserService) {
     fun getUserDetails(@PathVariable username: String) = userService.getUserDetails(username)
         ?: throw NotFoundException("User", "username", username)
 
+    @GetMapping(value = ["/user/details/{userId}"])
+    @PreAuthorize("hasAnyRole('ROLE_DELIUS_USER_AUTH', 'ROLE_DELIUS_USER_DETAILS')")
+    @Operation(description = "Get user details by Id. Requires `ROLE_DELIUS_USER_AUTH` or `ROLE_DELIUS_USER_DETAILS`.")
+    fun getUserDetailsById(@PathVariable(required = true) userId: Long) = userService.getUserDetailsById(userId)
+        ?: throw NotFoundException("User", "userId", userId)
+
     @GetMapping(value = ["/user"])
     @PreAuthorize("hasAnyRole('ROLE_DELIUS_USER_AUTH')")
     @Operation(description = "Get users by email. Requires `ROLE_DELIUS_USER_AUTH`.")

--- a/projects/hmpps-auth-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/entity/User.kt
+++ b/projects/hmpps-auth-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/entity/User.kt
@@ -6,6 +6,7 @@ import jakarta.persistence.Id
 import jakarta.persistence.Table
 import org.hibernate.annotations.Immutable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
 @Immutable
 @Entity
@@ -21,5 +22,8 @@ class User(
 
 interface UserRepository : JpaRepository<User, Long> {
     fun findUserById(userId: Long): User?
+
+    @Query("select u from User u where upper(u.username) = upper(:username)")
+    fun findUserByUsername(username: String): User?
 }
 

--- a/projects/hmpps-auth-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/entity/User.kt
+++ b/projects/hmpps-auth-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/entity/User.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.Immutable
+import org.springframework.data.jpa.repository.JpaRepository
+
+@Immutable
+@Entity
+@Table(name = "user_")
+class User(
+    @Id
+    @Column(name = "user_id")
+    val id: Long,
+
+    @Column(name = "distinguished_name")
+    val username: String
+)
+
+interface UserRepository : JpaRepository<User, Long> {
+    fun findUserById(userId: Long): User?
+}
+


### PR DESCRIPTION
Ive had to add a /user/details/{userId} endpoint as user/{username} already in use. Also can't easily add query param as /user/?email already in use which (apart from being messy to introduce a userId query param) currently returns a list. We want a 404 or single user object