### PR TITLE
PI-2291 Switch to Spring's PagedModel for responses

### DIFF
--- a/projects/approved-premises-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/StaffControllerIntegrationTest.kt
+++ b/projects/approved-premises-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/StaffControllerIntegrationTest.kt
@@ -26,8 +26,8 @@ class StaffControllerIntegrationTest {
         mockMvc
             .perform(get("/approved-premises/${approvedPremises.code.code}/staff").withToken())
             .andExpect(status().isOk)
-            .andExpect(jsonPath("$.numberOfElements", equalTo(3)))
-            .andExpect(jsonPath("$.size", equalTo(100)))
+            .andExpect(jsonPath("$.page.totalElements", equalTo(3)))
+            .andExpect(jsonPath("$.page.size", equalTo(100)))
             .andExpect(
                 jsonPath(
                     "$.content[*].name.surname",
@@ -43,8 +43,9 @@ class StaffControllerIntegrationTest {
         mockMvc
             .perform(get("/approved-premises/${approvedPremises.code.code}/staff").withToken())
             .andExpect(status().isOk)
-            .andExpect(jsonPath("$.numberOfElements", equalTo(0)))
-            .andExpect(jsonPath("$.totalElements", equalTo(0)))
+            .andExpect(jsonPath("$.content.size()", equalTo(0)))
+            .andExpect(jsonPath("$.page.totalPages", equalTo(0)))
+            .andExpect(jsonPath("$.page.totalElements", equalTo(0)))
     }
 
     @Test
@@ -60,7 +61,7 @@ class StaffControllerIntegrationTest {
         val approvedPremises = ApprovedPremisesGenerator.DEFAULT
         mockMvc.perform(get("/approved-premises/${approvedPremises.code.code}/staff?keyWorker=true").withToken())
             .andExpect(status().isOk)
-            .andExpect(jsonPath("$.numberOfElements", equalTo(1)))
+            .andExpect(jsonPath("$.page.totalElements", equalTo(1)))
             .andExpect(jsonPath("$.content[*].name.surname", equalTo(listOf("Key-worker"))))
             .andExpect(jsonPath("$.content[*].keyWorker", equalTo(listOf(true))))
     }

--- a/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/StaffService.kt
+++ b/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/StaffService.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.service
 
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PagedModel
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.exception.NotFoundException
@@ -23,7 +23,7 @@ class StaffService(
         approvedPremisesCode: String,
         keyWorkersOnly: Boolean,
         pageable: Pageable
-    ): Page<StaffResponse> {
+    ): PagedModel<StaffResponse> {
         if (!approvedPremisesRepository.existsByCodeCode(approvedPremisesCode)) {
             throw NotFoundException("Approved Premises", "code", approvedPremisesCode)
         }
@@ -36,7 +36,7 @@ class StaffService(
             staffRepository.findAllStaffLinkedToApprovedPremisesTeam(approvedPremisesCode, pageable).map {
                 it.toResponse(approvedPremisesCode)
             }
-        }
+        }.let { PagedModel(it) }
     }
 
     fun getStaffByUsername(username: String) =

--- a/projects/core-person-record-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/CorePersonIntegrationTest.kt
+++ b/projects/core-person-record-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/CorePersonIntegrationTest.kt
@@ -67,7 +67,7 @@ internal class CorePersonIntegrationTest {
         mockMvc
             .perform(get("/all-probation-cases?sort=crn,desc").withToken())
             .andExpect(status().is2xxSuccessful)
-            .andExpect(jsonPath("totalElements", equalTo(2)))
+            .andExpect(jsonPath("page.totalElements", equalTo(2)))
             .andExpect(jsonPath("content[0].identifiers.crn", equalTo(minPerson.identifiers.crn)))
             .andExpect(jsonPath("content[1].identifiers.crn", equalTo(fullPerson.identifiers.crn)))
     }

--- a/projects/core-person-record-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/api/resource/PersonResource.kt
+++ b/projects/core-person-record-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/api/resource/PersonResource.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.api.resource
 
 import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PagedModel
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -24,5 +25,5 @@ class PersonResource(private val personService: PersonService) {
     }
 
     @GetMapping(value = ["/all-probation-cases"])
-    fun getPersonDetails(pageable: Pageable) = personService.getAllPersonDetails(pageable)
+    fun getPersonDetails(pageable: Pageable) = PagedModel(personService.getAllPersonDetails(pageable))
 }


### PR DESCRIPTION
* Approved Premises API does not currently map the page fields, so this won't break anything there: https://github.com/ministryofjustice/hmpps-approved-premises-api/blob/cef16013ba101d8286e0161e85649a1626a29c9b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/model/deliuscontext/StaffMembersPage.kt#L3-L5
* Core Person Record only calls the paged endpoint on an ad-hoc basis to do a full load, so we can just co-ordinate the rollout with them. See https://github.com/ministryofjustice/hmpps-person-record/pull/426