### PR TITLE
Seed probation case for Approved Premises E2E testing

### DIFF
--- a/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/ProbationCaseDataLoader.kt
+++ b/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/ProbationCaseDataLoader.kt
@@ -45,12 +45,14 @@ class ProbationCaseDataLoader(
         probationCaseRepository.save(ProbationCaseGenerator.CASE_COMPLEX)
         probationCaseRepository.save(ProbationCaseGenerator.CASE_SIMPLE)
         probationCaseRepository.save(ProbationCaseGenerator.CASE_X320741)
+        probationCaseRepository.save(ProbationCaseGenerator.CASE_X320811)
 
         personManagerRepository.saveAll(
             listOf(
                 ProbationCaseGenerator.generateManager(ProbationCaseGenerator.CASE_COMPLEX).asPersonManager(),
                 ProbationCaseGenerator.generateManager(ProbationCaseGenerator.CASE_SIMPLE).asPersonManager(),
-                ProbationCaseGenerator.generateManager(ProbationCaseGenerator.CASE_X320741).asPersonManager()
+                ProbationCaseGenerator.generateManager(ProbationCaseGenerator.CASE_X320741).asPersonManager(),
+                ProbationCaseGenerator.generateManager(ProbationCaseGenerator.CASE_X320811).asPersonManager()
             )
         )
 

--- a/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/ProbationCaseGenerator.kt
+++ b/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/ProbationCaseGenerator.kt
@@ -46,6 +46,18 @@ object ProbationCaseGenerator {
         religion = ReferenceDataGenerator.RELIGION_OTHER,
         genderIdentity = ReferenceDataGenerator.GENDER_IDENTITY_PNS,
     )
+    val CASE_X320811 = generate(
+        crn = "X320811",
+        forename = "E2E Person",
+        surname = "AdHoc Bookings",
+        dateOfBirth = LocalDate.of(1987, 8, 2),
+        nomsId = "A1234AI",
+        gender = ReferenceDataGenerator.GENDER_MALE,
+        ethnicity = ReferenceDataGenerator.ETHNICITY_WHITE,
+        nationality = ReferenceDataGenerator.NATIONALITY_BRITISH,
+        religion = ReferenceDataGenerator.RELIGION_OTHER,
+        genderIdentity = ReferenceDataGenerator.GENDER_IDENTITY_PNS,
+    )
 
     fun generate(
         crn: String,


### PR DESCRIPTION
The Approved Premises local E2E tests have need of a "probation case" (person leaving custody) to use in E2E tests which rely on a manual or "ad hoc" booking. These bookings can only be made for people who don't have any existing applications with the service. This is most reliably achieved by using a distinct probation case.

In this commit we seed a case with CRN X320811, which [ties in with seeding at CommunityAPI][] -- which is still being used at present for fetching a list of convictions:

```
http://community-api/secure/offenders/crn/X320811/convictions
```

[ties in with seeding at CommunityAPI]:
https://github.com/ministryofjustice/community-api/blob/736ac63ff7705a0c8d998ed2773d59563b0fdea4/src/main/resources/db/data/V1_9__offender_X320811_custody_status_data.sql#L1