### PR TITLE
PI-1939 - use alfresco id in response object instead of document id. …

### DIFF
--- a/projects/manage-supervision-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/SentenceIntegrationTest.kt
+++ b/projects/manage-supervision-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/SentenceIntegrationTest.kt
@@ -71,8 +71,8 @@ class SentenceIntegrationTest {
                     Order("Default Sentence Type", 12, null, LocalDate.now().minusDays(14)),
                     listOf(Requirement("Main", "High Intensity", 12, "my notes", Rar(1, 0, 1))),
                     listOf(
-                        CourtDocument(COURT_DOCUMENT.id, LocalDate.now().minusDays(1), "court report"),
-                        CourtDocument(EVENT_DOCUMENT.id, LocalDate.now().minusDays(3), "event report")
+                        CourtDocument(COURT_DOCUMENT.alfrescoId, LocalDate.now().minusDays(1), "court report"),
+                        CourtDocument(EVENT_DOCUMENT.alfrescoId, LocalDate.now().minusDays(3), "event report")
                     )
                 ),
                 Sentence(

--- a/projects/manage-supervision-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/api/model/sentence/CourtDocument.kt
+++ b/projects/manage-supervision-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/api/model/sentence/CourtDocument.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.api.model.sentence
 import java.time.LocalDate
 
 data class CourtDocument(
-    val id: Long,
+    val id: String,
     val lastSaved: LocalDate?,
     val documentName: String?
 )

--- a/projects/manage-supervision-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/personalDetails/entity/Document.kt
+++ b/projects/manage-supervision-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/personalDetails/entity/Document.kt
@@ -71,7 +71,7 @@ class EventDocument : Document()
 class CourtReportDocument : Document()
 
 interface CourtDocumentDetails {
-    val id: Long
+    val id: String
     val lastSaved: LocalDate
     val documentName: String
 }
@@ -85,7 +85,7 @@ interface DocumentRepository : JpaRepository<PersonDocument, Long> {
     @Query(
         """
             SELECT id, lastSaved, documentName FROM (
-                SELECT d.DOCUMENT_ID AS id, d.LAST_SAVED AS lastSaved, d.DOCUMENT_NAME AS documentName
+                SELECT d.ALFRESCO_DOCUMENT_ID AS id, d.LAST_SAVED AS lastSaved, d.DOCUMENT_NAME AS documentName
                 FROM DOCUMENT d 
                 JOIN EVENT e 
                 ON e.EVENT_ID = d.PRIMARY_KEY_ID 
@@ -93,7 +93,7 @@ interface DocumentRepository : JpaRepository<PersonDocument, Long> {
                 AND e.EVENT_NUMBER = :eventNumber
                 AND TABLE_NAME = 'EVENT'
                 UNION 
-                SELECT d.DOCUMENT_ID AS id, d.LAST_SAVED AS lastSaved, d.DOCUMENT_NAME AS documentName
+                SELECT d.ALFRESCO_DOCUMENT_ID AS id, d.LAST_SAVED AS lastSaved, d.DOCUMENT_NAME AS documentName
                 FROM DOCUMENT d 
                 JOIN COURT_REPORT cr 
                 ON cr.COURT_REPORT_ID = d.PRIMARY_KEY_ID 

--- a/projects/manage-supervision-and-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/service/SentenceServiceTest.kt
+++ b/projects/manage-supervision-and-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/service/SentenceServiceTest.kt
@@ -96,7 +96,7 @@ class SentenceServiceTest {
 
         val requirement = RequirementDetails(1, "Main", "High Intensity", 12, "new requirement")
 
-        val courtDocumentDetails = CourtDocs(1, LocalDate.now(), "Pre Sentence Event")
+        val courtDocumentDetails = CourtDocs("A001", LocalDate.now(), "Pre Sentence Event")
 
         val completedRarDays = OverviewServiceTest.RarDays(1, "COMPLETED")
 
@@ -162,7 +162,7 @@ class SentenceServiceTest {
                             Rar(completedRarDays._days, scheduledRarDays._days, 3)
                         )
                     ),
-                    listOf(CourtDocument(1, LocalDate.now(), "Pre Sentence Event"))
+                    listOf(CourtDocument("A001", LocalDate.now(), "Pre Sentence Event"))
                 )
             ),
             ProbationHistory(0, null, 0, 0)
@@ -204,12 +204,12 @@ class SentenceServiceTest {
     }
 
     data class CourtDocs(
-        val _id: Long,
+        val _id: String,
         val _lastSaved: LocalDate,
         val _documentName: String
     ) : CourtDocumentDetails {
 
-        override val id: Long
+        override val id: String
             get() = _id
 
         override val lastSaved: LocalDate


### PR DESCRIPTION
… this will allow use of existing download api.