### PR TITLE
PI-2252 Add global admin role for all API endpoints

### DIFF
--- a/libs/commons/src/main/kotlin/uk/gov/justice/digital/hmpps/config/security/SecurityConfig.kt
+++ b/libs/commons/src/main/kotlin/uk/gov/justice/digital/hmpps/config/security/SecurityConfig.kt
@@ -2,8 +2,13 @@ package uk.gov.justice.digital.hmpps.config.security
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.security.ConditionalOnDefaultWebSecurity
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl.withDefaultRolePrefix
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
@@ -15,8 +20,9 @@ fun interface SecurityConfigurer {
 
 @Configuration
 @EnableWebSecurity
-@EnableMethodSecurity(prePostEnabled = true)
+@EnableMethodSecurity
 @ConditionalOnDefaultWebSecurity
+@EnableConfigurationProperties(SecurityConfig.OAuth2Properties::class)
 class SecurityConfig(private val configurers: List<SecurityConfigurer>) {
 
     @Bean
@@ -24,5 +30,19 @@ class SecurityConfig(private val configurers: List<SecurityConfigurer>) {
     fun configure(http: HttpSecurity): SecurityFilterChain {
         configurers.forEach { it.configure(http) }
         return http.build()
+    }
+
+    @Bean
+    fun roleHierarchy(oauth2: OAuth2Properties): RoleHierarchy = withDefaultRolePrefix().also {
+        if (oauth2.roles.isNotEmpty()) it.role("PROBATION_INTEGRATION_ADMIN").implies(*oauth2.roles.toTypedArray())
+    }.build()
+
+    @Bean
+    fun methodSecurityExpressionHandler(roleHierarchy: RoleHierarchy) =
+        DefaultMethodSecurityExpressionHandler().also { it.setRoleHierarchy(roleHierarchy) }
+
+    @ConfigurationProperties(prefix = "oauth2")
+    class OAuth2Properties {
+        var roles: List<String> = emptyList()
     }
 }

--- a/libs/dev-tools/src/main/kotlin/uk/gov/justice/digital/hmpps/security/TokenHelper.kt
+++ b/libs/dev-tools/src/main/kotlin/uk/gov/justice/digital/hmpps/security/TokenHelper.kt
@@ -1,7 +1,5 @@
 package uk.gov.justice.digital.hmpps.security
 
-import org.springframework.boot.context.properties.ConfigurationProperties
-import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
@@ -11,25 +9,19 @@ import java.time.Duration
 import java.time.Instant
 
 @Configuration
-@EnableConfigurationProperties(TokenHelper.JwtProperties::class)
 class TokenHelper {
     companion object {
         const val TOKEN = "token"
     }
 
-    @ConfigurationProperties(prefix = "jwt")
-    class JwtProperties {
-        var authorities: List<String> = emptyList()
-    }
-
     @Bean
-    fun jwt(jwtProperties: JwtProperties): Jwt = Jwt
+    fun jwt(): Jwt = Jwt
         .withTokenValue(TOKEN)
         .issuedAt(Instant.now())
         .expiresAt(Instant.now().plus(Duration.ofDays(1)))
         .header("alg", "none")
         .claim("sub", "probation-integration-dev")
-        .claim("authorities", jwtProperties.authorities)
+        .claim("authorities", listOf("ROLE_PROBATION_INTEGRATION_ADMIN"))
         .build()
 
     @Bean

--- a/projects/accredited-programmes-and-oasys/src/main/resources/application.yml
+++ b/projects/accredited-programmes-and-oasys/src/main/resources/application.yml
@@ -17,6 +17,11 @@ spring:
         token-uri: ${integrations.ords.url}/oauth/token
   threads.virtual.enabled: true
 
+oauth2.roles:
+  - PROBATION_API__ACCREDITED_PROGRAMMES__ASSESSMENT
+
+springdoc.default-produces-media-type: application/json
+
 management:
   endpoints.web:
     base-path: /
@@ -31,9 +36,6 @@ spring.config.activate.on-profile: [ "dev", "integration-test" ]
 server.shutdown: immediate
 
 context.initializer.classes: uk.gov.justice.digital.hmpps.wiremock.WireMockInitialiser
-
-jwt.authorities:
-  - ROLE_PROBATION_API__ACCREDITED_PROGRAMMES__ASSESSMENT
 
 integrations:
   ords:

--- a/projects/approved-premises-and-delius/src/main/resources/application.yml
+++ b/projects/approved-premises-and-delius/src/main/resources/application.yml
@@ -28,6 +28,9 @@ spring:
         token-uri: http://localhost:${wiremock.port}/auth/oauth/token
   threads.virtual.enabled: true
 
+oauth2.roles:
+  - PROBATION_API__APPROVED_PREMISES__CASE_DETAIL
+
 springdoc.default-produces-media-type: application/json
 
 delius.db.username: ApprovedPremisesAndDelius # Should match value in [deploy/database/access.yml].
@@ -55,9 +58,6 @@ spring:
 seed.database: true
 wiremock.enabled: true
 context.initializer.classes: uk.gov.justice.digital.hmpps.wiremock.WireMockInitialiser
-
-jwt.authorities:
-  - ROLE_PROBATION_API__APPROVED_PREMISES__CASE_DETAIL
 
 messaging.consumer.queue: message-queue
 

--- a/projects/approved-premises-and-oasys/src/main/resources/application.yml
+++ b/projects/approved-premises-and-oasys/src/main/resources/application.yml
@@ -17,6 +17,9 @@ spring:
         token-uri: http://localhost:${wiremock.port}/eor/oasys/oauth/token
   threads.virtual.enabled: true
 
+oauth2.roles:
+  - PROBATION_API__APPROVED_PREMISES__ASSESSMENTS
+
 springdoc.default-produces-media-type: application/json
 
 management:
@@ -35,8 +38,6 @@ server.shutdown: immediate
 
 wiremock.enabled: true
 context.initializer.classes: uk.gov.justice.digital.hmpps.wiremock.WireMockInitialiser
-jwt.authorities:
-  - ROLE_PROBATION_API__APPROVED_PREMISES__ASSESSMENTS
 
 ords:
   client-id: approved-premises-and-oasys

--- a/projects/arns-and-delius/src/main/resources/application.yml
+++ b/projects/arns-and-delius/src/main/resources/application.yml
@@ -17,6 +17,10 @@ spring:
             create_tables: false
             drop_tables: false
   threads.virtual.enabled: true
+
+oauth2.roles:
+  - PROBATION_API__ARNS__USER_ACCESS
+
 springdoc.default-produces-media-type: application/json
 
 delius.db.username: ArnsAndDelius # Should match value in [deploy/database/access.yml].
@@ -41,8 +45,6 @@ spring:
 seed.database: true
 wiremock.enabled: true
 context.initializer.classes: uk.gov.justice.digital.hmpps.wiremock.WireMockInitialiser
-jwt.authorities:
-  - ROLE_PROBATION_API__ARNS__USER_ACCESS
 
 logging.level:
   uk.gov.justice.digital.hmpps: DEBUG

--- a/projects/cas3-and-delius/src/main/resources/application.yml
+++ b/projects/cas3-and-delius/src/main/resources/application.yml
@@ -28,8 +28,6 @@ spring:
         token-uri: http://localhost:${wiremock.port}/auth/oauth/token
   threads.virtual.enabled: true
 
-springdoc.default-produces-media-type: application/json
-
 delius.db.username: Cas3AndDelius # Should match value in [deploy/database/access.yml].
 
 management:

--- a/projects/core-person-record-and-delius/src/main/resources/application.yml
+++ b/projects/core-person-record-and-delius/src/main/resources/application.yml
@@ -18,6 +18,9 @@ spring:
             drop_tables: false
   threads.virtual.enabled: true
 
+oauth2.roles:
+  - PROBATION_API__CORE_PERSON__CASE_DETAIL
+
 springdoc.default-produces-media-type: application/json
 
 delius.db.username: CorePersonRecordAndDelius # Should match value in [deploy/database/access.yml].
@@ -40,9 +43,6 @@ spring:
   jpa.hibernate.ddl-auto: create-drop
 
 seed.database: true
-
-jwt.authorities:
-  - ROLE_PROBATION_API__CORE_PERSON__CASE_DETAIL
 
 logging.level:
   uk.gov.justice.digital.hmpps: DEBUG

--- a/projects/court-case-and-delius/src/main/resources/application.yml
+++ b/projects/court-case-and-delius/src/main/resources/application.yml
@@ -28,6 +28,9 @@ spring:
         token-uri: http://localhost:${wiremock.port}/auth/oauth/token
   threads.virtual.enabled: true
 
+oauth2.roles:
+  - PROBATION_API__COURT_CASE__CASE_DETAIL
+
 springdoc.default-produces-media-type: application/json
 
 delius.db.username: CourtCaseAndDelius # Should match value in [deploy/database/access.yml].
@@ -52,9 +55,6 @@ spring:
 seed.database: true
 wiremock.enabled: true
 context.initializer.classes: uk.gov.justice.digital.hmpps.wiremock.WireMockInitialiser
-
-jwt.authorities:
-  - ROLE_PROBATION_API__COURT_CASE__CASE_DETAIL
 
 messaging.consumer.queue: events
 

--- a/projects/create-and-vary-a-licence-and-delius/src/main/resources/application.yml
+++ b/projects/create-and-vary-a-licence-and-delius/src/main/resources/application.yml
@@ -32,6 +32,10 @@ spring:
         token-uri: http://localhost:${wiremock.port}/auth/oauth/token
   threads.virtual.enabled: true
 
+oauth2.roles:
+  - PROBATION_API__CVL__USER_ROLES__RW
+  - PROBATION_API__CVL__CASE_DETAIL
+
 springdoc.default-produces-media-type: application/json
 
 delius.db.username: CreateAndVaryALicenceAndDelius # Should match value in [deploy/database/access.yml].
@@ -58,10 +62,6 @@ spring:
 
 seed.database: true
 context.initializer.classes: uk.gov.justice.digital.hmpps.wiremock.WireMockInitialiser
-
-jwt.authorities:
-  - ROLE_PROBATION_API__CVL__USER_ROLES__RW
-  - ROLE_PROBATION_API__CVL__CASE_DETAIL
 
 oauth2:
   client-id: create-and-vary-a-licence-and-delius

--- a/projects/custody-key-dates-and-delius/src/main/resources/application.yml
+++ b/projects/custody-key-dates-and-delius/src/main/resources/application.yml
@@ -28,6 +28,11 @@ spring:
         token-uri: http://localhost:${wiremock.port}/auth/oauth/token
   threads.virtual.enabled: true
 
+oauth2.roles:
+  - PROBATION_API__CUSTODY_DATES__RW
+
+springdoc.default-produces-media-type: application/json
+
 delius.db.username: CustodyKeyDatesAndDelius # Should match value in [deploy/database/access.yml].
 
 management:
@@ -51,9 +56,6 @@ spring:
 seed.database: true
 wiremock.enabled: true
 context.initializer.classes: uk.gov.justice.digital.hmpps.wiremock.WireMockInitialiser
-
-jwt.authorities:
-  - ROLE_PROBATION_API__CUSTODY_DATES__RW
 
 messaging.consumer.queue: message-queue
 

--- a/projects/domain-events-and-delius/src/main/resources/application.yml
+++ b/projects/domain-events-and-delius/src/main/resources/application.yml
@@ -18,8 +18,10 @@ spring:
             drop_tables: false
   threads.virtual.enabled: true
 
-springdoc.default-produces-media-type: application/json
+oauth2.roles:
+  - PROBATION_API__DOMAIN_EVENTS__ENGAGEMENT
 
+springdoc.default-produces-media-type: application/json
 
 delius.db.username: DomainEventsAndDelius # Should match value in [deploy/database/access.yml].
 
@@ -42,9 +44,6 @@ spring:
   jpa.hibernate.ddl-auto: create-drop
 
 seed.database: true
-
-jwt.authorities:
-  - ROLE_PROBATION_API__DOMAIN_EVENTS__ENGAGEMENT
 
 poller.fixed-delay: 2000
 

--- a/projects/dps-and-delius/src/main/resources/application.yml
+++ b/projects/dps-and-delius/src/main/resources/application.yml
@@ -19,6 +19,9 @@ spring:
     open-in-view: false # this prevents aborted streaming requests from leaving a DB connection in-use
   threads.virtual.enabled: true
 
+oauth2.roles:
+  - PROBATION_API__DPS__DOCUMENTS
+
 springdoc.default-produces-media-type: application/json
 
 delius.db.username: DpsAndDelius # Should match value in [deploy/database/access.yml].
@@ -45,9 +48,6 @@ spring:
 seed.database: true
 wiremock.enabled: true
 context.initializer.classes: uk.gov.justice.digital.hmpps.wiremock.WireMockInitialiser
-
-jwt.authorities:
-  - ROLE_PROBATION_API__DPS__DOCUMENTS
 
 logging.level:
   uk.gov.justice.digital.hmpps: DEBUG

--- a/projects/effective-proposal-framework-and-delius/src/main/resources/application.yml
+++ b/projects/effective-proposal-framework-and-delius/src/main/resources/application.yml
@@ -18,6 +18,9 @@ spring:
             drop_tables: false
   threads.virtual.enabled: true
 
+oauth2.roles:
+  - PROBATION_API__EPF__CASE_DETAIL
+
 springdoc.default-produces-media-type: application/json
 
 delius.db.username: EffectiveProposalFrameworkAndDelius # Should match value in [deploy/database/access.yml].
@@ -42,9 +45,6 @@ spring:
 seed.database: true
 wiremock.enabled: true
 context.initializer.classes: uk.gov.justice.digital.hmpps.wiremock.WireMockInitialiser
-
-jwt.authorities:
-  - ROLE_PROBATION_API__EPF__CASE_DETAIL
 
 logging.level:
   uk.gov.justice.digital.hmpps: DEBUG

--- a/projects/external-api-and-delius/src/main/resources/application.yml
+++ b/projects/external-api-and-delius/src/main/resources/application.yml
@@ -22,6 +22,9 @@ spring:
     base-environment:
       java.naming.ldap.derefAliases: never
 
+oauth2.roles:
+  - PROBATION_API__HMPPS_API__CASE_DETAIL
+
 springdoc.default-produces-media-type: application/json
 
 delius.db.username: ExternalApiAndDelius # Should match value in [deploy/database/access.yml].
@@ -47,9 +50,6 @@ spring:
 seed.database: true
 wiremock.enabled: true
 context.initializer.classes: uk.gov.justice.digital.hmpps.wiremock.WireMockInitialiser
-
-jwt.authorities:
-  - ROLE_PROBATION_API__HMPPS_API__CASE_DETAIL
 
 logging.level:
   uk.gov.justice.digital.hmpps: DEBUG

--- a/projects/hdc-licences-and-delius/src/main/resources/application.yml
+++ b/projects/hdc-licences-and-delius/src/main/resources/application.yml
@@ -22,6 +22,10 @@ spring:
       java.naming.ldap.derefAliases: never
   threads.virtual.enabled: true
 
+oauth2.roles:
+  - PROBATION_API__HDC__STAFF
+  - PROBATION_API__HDC__USER_ROLES__RW
+
 springdoc.default-produces-media-type: application/json
 
 delius.db.username: HdcLicencesAndDelius # Should match value in [deploy/database/access.yml].
@@ -49,10 +53,6 @@ spring:
 seed.database: true
 wiremock.enabled: true
 context.initializer.classes: uk.gov.justice.digital.hmpps.wiremock.WireMockInitialiser
-
-jwt.authorities:
-  - ROLE_PROBATION_API__HDC__STAFF
-  - ROLE_PROBATION_API__HDC__USER_ROLES__RW
 
 logging.level:
   uk.gov.justice.digital.hmpps: DEBUG

--- a/projects/hmpps-auth-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/controller/AuthenticationController.kt
+++ b/projects/hmpps-auth-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/controller/AuthenticationController.kt
@@ -43,7 +43,7 @@ class AuthenticationController(private val ldapTemplate: LdapTemplate) {
             ),
             ApiResponse(
                 responseCode = "403",
-                description = "Client role required: `ROLE_DELIUS_USER_AUTH`",
+                description = "Client role required: `DELIUS_USER_AUTH`",
                 content = [Content(mediaType = "text/plain")]
             )
         ]

--- a/projects/hmpps-auth-and-delius/src/main/resources/application.yml
+++ b/projects/hmpps-auth-and-delius/src/main/resources/application.yml
@@ -22,6 +22,11 @@ spring:
       java.naming.ldap.derefAliases: never
   threads.virtual.enabled: true
 
+oauth2.roles:
+  - PROBATION_API__HMPPS_AUTH__AUTHENTICATE
+  - PROBATION_API__HMPPS_AUTH__PASSWORD__RW
+  - PROBATION_API__HMPPS_AUTH__USER_DETAILS
+
 springdoc.default-produces-media-type: application/json
 
 delius.db.username: HmppsAuthAndDelius # Should match value in [deploy/database/access.yml].
@@ -49,11 +54,6 @@ spring:
 seed.database: true
 wiremock.enabled: true
 context.initializer.classes: uk.gov.justice.digital.hmpps.wiremock.WireMockInitialiser
-
-jwt.authorities:
-  - ROLE_PROBATION_API__HMPPS_AUTH__AUTHENTICATE
-  - ROLE_PROBATION_API__HMPPS_AUTH__PASSWORD__RW
-  - ROLE_PROBATION_API__HMPPS_AUTH__USER_DETAILS
 
 logging.level:
   uk.gov.justice.digital.hmpps: DEBUG

--- a/projects/make-recall-decisions-and-delius/src/main/resources/application.yml
+++ b/projects/make-recall-decisions-and-delius/src/main/resources/application.yml
@@ -32,6 +32,9 @@ spring:
         token-uri: http://localhost:${wiremock.port}/auth/oauth/token
   threads.virtual.enabled: true
 
+oauth2.roles:
+  - PROBATION_API__CONSIDER_A_RECALL__CASE_DETAIL
+
 springdoc.default-produces-media-type: application/json
 
 delius.db.username: MakeRecallDecisionsAndDelius # Should match value in [deploy/database/access.yml].
@@ -61,9 +64,6 @@ spring:
 seed.database: true
 wiremock.enabled: true
 context.initializer.classes: uk.gov.justice.digital.hmpps.wiremock.WireMockInitialiser
-
-jwt.authorities:
-  - ROLE_PROBATION_API__CONSIDER_A_RECALL__CASE_DETAIL
 
 messaging.consumer.queue: message-queue
 

--- a/projects/manage-pom-cases-and-delius/src/main/resources/application.yml
+++ b/projects/manage-pom-cases-and-delius/src/main/resources/application.yml
@@ -32,6 +32,9 @@ spring:
         token-uri: http://localhost:${wiremock.port}/auth/oauth/token
   threads.virtual.enabled: true
 
+oauth2.roles:
+  - PROBATION_API__MANAGE_POM_CASES__CASE_DETAIL
+
 springdoc.default-produces-media-type: application/json
 
 delius.db.username: ManagePomCasesAndDelius # Should match value in [deploy/database/access.yml].
@@ -57,9 +60,6 @@ spring:
 seed.database: true
 wiremock.enabled: true
 context.initializer.classes: uk.gov.justice.digital.hmpps.wiremock.WireMockInitialiser
-
-jwt.authorities:
-  - ROLE_PROBATION_API__MANAGE_POM_CASES__CASE_DETAIL
 
 messaging.consumer.queue: message-queue
 

--- a/projects/manage-supervision-and-delius/src/main/resources/application.yml
+++ b/projects/manage-supervision-and-delius/src/main/resources/application.yml
@@ -22,6 +22,9 @@ spring:
     base-environment:
       java.naming.ldap.derefAliases: never
 
+oauth2.roles:
+  - PROBATION_API__MANAGE_A_SUPERVISION__CASE_DETAIL
+
 springdoc.default-produces-media-type: application/json
 
 delius.db.username: ManageSupervisionAndDelius # Should match value in [deploy/database/access.yml].
@@ -50,9 +53,6 @@ seed.database: true
 
 wiremock.enabled: true
 context.initializer.classes: uk.gov.justice.digital.hmpps.wiremock.WireMockInitialiser
-
-jwt.authorities:
-  - ROLE_PROBATION_API__MANAGE_A_SUPERVISION__CASE_DETAIL
 
 logging.level:
   uk.gov.justice.digital.hmpps: DEBUG

--- a/projects/manage-supervision-and-oasys/src/main/kotlin/uk/gov/justice/digital/hmpps/controller/ApiController.kt
+++ b/projects/manage-supervision-and-oasys/src/main/kotlin/uk/gov/justice/digital/hmpps/controller/ApiController.kt
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 class ApiController {
-    @PreAuthorize("hasRole('ROLE_EXAMPLE')")
+    @PreAuthorize("hasRole('EXAMPLE')")
     @GetMapping(value = ["/example/{inputId}"])
     fun handle(
         @PathVariable("inputId") inputId: String

--- a/projects/manage-supervision-and-oasys/src/main/resources/application.yml
+++ b/projects/manage-supervision-and-oasys/src/main/resources/application.yml
@@ -15,6 +15,9 @@ spring:
         token-uri: ${integrations.ords.url}/oauth/token
   threads.virtual.enabled: true
 
+oauth2.roles:
+  - EXAMPLE
+
 springdoc.default-produces-media-type: application/json
 
 management:
@@ -32,9 +35,6 @@ spring.config.activate.on-profile: [ "dev", "integration-test" ]
 server.shutdown: immediate
 
 context.initializer.classes: uk.gov.justice.digital.hmpps.wiremock.WireMockInitialiser
-
-jwt.authorities:
-  - ROLE_EXAMPLE
 
 integrations:
   ords:

--- a/projects/oasys-and-delius/src/main/resources/application.yml
+++ b/projects/oasys-and-delius/src/main/resources/application.yml
@@ -18,6 +18,9 @@ spring:
             drop_tables: false
   threads.virtual.enabled: true
 
+oauth2.roles:
+  - PROBATION_API__OASYS__CASE_DETAIL
+
 springdoc.default-produces-media-type: application/json
 
 delius.db.username: OasysAndDelius # Should match value in [deploy/database/access.yml].
@@ -41,9 +44,6 @@ spring:
 
 seed.database: true
 context.initializer.classes: uk.gov.justice.digital.hmpps.wiremock.WireMockInitialiser
-
-jwt.authorities:
-  - ROLE_PROBATION_API__OASYS__CASE_DETAIL
 
 logging.level:
   uk.gov.justice.digital.hmpps: DEBUG

--- a/projects/pathfinder-and-delius/src/main/resources/application.yml
+++ b/projects/pathfinder-and-delius/src/main/resources/application.yml
@@ -22,6 +22,10 @@ spring:
       java.naming.ldap.derefAliases: never
   threads.virtual.enabled: true
 
+oauth2.roles:
+  - PROBATION_API__PATHFINDER__CASE_DETAIL
+  - PROBATION_API__PATHFINDER__USER_ROLES__RW
+
 springdoc.default-produces-media-type: application/json
 
 delius.db.username: PathfinderAndDelius # Should match value in [deploy/database/access.yml].
@@ -49,10 +53,6 @@ spring:
 seed.database: true
 wiremock.enabled: true
 context.initializer.classes: uk.gov.justice.digital.hmpps.wiremock.WireMockInitialiser
-
-jwt.authorities:
-  - ROLE_PROBATION_API__PATHFINDER__CASE_DETAIL
-  - ROLE_PROBATION_API__PATHFINDER__USER_ROLES__RW
 
 logging.level:
   uk.gov.justice.digital.hmpps: DEBUG

--- a/projects/pre-sentence-reports-to-delius/src/main/resources/application.yml
+++ b/projects/pre-sentence-reports-to-delius/src/main/resources/application.yml
@@ -29,6 +29,9 @@ spring:
           token-uri: http://localhost:${wiremock.port}/auth/oauth/token
   threads.virtual.enabled: true
 
+oauth2.roles:
+  - PROBATION_API__PSR__CONTEXT
+
 springdoc.default-produces-media-type: application/json
 
 delius.db.username: PreSentenceService
@@ -55,9 +58,6 @@ spring:
 seed.database: true
 wiremock.enabled: true
 context.initializer.classes: uk.gov.justice.digital.hmpps.wiremock.WireMockInitialiser
-
-jwt.authorities:
-  - ROLE_PROBATION_API__PSR__CONTEXT
 
 messaging.consumer.queue: pre-sentence-report-events
 

--- a/projects/prison-education-and-delius/src/main/resources/application.yml
+++ b/projects/prison-education-and-delius/src/main/resources/application.yml
@@ -22,6 +22,9 @@ spring:
       java.naming.ldap.derefAliases: never
   threads.virtual.enabled: true
 
+oauth2.roles:
+  - PROBATION_API__PRISON_EDUCATION__CASE_DETAIL
+
 springdoc.default-produces-media-type: application/json
 
 delius.db.username: PrisonEducationAndDelius # Should match value in [deploy/database/access.yml].
@@ -47,9 +50,6 @@ spring:
 seed.database: true
 wiremock.enabled: true
 context.initializer.classes: uk.gov.justice.digital.hmpps.wiremock.WireMockInitialiser
-
-jwt.authorities:
-  - ROLE_PROBATION_API__PRISON_EDUCATION__CASE_DETAIL
 
 logging.level:
   uk.gov.justice.digital.hmpps: DEBUG

--- a/projects/prison-identifier-and-delius/src/main/resources/application.yml
+++ b/projects/prison-identifier-and-delius/src/main/resources/application.yml
@@ -28,6 +28,9 @@ spring:
         token-uri: http://localhost:${wiremock.port}/auth/oauth/token
   threads.virtual.enabled: true
 
+oauth2.roles:
+  - PROBATION_API__PRISON_IDENTIFIER__UPDATE
+
 springdoc.default-produces-media-type: application/json
 
 delius.db.username: PrisonIdentifierAndDelius # Should match value in [deploy/database/access.yml].
@@ -57,9 +60,6 @@ messaging:
 
 seed.database: true
 context.initializer.classes: uk.gov.justice.digital.hmpps.wiremock.WireMockInitialiser
-
-jwt.authorities:
-  - ROLE_PROBATION_API__PRISON_IDENTIFIER__UPDATE
 
 integrations:
   prison-api.url: http://localhost:${wiremock.port}/prison-api

--- a/projects/prisoner-profile-and-delius/src/main/resources/application.yml
+++ b/projects/prisoner-profile-and-delius/src/main/resources/application.yml
@@ -22,6 +22,9 @@ spring:
       java.naming.ldap.derefAliases: never
   threads.virtual.enabled: true
 
+oauth2.roles:
+  - PROBATION_API__PRISONER_PROFILE__CASE_DETAIL
+
 springdoc.default-produces-media-type: application/json
 
 delius.db.username: PrisonerProfileAndDelius # Should match value in [deploy/database/access.yml].
@@ -48,9 +51,6 @@ spring:
 
 seed.database: true
 context.initializer.classes: uk.gov.justice.digital.hmpps.wiremock.WireMockInitialiser
-
-jwt.authorities:
-  - ROLE_PROBATION_API__PRISONER_PROFILE__CASE_DETAIL
 
 logging.level:
   uk.gov.justice.digital.hmpps: DEBUG

--- a/projects/probation-search-and-delius/src/main/resources/application.yml
+++ b/projects/probation-search-and-delius/src/main/resources/application.yml
@@ -18,6 +18,9 @@ spring:
             drop_tables: false
   threads.virtual.enabled: true
 
+oauth2.roles:
+  - PROBATION_API__PROBATION_SEARCH__AUDIT_RW
+
 springdoc.default-produces-media-type: application/json
 
 delius.db.username: ProbationSearchAndDelius # Should match value in [deploy/database/access.yml].
@@ -42,9 +45,6 @@ spring:
 seed.database: true
 wiremock.enabled: true
 context.initializer.classes: uk.gov.justice.digital.hmpps.wiremock.WireMockInitialiser
-
-jwt.authorities:
-  - ROLE_PROBATION_API__PROBATION_SEARCH__AUDIT_RW
 
 logging.level:
   uk.gov.justice.digital.hmpps: DEBUG

--- a/projects/refer-and-monitor-and-delius/src/main/resources/application.yml
+++ b/projects/refer-and-monitor-and-delius/src/main/resources/application.yml
@@ -32,6 +32,9 @@ spring:
         token-uri: http://localhost:${wiremock.port}/auth/oauth/token
   threads.virtual.enabled: true
 
+oauth2.roles:
+  - PROBATION_API__REFER_AND_MONITOR__CASE_DETAIL__RW
+
 springdoc.default-produces-media-type: application/json
 
 delius.db.username: ReferAndMonitorAndDelius # Should match value in [deploy/database/access.yml].
@@ -57,9 +60,6 @@ spring:
 
 seed.database: true
 context.initializer.classes: uk.gov.justice.digital.hmpps.wiremock.WireMockInitialiser
-
-jwt.authorities:
-  - ROLE_PROBATION_API__REFER_AND_MONITOR__CASE_DETAIL__RW
 
 messaging.consumer.queue: message-queue
 

--- a/projects/resettlement-passport-and-delius/src/main/resources/application.yml
+++ b/projects/resettlement-passport-and-delius/src/main/resources/application.yml
@@ -22,6 +22,10 @@ spring:
       java.naming.ldap.derefAliases: never
   threads.virtual.enabled: true
 
+oauth2.roles:
+  - PROBATION_API__RESETTLEMENT_PASSPORT__CASE_DETAIL
+  - PROBATION_API__RESETTLEMENT_PASSPORT__APPOINTMENT_RW
+
 springdoc.default-produces-media-type: application/json
 
 delius.db.username: ResettlementPassportAndDelius # Should match value in [deploy/database/access.yml].
@@ -47,10 +51,6 @@ spring:
 seed.database: true
 wiremock.enabled: true
 context.initializer.classes: uk.gov.justice.digital.hmpps.wiremock.WireMockInitialiser
-
-jwt.authorities:
-  - ROLE_PROBATION_API__RESETTLEMENT_PASSPORT__CASE_DETAIL
-  - ROLE_PROBATION_API__RESETTLEMENT_PASSPORT__APPOINTMENT_RW
 
 logging.level:
   uk.gov.justice.digital.hmpps: DEBUG

--- a/projects/sentence-plan-and-delius/src/main/resources/application.yml
+++ b/projects/sentence-plan-and-delius/src/main/resources/application.yml
@@ -18,6 +18,9 @@ spring:
             drop_tables: false
   threads.virtual.enabled: true
 
+oauth2.roles:
+  - PROBATION_API__SENTENCE_PLAN__CASE_DETAIL
+
 springdoc.default-produces-media-type: application/json
 
 delius.db.username: SentencePlanAndDelius # Should match value in [deploy/database/access.yml].
@@ -42,9 +45,6 @@ spring:
 seed.database: true
 wiremock.enabled: true
 context.initializer.classes: uk.gov.justice.digital.hmpps.wiremock.WireMockInitialiser
-
-jwt.authorities:
-  - ROLE_PROBATION_API__SENTENCE_PLAN__CASE_DETAIL
 
 logging.level:
   uk.gov.justice.digital.hmpps: DEBUG

--- a/projects/sentence-plan-and-oasys/src/main/resources/application.yml
+++ b/projects/sentence-plan-and-oasys/src/main/resources/application.yml
@@ -5,6 +5,9 @@ spring:
     default-property-inclusion: non_empty
   threads.virtual.enabled: true
 
+oauth2.roles:
+  - PROBATION_API__SENTENCE_PLAN__CASE_DETAIL
+
 springdoc.default-produces-media-type: application/json
 
 management:
@@ -23,9 +26,6 @@ server.shutdown: immediate
 
 wiremock.enabled: true
 context.initializer.classes: uk.gov.justice.digital.hmpps.wiremock.WireMockInitialiser
-
-jwt.authorities:
-  - ROLE_PROBATION_API__SENTENCE_PLAN__CASE_DETAIL
 
 ords:
   client-id: sentence-plan-and-oasys

--- a/projects/soc-and-delius/src/main/resources/application.yml
+++ b/projects/soc-and-delius/src/main/resources/application.yml
@@ -18,6 +18,9 @@ spring:
             drop_tables: false
   threads.virtual.enabled: true
 
+oauth2.roles:
+  - PROBATION_API__SOC__CASE_DETAIL
+
 springdoc.default-produces-media-type: application/json
 
 delius.db.username: SocAndDelius # Should match value in [deploy/database/access.yml].
@@ -42,9 +45,6 @@ spring:
 seed.database: true
 wiremock.enabled: true
 context.initializer.classes: uk.gov.justice.digital.hmpps.wiremock.WireMockInitialiser
-
-jwt.authorities:
-  - ROLE_PROBATION_API__SOC__CASE_DETAIL
 
 logging.level:
   uk.gov.justice.digital.hmpps: DEBUG

--- a/projects/tier-to-delius/src/main/resources/application.yml
+++ b/projects/tier-to-delius/src/main/resources/application.yml
@@ -28,6 +28,9 @@ spring:
         token-uri: http://localhost:${wiremock.port}/auth/oauth/token
   threads.virtual.enabled: true
 
+oauth2.roles:
+  - PROBATION_API__TIER__CASE_DETAIL
+
 springdoc.default-produces-media-type: application/json
 
 delius.db.username: TierToDelius # Should match value in [deploy/database/access.yml].
@@ -54,9 +57,6 @@ spring:
 seed.database: true
 wiremock.enabled: true
 context.initializer.classes: uk.gov.justice.digital.hmpps.wiremock.WireMockInitialiser
-
-jwt.authorities:
-  - ROLE_PROBATION_API__TIER__CASE_DETAIL
 
 messaging.consumer.queue: message-queue
 integrations.tier.url: http://localhost:${wiremock.port}/hmpps-tier

--- a/projects/unpaid-work-and-delius/src/main/resources/application.yml
+++ b/projects/unpaid-work-and-delius/src/main/resources/application.yml
@@ -28,6 +28,9 @@ spring:
         token-uri: http://localhost:${wiremock.port}/auth/oauth/token
   threads.virtual.enabled: true
 
+oauth2.roles:
+  - PROBATION_API__UPW__CASE_DETAIL
+
 springdoc.default-produces-media-type: application/json
 
 delius.db.username: UnpaidWorkAndDelius # Should match value in [deploy/database/access.yml].
@@ -53,9 +56,6 @@ spring:
 seed.database: true
 wiremock.enabled: true
 context.initializer.classes: uk.gov.justice.digital.hmpps.wiremock.WireMockInitialiser
-
-jwt.authorities:
-  - ROLE_PROBATION_API__UPW__CASE_DETAIL
 
 messaging.consumer.queue: message-queue
 

--- a/projects/workforce-allocations-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/api/resource/AllocationDemandResource.kt
+++ b/projects/workforce-allocations-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/api/resource/AllocationDemandResource.kt
@@ -4,13 +4,7 @@ import io.swagger.v3.oas.annotations.Operation
 import jakarta.validation.Valid
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.validation.annotation.Validated
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import uk.gov.justice.digital.hmpps.api.model.AllocationDemandRequest
 import uk.gov.justice.digital.hmpps.api.model.AllocationDemandResponse
 import uk.gov.justice.digital.hmpps.service.AllocationDemandService
@@ -46,7 +40,7 @@ class AllocationDemandResource(
             )
         }
 
-    @PreAuthorize("hasAnyRole('ROLE_ALLOCATION_CONTEXT','PROBATION_API__WORKFORCE_ALLOCATIONS__CASE_DETAIL')")
+    @PreAuthorize("hasAnyRole('ALLOCATION_CONTEXT','PROBATION_API__WORKFORCE_ALLOCATIONS__CASE_DETAIL')")
     @Operation(
         summary = "List of summary probation case details with probation practioner details",
         description = """Summary information on the probation case provided in the request along

--- a/projects/workforce-allocations-to-delius/src/main/resources/application.yml
+++ b/projects/workforce-allocations-to-delius/src/main/resources/application.yml
@@ -32,6 +32,9 @@ spring:
         token-uri: http://localhost:${wiremock.port}/auth/oauth/token
   threads.virtual.enabled: true
 
+oauth2.roles:
+  - PROBATION_API__WORKFORCE_ALLOCATIONS__CASE_DETAIL
+
 springdoc.default-produces-media-type: application/json
 
 delius.db.username: HMPPSAllocations
@@ -57,9 +60,6 @@ spring:
 
 seed.database: true
 context.initializer.classes: uk.gov.justice.digital.hmpps.wiremock.WireMockInitialiser
-
-jwt.authorities:
-  - ROLE_PROBATION_API__WORKFORCE_ALLOCATIONS__CASE_DETAIL
 
 messaging.consumer.queue: workforce-allocations-events
 

--- a/templates/projects/api-client-and-server/src/main/kotlin/uk/gov/justice/digital/hmpps/controller/ApiController.kt
+++ b/templates/projects/api-client-and-server/src/main/kotlin/uk/gov/justice/digital/hmpps/controller/ApiController.kt
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 class ApiController {
-    @PreAuthorize("hasRole('ROLE_EXAMPLE')")
+    @PreAuthorize("hasRole('EXAMPLE')")
     @GetMapping(value = ["/example/{inputId}"])
     fun handle(
         @PathVariable("inputId") inputId: String

--- a/templates/projects/api-client-and-server/src/main/resources/application.yml
+++ b/templates/projects/api-client-and-server/src/main/resources/application.yml
@@ -28,6 +28,9 @@ spring:
         token-uri: http://localhost:${wiremock.port}/auth/oauth/token
   threads.virtual.enabled: true
 
+oauth2.roles:
+  - EXAMPLE
+
 springdoc.default-produces-media-type: application/json
 
 delius.db.username: $SERVICE_NAME_CAMELCASE # Should match value in [deploy/database/access.yml].
@@ -53,9 +56,6 @@ spring:
 seed.database: true
 wiremock.enabled: true
 context.initializer.classes: uk.gov.justice.digital.hmpps.wiremock.WireMockInitialiser
-
-jwt.authorities:
-  - ROLE_EXAMPLE
 
 oauth2:
   client-id: $SERVICE_NAME

--- a/templates/projects/api-server/src/main/kotlin/uk/gov/justice/digital/hmpps/controller/ApiController.kt
+++ b/templates/projects/api-server/src/main/kotlin/uk/gov/justice/digital/hmpps/controller/ApiController.kt
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 class ApiController {
-    @PreAuthorize("hasRole('ROLE_EXAMPLE')")
+    @PreAuthorize("hasRole('EXAMPLE')")
     @GetMapping(value = ["/example/{inputId}"])
     fun handle(
         @PathVariable("inputId") inputId: String

--- a/templates/projects/api-server/src/main/resources/application.yml
+++ b/templates/projects/api-server/src/main/resources/application.yml
@@ -18,6 +18,9 @@ spring:
             drop_tables: false
   threads.virtual.enabled: true
 
+oauth2.roles:
+  - EXAMPLE
+
 springdoc.default-produces-media-type: application/json
 
 delius.db.username: $SERVICE_NAME_CAMELCASE # Should match value in [deploy/database/access.yml].
@@ -42,9 +45,6 @@ spring:
 seed.database: true
 wiremock.enabled: true
 context.initializer.classes: uk.gov.justice.digital.hmpps.wiremock.WireMockInitialiser
-
-jwt.authorities:
-  - ROLE_EXAMPLE
 
 logging.level:
   uk.gov.justice.digital.hmpps: DEBUG

--- a/templates/projects/message-listener-with-api-client-and-server/src/main/kotlin/uk/gov/justice/digital/hmpps/controller/ApiController.kt
+++ b/templates/projects/message-listener-with-api-client-and-server/src/main/kotlin/uk/gov/justice/digital/hmpps/controller/ApiController.kt
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 class ApiController {
-    @PreAuthorize("hasRole('ROLE_EXAMPLE')")
+    @PreAuthorize("hasRole('EXAMPLE')")
     @GetMapping(value = ["/example/{inputId}"])
     fun handle(
         @PathVariable("inputId") inputId: String

--- a/templates/projects/message-listener-with-api-client-and-server/src/main/resources/application.yml
+++ b/templates/projects/message-listener-with-api-client-and-server/src/main/resources/application.yml
@@ -28,6 +28,9 @@ spring:
         token-uri: http://localhost:${wiremock.port}/auth/oauth/token
   threads.virtual.enabled: true
 
+oauth2.roles:
+  - EXAMPLE
+
 springdoc.default-produces-media-type: application/json
 
 delius.db.username: $SERVICE_NAME_CAMELCASE # Should match value in [deploy/database/access.yml].
@@ -53,9 +56,6 @@ spring:
 seed.database: true
 wiremock.enabled: true
 context.initializer.classes: uk.gov.justice.digital.hmpps.wiremock.WireMockInitialiser
-
-jwt.authorities:
-  - ROLE_EXAMPLE
 
 messaging.consumer.queue: message-queue
 


### PR DESCRIPTION
Main changes are in SecurityConfig.kt, which sets up a role hierarchy so that the PROBATION_INTEGRATION_ADMIN role implies all other roles required by the service.