### PR TITLE
PI-2051 Enable prison-identifier-and-delius matching in prod

### DIFF
--- a/projects/prison-identifier-and-delius/deploy/values-dev.yml
+++ b/projects/prison-identifier-and-delius/deploy/values-dev.yml
@@ -14,8 +14,6 @@ generic-service:
     INTEGRATIONS_PRISONER-SEARCH_URL: https://prisoner-search-dev.prison.service.justice.gov.uk
     INTEGRATIONS_PROBATION-SEARCH_URL: https://probation-offender-search-dev.hmpps.service.justice.gov.uk
 
-    MESSAGING_CONSUMER_DRY-RUN: false
-
     SPRING_DATASOURCE_HIKARI_MAXIMUMPOOLSIZE: 5
     SPRING_DATASOURCE_HIKARI_MINIMUMIDLE: 0
 

--- a/projects/prison-identifier-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/MergeIntegrationTest.kt
+++ b/projects/prison-identifier-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/MergeIntegrationTest.kt
@@ -9,14 +9,12 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.test.context.TestPropertySource
 import uk.gov.justice.digital.hmpps.data.generator.PersonGenerator.PERSON_WITH_NOMS
 import uk.gov.justice.digital.hmpps.messaging.HmppsChannelManager
 import uk.gov.justice.digital.hmpps.telemetry.TelemetryService
 
 @AutoConfigureMockMvc
 @SpringBootTest(webEnvironment = RANDOM_PORT)
-@TestPropertySource(properties = ["messaging.consumer.dry-run=false"])
 internal class MergeIntegrationTest {
     @Value("\${messaging.consumer.queue}")
     lateinit var queueName: String

--- a/projects/prison-identifier-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/ProbationMatchingIntegrationTest.kt
+++ b/projects/prison-identifier-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/ProbationMatchingIntegrationTest.kt
@@ -14,6 +14,7 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDO
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.boot.test.mock.mockito.SpyBean
 import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.TestPropertySource
 import uk.gov.justice.digital.hmpps.entity.AdditionalIdentifierRepository
 import uk.gov.justice.digital.hmpps.entity.CustodyRepository
 import uk.gov.justice.digital.hmpps.entity.PersonRepository
@@ -22,6 +23,7 @@ import uk.gov.justice.digital.hmpps.telemetry.TelemetryService
 
 @AutoConfigureMockMvc
 @SpringBootTest(webEnvironment = RANDOM_PORT)
+@TestPropertySource(properties = ["messaging.consumer.dry-run=true"])
 internal class ProbationMatchingIntegrationTest {
 
     @Value("\${messaging.consumer.queue}")

--- a/projects/prison-identifier-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/Handler.kt
+++ b/projects/prison-identifier-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/Handler.kt
@@ -17,7 +17,7 @@ class Handler(
     private val telemetryService: TelemetryService,
     private val probationMatchingService: ProbationMatchingService,
     private val prisonMatchingService: PrisonMatchingService,
-    @Value("\${messaging.consumer.dry-run:true}") private val messagingDryRun: Boolean
+    @Value("\${messaging.consumer.dry-run:false}") private val messagingDryRun: Boolean
 ) : NotificationHandler<Any> {
     override fun handle(notification: Notification<Any>) {
         telemetryService.notificationReceived(notification)


### PR DESCRIPTION
Disables the dry-run flag for event-driven matching in dev, preprod and prod.

Note: dry-run is still enabled for bulk matching.