### PR TITLE
PI-1851 Fix test result XML files being merged

### DIFF
--- a/.github/actions/analyse/action.yml
+++ b/.github/actions/analyse/action.yml
@@ -16,7 +16,11 @@ runs:
     - uses: actions/download-artifact@v4
       with:
         pattern: test-results-*
-        merge-multiple: true
+        path: test-results
+
+    - name: Unpack test results
+      run: for dir in test-results/*; do cp -R "$dir"/* .; done
+      shell: bash
 
     - name: Publish test reports
       uses: mikepenz/action-junit-report@5f47764eec0e1c1f19f40c8e60a5ba47e47015c5 # v4.1.0


### PR DESCRIPTION
When we have multiple test results for the same project (e.g. for the libs), it previously attempted to merge the XML files which resulted in parse errors later on. This ensures files are overwritten instead of merged.