### PR TITLE
Seed LAO Test Data for Approved Premises

### DIFF
--- a/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/DataLoader.kt
+++ b/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/DataLoader.kt
@@ -147,6 +147,12 @@ class DataLoader(
         staffRepository.save(StaffGenerator.JIM_SNOW)
         staffUserRepository.save(StaffGenerator.JIM_SNOW_USER)
 
+        staffRepository.save(StaffGenerator.LAO_FULL_ACCESS)
+        staffUserRepository.save(StaffGenerator.LAO_FULL_ACCESS_USER)
+
+        staffRepository.save(StaffGenerator.LAO_RESTRICTED)
+        staffUserRepository.save(StaffGenerator.LAO_RESTRICTED_USER)
+
         val personManagerStaff = StaffGenerator.generate(code = "N54A001")
         staffRepository.save(personManagerStaff)
         val person = PersonGenerator.DEFAULT

--- a/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/LimitedAccessGenerator.kt
+++ b/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/LimitedAccessGenerator.kt
@@ -1,0 +1,43 @@
+package uk.gov.justice.digital.hmpps.data.generator
+
+import uk.gov.justice.digital.hmpps.data.MutableLimitedAccessPerson
+import uk.gov.justice.digital.hmpps.entity.Exclusion
+import uk.gov.justice.digital.hmpps.entity.LimitedAccessPerson
+import uk.gov.justice.digital.hmpps.entity.LimitedAccessUser
+import uk.gov.justice.digital.hmpps.entity.Restriction
+import uk.gov.justice.digital.hmpps.integrations.delius.person.ProbationCase
+import uk.gov.justice.digital.hmpps.integrations.delius.staff.StaffUser
+import java.time.LocalDateTime
+
+object LimitedAccessGenerator {
+    val FULL_ACCESS_USER = generateLaoUser(StaffGenerator.LAO_FULL_ACCESS_USER)
+    val LIMITED_ACCESS_USER = generateLaoUser(StaffGenerator.LAO_RESTRICTED_USER)
+    val EXCLUDED_CASE =
+        generateLaoPerson(ProbationCaseGenerator.CASE_LAO_EXCLUSION, exclusionMessage = "This case has an exclusion")
+    val RESTRICTED_CASE = generateLaoPerson(
+        ProbationCaseGenerator.CASE_LAO_RESTRICTED,
+        restrictionMessage = "This case has an restriction"
+    )
+
+    fun generateLaoUser(staffUser: StaffUser) = LimitedAccessUser(staffUser.username, staffUser.id)
+
+    fun generateLaoPerson(
+        probationCase: ProbationCase,
+        exclusionMessage: String? = null,
+        restrictionMessage: String? = null,
+    ) = MutableLimitedAccessPerson(probationCase.crn, exclusionMessage, restrictionMessage, probationCase.id)
+
+    fun generateExclusion(
+        person: LimitedAccessPerson,
+        user: LimitedAccessUser = LIMITED_ACCESS_USER,
+        endDateTime: LocalDateTime? = null,
+        id: Long = IdGenerator.getAndIncrement(),
+    ) = Exclusion(person, user, endDateTime, id)
+
+    fun generateRestriction(
+        person: LimitedAccessPerson,
+        user: LimitedAccessUser = FULL_ACCESS_USER,
+        endDateTime: LocalDateTime? = null,
+        id: Long = IdGenerator.getAndIncrement(),
+    ) = Restriction(person, user, endDateTime, id)
+}

--- a/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/ProbationCaseGenerator.kt
+++ b/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/ProbationCaseGenerator.kt
@@ -57,6 +57,34 @@ object ProbationCaseGenerator {
         religion = ReferenceDataGenerator.RELIGION_OTHER,
         genderIdentity = ReferenceDataGenerator.GENDER_IDENTITY_PNS,
     )
+    val CASE_LAO_EXCLUSION = generate(
+        crn = "X400000",
+        forename = "Elliot Exclusion",
+        surname = "Erickson",
+        dateOfBirth = LocalDate.of(1979, 4, 11),
+        nomsId = "A1235AI",
+        gender = ReferenceDataGenerator.GENDER_MALE,
+        ethnicity = ReferenceDataGenerator.ETHNICITY_WHITE,
+        nationality = ReferenceDataGenerator.NATIONALITY_BRITISH,
+        religion = ReferenceDataGenerator.RELIGION_OTHER,
+        genderIdentity = ReferenceDataGenerator.GENDER_IDENTITY_PNS,
+        currentExclusion = true,
+        currentRestriction = false,
+    )
+    val CASE_LAO_RESTRICTED = generate(
+        crn = "X400001",
+        forename = "Reginald Restricted",
+        surname = "Robinson",
+        dateOfBirth = LocalDate.of(1981, 1, 1),
+        nomsId = "A1236AI",
+        gender = ReferenceDataGenerator.GENDER_MALE,
+        ethnicity = ReferenceDataGenerator.ETHNICITY_WHITE,
+        nationality = ReferenceDataGenerator.NATIONALITY_BRITISH,
+        religion = ReferenceDataGenerator.RELIGION_OTHER,
+        genderIdentity = ReferenceDataGenerator.GENDER_IDENTITY_PNS,
+        currentExclusion = false,
+        currentRestriction = true,
+    )
 
     fun generate(
         crn: String,

--- a/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/StaffGenerator.kt
+++ b/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/StaffGenerator.kt
@@ -14,9 +14,17 @@ object StaffGenerator {
     val JIM_SNOW = generate(
         name = "Jim Snow"
     )
+    val LAO_FULL_ACCESS = generate(
+        name = "LAO Full Access"
+    )
+    val LAO_RESTRICTED = generate(
+        name = "LAO Restricted"
+    )
 
     val DEFAULT_STAFF_USER = generateStaffUser("john-smith", DEFAULT_STAFF)
     val JIM_SNOW_USER = generateStaffUser("JIMSNOWLDAP", JIM_SNOW)
+    val LAO_FULL_ACCESS_USER = generateStaffUser("LAOFULLACCESS", LAO_FULL_ACCESS)
+    val LAO_RESTRICTED_USER = generateStaffUser("LAORESTRICTED", LAO_RESTRICTED)
 
     fun generate(
         name: String = "Test",


### PR DESCRIPTION
This commit enhances the approved-premises-and-delius seed data to include two new offenders and two new users to supports testing of LAO access in Approved Premises.

Two new users and cases are added:

* LAOFULLACCESS - has access to the new excluded case X400000
* LAORESTRICTED - does not have access to the new restricted case X400001