### PR TITLE
Seed Approved Premises for local testing

### DIFF
--- a/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/DataLoader.kt
+++ b/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/DataLoader.kt
@@ -84,7 +84,7 @@ class DataLoader(
         moveOnCategoryRepository.save(ReferenceDataGenerator.MC05)
         registerTypeRepository.saveAll(ReferenceDataGenerator.REGISTER_TYPES.values)
 
-        addressRepository.saveAll(listOf(AddressGenerator.Q001, AddressGenerator.Q002))
+        addressRepository.saveAll(listOf(AddressGenerator.Q001, AddressGenerator.Q002, AddressGenerator.Q710))
 
         probationAreaRepository.save(ProbationAreaGenerator.DEFAULT)
         approvedPremisesRepository.save(ApprovedPremisesGenerator.DEFAULT)
@@ -97,6 +97,7 @@ class DataLoader(
             )
         )
         approvedPremisesRepository.save(ApprovedPremisesGenerator.NO_STAFF)
+        approvedPremisesRepository.save(ApprovedPremisesGenerator.E2E_TEST)
         officeLocationRepository.save(OfficeLocationGenerator.DEFAULT)
         apGroupLinkRepository.saveAll(ApprovedPremisesGenerator.AP_GROUP_LINKS)
 
@@ -110,7 +111,7 @@ class DataLoader(
                 "Key-worker",
                 "KEY0001",
                 teams = listOf(TeamGenerator.APPROVED_PREMISES_TEAM),
-                approvedPremises = listOf(ApprovedPremisesGenerator.DEFAULT)
+                approvedPremises = listOf(ApprovedPremisesGenerator.DEFAULT, ApprovedPremisesGenerator.E2E_TEST)
             )
         )
         staffRepository.save(

--- a/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/DataLoader.kt
+++ b/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/DataLoader.kt
@@ -106,11 +106,12 @@ class DataLoader(
         teamRepository.save(TeamGenerator.APPROVED_PREMISES_TEAM_WITH_NO_STAFF)
         teamRepository.save(TeamGenerator.NON_APPROVED_PREMISES_TEAM)
         teamRepository.save(TeamGenerator.UNALLOCATED)
+        teamRepository.save(TeamGenerator.E2E_TEST_TEAM)
         staffRepository.save(
             StaffGenerator.generate(
                 "Key-worker",
                 "KEY0001",
-                teams = listOf(TeamGenerator.APPROVED_PREMISES_TEAM),
+                teams = listOf(TeamGenerator.APPROVED_PREMISES_TEAM, TeamGenerator.E2E_TEST_TEAM),
                 approvedPremises = listOf(ApprovedPremisesGenerator.DEFAULT, ApprovedPremisesGenerator.E2E_TEST)
             )
         )

--- a/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/AddressGenerator.kt
+++ b/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/AddressGenerator.kt
@@ -23,6 +23,7 @@ object AddressGenerator {
 
     val Q001 = generateAddress("", "1", "Promise Street", "", "Make Believe", "", "MB01 1PS", "01234567890")
     val Q002 = generateAddress("", "2", "Future Street", "", "Make Believe", "", "MB02 2PS", "01234567891")
+    val Q710 = generateAddress("Test AP 10", "10", "Hope Street", "", "Make Believe", "", "MB03 3PS", "01234567892")
 
     fun generateAddress(
         buildingName: String? = null,

--- a/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/ApprovedPremisesGenerator.kt
+++ b/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/ApprovedPremisesGenerator.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.integrations.delius.referencedata.ReferenceD
 object ApprovedPremisesGenerator {
     val DEFAULT = generate(ReferenceDataGenerator.NHC_Q001, AddressGenerator.Q001)
     val NO_STAFF = generate(ReferenceDataGenerator.NHC_Q002, AddressGenerator.Q002)
+    val E2E_TEST = generate(ReferenceDataGenerator.NHC_Q710, AddressGenerator.Q710)
     val AP_GROUP_LINKS = listOf(generateGroupLink(DEFAULT), generateGroupLink(NO_STAFF))
 
     fun generate(

--- a/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/ReferenceDataGenerator.kt
+++ b/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/ReferenceDataGenerator.kt
@@ -29,6 +29,7 @@ object ReferenceDataGenerator {
     val PREV_ADDRESS_STATUS = generate("P", ADDRESS_STATUS.id, "Previous Address")
     val NHC_Q001 = generate("Q001", HOSTEL_CODE.id)
     val NHC_Q002 = generate("Q002", HOSTEL_CODE.id)
+    val NHC_Q710 = generate("Q710", HOSTEL_CODE.id)
     val STAFF_GRADE = generate("TEST", DatasetGenerator.STAFF_GRADE.id, "Test staff grade")
 
     val REFERRAL_DATE_TYPE = generate("CRC", ALL_DATASETS[DatasetCode.AP_REFERRAL_DATE_TYPE]!!.id)
@@ -83,6 +84,7 @@ object ReferenceDataGenerator {
         PREV_ADDRESS_STATUS,
         NHC_Q001,
         NHC_Q002,
+        NHC_Q710,
         STAFF_GRADE,
         REFERRAL_DATE_TYPE,
         REFERRAL_GROUP,

--- a/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/TeamGenerator.kt
+++ b/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/TeamGenerator.kt
@@ -13,6 +13,7 @@ object TeamGenerator {
     val APPROVED_PREMISES_TEAM_WITH_NO_STAFF = generate(ApprovedPremisesGenerator.NO_STAFF)
     val NON_APPROVED_PREMISES_TEAM = generate()
     val UNALLOCATED = generate(code = "N54UAT")
+    val E2E_TEST_TEAM = generate(ApprovedPremisesGenerator.E2E_TEST)
 
     fun generate(
         approvedPremises: ApprovedPremises? = null,


### PR DESCRIPTION
To get the Approved Premises E2E tests running properly in the local development environment as well as in the deployed dev/test env we need to look up staff for the "AP Test 10" Premises (QCode 710) in AP-and-Delius, in both the local and the deployed dev/test environments.

In this commit we create a new AP in the local ('dev' namespace) AP-and-Delius context with the expected QCode to match what's already in use in the dev/test environment.

This will allow our locally running API to ask for staff members:

`GET https://ap-and-delius/approved-premises/Q710/staff`

and execute the sanme E2E test in both local and deployed environments.