### PR TITLE
PI-2102 - remove sql restriction on nsi table, as these soft deleted …

### DIFF
--- a/projects/court-case-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/NsisByCrnAndConvictionIdIntegrationTest.kt
+++ b/projects/court-case-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/NsisByCrnAndConvictionIdIntegrationTest.kt
@@ -114,7 +114,7 @@ internal class NsisByCrnAndConvictionIdIntegrationTest {
                     "Months",
                     managers,
                     BREACH_NSIS.notes,
-                    BREACH_NSIS.intendedProvider?.toProbationArea(true),
+                    BREACH_NSIS.intendedProvider?.toProbationArea(false),
                     BREACH_NSIS.active,
                     BREACH_NSIS.softDeleted,
                     BREACH_NSIS.externalReference

--- a/projects/court-case-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/event/nsi/Nsi.kt
+++ b/projects/court-case-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/event/nsi/Nsi.kt
@@ -15,7 +15,6 @@ import java.time.ZonedDateTime
 
 @Entity
 @Table(name = "nsi")
-@SQLRestriction("soft_deleted = 0 and active_flag = 1")
 class Nsi(
 
     @Column(name = "offender_id")

--- a/projects/court-case-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/service/InterventionService.kt
+++ b/projects/court-case-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/service/InterventionService.kt
@@ -47,7 +47,7 @@ class InterventionService(
             length?.let { "Months" },
             managers.map { it.toNsiManager() },
             notes,
-            intendedProvider?.toProbationArea(true),
+            intendedProvider?.toProbationArea(false),
             active,
             softDeleted,
             externalReference


### PR DESCRIPTION
…and non-active records can be returned.  Also, probation area teams are not required for this api.