### PR TITLE
Filter out `/info` requests from Telemetry

### DIFF
--- a/libs/commons/src/main/kotlin/uk/gov/justice/digital/hmpps/config/SentryConfig.kt
+++ b/libs/commons/src/main/kotlin/uk/gov/justice/digital/hmpps/config/SentryConfig.kt
@@ -8,6 +8,6 @@ import org.springframework.context.annotation.Configuration
 class SentryConfig {
     @Bean
     fun ignoreHealthRequests() = SentryOptions.BeforeSendTransactionCallback { transaction, _ ->
-        transaction.transaction?.let { if (it.startsWith("GET /health")) null else transaction }
+        transaction.transaction?.let { if (it.startsWith("GET /health") or it.startsWith("GET /info")) null else transaction }
     }
 }

--- a/projects/accredited-programmes-and-oasys/applicationinsights.json
+++ b/projects/accredited-programmes-and-oasys/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/approved-premises-and-delius/applicationinsights.json
+++ b/projects/approved-premises-and-delius/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/approved-premises-and-oasys/applicationinsights.json
+++ b/projects/approved-premises-and-oasys/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/arns-and-delius/applicationinsights.json
+++ b/projects/arns-and-delius/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/assessment-summary-and-delius/applicationinsights.json
+++ b/projects/assessment-summary-and-delius/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/cas2-and-delius/applicationinsights.json
+++ b/projects/cas2-and-delius/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/cas3-and-delius/applicationinsights.json
+++ b/projects/cas3-and-delius/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/core-person-record-and-delius/applicationinsights.json
+++ b/projects/core-person-record-and-delius/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/court-case-and-delius/applicationinsights.json
+++ b/projects/court-case-and-delius/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/create-and-vary-a-licence-and-delius/applicationinsights.json
+++ b/projects/create-and-vary-a-licence-and-delius/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/custody-key-dates-and-delius/applicationinsights.json
+++ b/projects/custody-key-dates-and-delius/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/domain-events-and-delius/applicationinsights.json
+++ b/projects/domain-events-and-delius/applicationinsights.json
@@ -38,6 +38,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/dps-and-delius/applicationinsights.json
+++ b/projects/dps-and-delius/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/effective-proposal-framework-and-delius/applicationinsights.json
+++ b/projects/effective-proposal-framework-and-delius/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/external-api-and-delius/applicationinsights.json
+++ b/projects/external-api-and-delius/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/hdc-licences-and-delius/applicationinsights.json
+++ b/projects/hdc-licences-and-delius/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/hmpps-auth-and-delius/applicationinsights.json
+++ b/projects/hmpps-auth-and-delius/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/make-recall-decisions-and-delius/applicationinsights.json
+++ b/projects/make-recall-decisions-and-delius/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/manage-offences-and-delius/applicationinsights.json
+++ b/projects/manage-offences-and-delius/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/manage-pom-cases-and-delius/applicationinsights.json
+++ b/projects/manage-pom-cases-and-delius/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/manage-supervision-and-delius/applicationinsights.json
+++ b/projects/manage-supervision-and-delius/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/manage-supervision-and-oasys/applicationinsights.json
+++ b/projects/manage-supervision-and-oasys/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/oasys-and-delius/applicationinsights.json
+++ b/projects/oasys-and-delius/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/offender-events-and-delius/applicationinsights.json
+++ b/projects/offender-events-and-delius/applicationinsights.json
@@ -38,6 +38,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/opd-and-delius/applicationinsights.json
+++ b/projects/opd-and-delius/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/pathfinder-and-delius/applicationinsights.json
+++ b/projects/pathfinder-and-delius/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/pre-sentence-reports-to-delius/applicationinsights.json
+++ b/projects/pre-sentence-reports-to-delius/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/prison-case-notes-to-probation/applicationinsights.json
+++ b/projects/prison-case-notes-to-probation/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/prison-custody-status-to-delius/applicationinsights.json
+++ b/projects/prison-custody-status-to-delius/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/prison-education-and-delius/applicationinsights.json
+++ b/projects/prison-education-and-delius/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/prison-identifier-and-delius/applicationinsights.json
+++ b/projects/prison-identifier-and-delius/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/prisoner-profile-and-delius/applicationinsights.json
+++ b/projects/prisoner-profile-and-delius/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/probation-search-and-delius/applicationinsights.json
+++ b/projects/probation-search-and-delius/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/refer-and-monitor-and-delius/applicationinsights.json
+++ b/projects/refer-and-monitor-and-delius/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/resettlement-passport-and-delius/applicationinsights.json
+++ b/projects/resettlement-passport-and-delius/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/risk-assessment-scores-to-delius/applicationinsights.json
+++ b/projects/risk-assessment-scores-to-delius/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/sentence-plan-and-delius/applicationinsights.json
+++ b/projects/sentence-plan-and-delius/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/sentence-plan-and-oasys/applicationinsights.json
+++ b/projects/sentence-plan-and-oasys/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/soc-and-delius/applicationinsights.json
+++ b/projects/soc-and-delius/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/tier-to-delius/applicationinsights.json
+++ b/projects/tier-to-delius/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/unpaid-work-and-delius/applicationinsights.json
+++ b/projects/unpaid-work-and-delius/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/projects/workforce-allocations-to-delius/applicationinsights.json
+++ b/projects/workforce-allocations-to-delius/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/templates/projects/api-client-and-server/applicationinsights.json
+++ b/templates/projects/api-client-and-server/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/templates/projects/api-server/applicationinsights.json
+++ b/templates/projects/api-server/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/templates/projects/message-listener-with-api-client-and-server/applicationinsights.json
+++ b/templates/projects/message-listener-with-api-client-and-server/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/templates/projects/message-listener-with-api-client/applicationinsights.json
+++ b/templates/projects/message-listener-with-api-client/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {

--- a/templates/projects/message-listener/applicationinsights.json
+++ b/templates/projects/message-listener/applicationinsights.json
@@ -35,6 +35,17 @@
           "percentage": 0
         },
         {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/info/?.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 0
+        },
+        {
           "telemetryType": "dependency",
           "attributes": [
             {


### PR DESCRIPTION
This endpoint is now being polled by the developer portal, so it'd be good to remove the noise from App Insights + Sentry.