### PR TITLE
PI-2231 Handle null withdrawalCode

### DIFF
--- a/projects/refer-and-monitor-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/ReferralEndSubmitted.kt
+++ b/projects/refer-and-monitor-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/ReferralEndSubmitted.kt
@@ -41,19 +41,19 @@ class ReferralEndSubmitted(
 
         Success(
             ReferralEnded,
-            mapOf(
+            listOfNotNull(
                 "crn" to event.personReference.findCrn()!!,
                 "referralUrn" to event.referralUrn(),
                 "endDate" to sentReferral.endDate.toString(),
                 "endType" to termination.endType.toString(),
-                "withdrawalCode" to termination.withdrawalCode
-            )
+                termination.withdrawalCode?.let { "withdrawalCode" to it }
+            ).toMap()
         )
     }
 }
 
 fun HmppsDomainEvent.deliveryState() = additionalInformation["deliveryState"] as String
-fun HmppsDomainEvent.withdrawalCode() = additionalInformation["withdrawalCode"] as String
+fun HmppsDomainEvent.withdrawalCode() = (additionalInformation["withdrawalCode"] as String?)?.takeIf { it.isNotEmpty() }
 fun HmppsDomainEvent.referralUrn() = additionalInformation["referralURN"] as String
 fun HmppsDomainEvent.referralUiUrl() = additionalInformation["referralProbationUserURL"] as String
 
@@ -107,7 +107,7 @@ data class NsiTermination(
     val startDate: ZonedDateTime,
     val endDate: ZonedDateTime,
     val endType: ReferralEndType,
-    val withdrawalCode: String,
+    val withdrawalCode: String?,
     val notes: String,
     val notificationDateTime: ZonedDateTime?,
     val notificationNotes: String

--- a/projects/refer-and-monitor-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/NsiService.kt
+++ b/projects/refer-and-monitor-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/NsiService.kt
@@ -77,8 +77,7 @@ class NsiService(
     fun terminateNsi(termination: NsiTermination) = audit(MANAGE_NSI) { audit ->
         val nsi = findNsi(termination)
         val status = nsiStatusRepository.getByCode(END.value)
-        val outcomeCode = termination.withdrawalCode
-            .takeIf { it.isNotEmpty() && featureFlags.enabled("referral-withdrawal-reason") }
+        val outcomeCode = termination.withdrawalCode.takeIf { featureFlags.enabled("referral-withdrawal-reason") }
             ?: termination.endType.outcome
         val outcome = nsiOutcomeRepository.nsiOutcome(outcomeCode)
 


### PR DESCRIPTION
R&M aren't sending it yet in production.  Note: they will send an empty string once they deploy their changes, hence the `takeIf { it.isNotEmpty() }`.