### PR TITLE
PI-1826 Return most recent release date

### DIFF
--- a/projects/make-recall-decisions-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/casesummary/Release.kt
+++ b/projects/make-recall-decisions-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/casesummary/Release.kt
@@ -1,12 +1,6 @@
 package uk.gov.justice.digital.hmpps.integrations.delius.casesummary
 
-import jakarta.persistence.Column
-import jakarta.persistence.Entity
-import jakarta.persistence.Id
-import jakarta.persistence.JoinColumn
-import jakarta.persistence.ManyToOne
-import jakarta.persistence.OneToOne
-import jakarta.persistence.Table
+import jakarta.persistence.*
 import org.hibernate.annotations.Immutable
 import org.hibernate.annotations.SQLRestriction
 import org.springframework.data.jpa.repository.EntityGraph
@@ -76,5 +70,5 @@ class Institution(
 
 interface CaseSummaryReleaseRepository : JpaRepository<Release, Long> {
     @EntityGraph(attributePaths = ["recall", "institution"])
-    fun findFirstByCustodyIdOrderByDateDesc(custodyId: Long): Release?
+    fun findFirstByCustodyIdInOrderByDateDesc(custodyIds: List<Long>): Release?
 }

--- a/projects/make-recall-decisions-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/CaseSummaryService.kt
+++ b/projects/make-recall-decisions-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/CaseSummaryService.kt
@@ -1,39 +1,9 @@
 package uk.gov.justice.digital.hmpps.service
 
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.api.model.ContactHistory
-import uk.gov.justice.digital.hmpps.api.model.LicenceConditions
-import uk.gov.justice.digital.hmpps.api.model.MappaAndRoshHistory
-import uk.gov.justice.digital.hmpps.api.model.Overview
-import uk.gov.justice.digital.hmpps.api.model.PersonalDetails
-import uk.gov.justice.digital.hmpps.api.model.PersonalDetailsOverview
-import uk.gov.justice.digital.hmpps.api.model.RecommendationModel
+import uk.gov.justice.digital.hmpps.api.model.*
 import uk.gov.justice.digital.hmpps.api.model.RecommendationModel.Institution
-import uk.gov.justice.digital.hmpps.api.model.dates
-import uk.gov.justice.digital.hmpps.api.model.identifiers
-import uk.gov.justice.digital.hmpps.api.model.name
-import uk.gov.justice.digital.hmpps.api.model.toAddress
-import uk.gov.justice.digital.hmpps.api.model.toContact
-import uk.gov.justice.digital.hmpps.api.model.toConviction
-import uk.gov.justice.digital.hmpps.api.model.toConvictionDetails
-import uk.gov.justice.digital.hmpps.api.model.toConvictionWithLicenceConditions
-import uk.gov.justice.digital.hmpps.api.model.toManager
-import uk.gov.justice.digital.hmpps.api.model.toMappa
-import uk.gov.justice.digital.hmpps.api.model.toRosh
-import uk.gov.justice.digital.hmpps.integrations.delius.casesummary.CaseSummaryAddressRepository
-import uk.gov.justice.digital.hmpps.integrations.delius.casesummary.CaseSummaryContactRepository
-import uk.gov.justice.digital.hmpps.integrations.delius.casesummary.CaseSummaryEventRepository
-import uk.gov.justice.digital.hmpps.integrations.delius.casesummary.CaseSummaryPersonManagerRepository
-import uk.gov.justice.digital.hmpps.integrations.delius.casesummary.CaseSummaryPersonRepository
-import uk.gov.justice.digital.hmpps.integrations.delius.casesummary.CaseSummaryRegistrationRepository
-import uk.gov.justice.digital.hmpps.integrations.delius.casesummary.CaseSummaryReleaseRepository
-import uk.gov.justice.digital.hmpps.integrations.delius.casesummary.Event
-import uk.gov.justice.digital.hmpps.integrations.delius.casesummary.Person
-import uk.gov.justice.digital.hmpps.integrations.delius.casesummary.findMainAddress
-import uk.gov.justice.digital.hmpps.integrations.delius.casesummary.findMappa
-import uk.gov.justice.digital.hmpps.integrations.delius.casesummary.findRoshHistory
-import uk.gov.justice.digital.hmpps.integrations.delius.casesummary.getPerson
-import uk.gov.justice.digital.hmpps.integrations.delius.casesummary.searchContacts
+import uk.gov.justice.digital.hmpps.integrations.delius.casesummary.*
 import java.time.LocalDate
 
 @Service
@@ -143,8 +113,8 @@ class CaseSummaryService(
         )
     }
 
-    private fun List<Event>.lastRelease() = map { it.disposal?.custody }.singleOrNull()
-        ?.let { releaseRepository.findFirstByCustodyIdOrderByDateDesc(it.id) }
+    private fun List<Event>.lastRelease() = mapNotNull { it.disposal?.custody?.id }
+        .let { releaseRepository.findFirstByCustodyIdInOrderByDateDesc(it) }
 
     private fun List<Event>.custodial() = filter { it.disposal?.custody != null }
 }


### PR DESCRIPTION
The overview endpoint previously returned null if there were multiple active events.  This change looks at all active custodial events and returns the most recent release/recall dates.