### PR TITLE
PI-2255 Ensure full DN is used for aliasedObjectName attribute

### DIFF
--- a/libs/commons/src/main/kotlin/uk/gov/justice/digital/hmpps/ldap/LdapTemplateExtensions.kt
+++ b/libs/commons/src/main/kotlin/uk/gov/justice/digital/hmpps/ldap/LdapTemplateExtensions.kt
@@ -51,7 +51,7 @@ fun LdapTemplate.addRole(@SpanAttribute username: String, @SpanAttribute role: D
     val roleContext = lookupContext(role.context())
         ?: throw NotFoundException("NDeliusRole of ${role.name} not found")
     val attributes: Attributes = BasicAttributes(true).apply {
-        put(roleContext.dn.asAttribute("aliasedObjectName"))
+        put(roleContext.nameInNamespace.asAttribute("aliasedObjectName"))
         put(role.name.asAttribute("cn"))
         put(listOf("NDRoleAssociation", "alias", "top").asAttribute("objectclass"))
     }


### PR DESCRIPTION
Fixes roles being created in the LDAP without the full aliasedObjectName.

* `roleContext.dn`: cn=ROLE1,cn=ndRoleCatalogue
* `roleContext.nameInNamespace`: cn=ROLE1,cn=ndRoleCatalogue,ou=Users,dc=moj,dc=com