### PR TITLE
PI-1828 add event not found to AP reporting

### DIFF
--- a/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/approvedpremises/referral/entity/Referral.kt
+++ b/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/approvedpremises/referral/entity/Referral.kt
@@ -12,6 +12,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
+import uk.gov.justice.digital.hmpps.exception.IgnorableMessageException
 import uk.gov.justice.digital.hmpps.exception.NotFoundException
 import java.time.LocalDate
 import java.time.ZonedDateTime
@@ -202,5 +203,5 @@ interface EventRepository : JpaRepository<Event, Long> {
     fun findForUpdate(id: Long): Long
 }
 
-fun EventRepository.getByEventNumber(personId: Long, number: String) =
-    findByPersonIdAndNumber(personId, number) ?: throw NotFoundException("Event Not Found")
+fun EventRepository.getByEventNumber(personId: Long, number: String) = findByPersonIdAndNumber(personId, number)
+    ?: throw IgnorableMessageException("Event Not Found", mapOf("eventNumber" to number))


### PR DESCRIPTION
EventRepository.getByEventNumber is only used in message handling.
We get a few errors when the event has been terminated before we get withdrawal events for example - meaning we don't create the contact. It's probably ok we don't create the contact since the event has been terminated, but we don't want to error - so adding this to the reporting events in app insights.