### PR TITLE
Fix AsyncAPI docs with duplicate `messageId`s

### DIFF
--- a/libs/messaging/src/main/kotlin/uk/gov/justice/digital/hmpps/documentation/AsyncApiReferencingSerializer.kt
+++ b/libs/messaging/src/main/kotlin/uk/gov/justice/digital/hmpps/documentation/AsyncApiReferencingSerializer.kt
@@ -19,12 +19,18 @@ class AsyncApiReferencingSerializer(val objectMapper: ObjectMapper) : AsyncApiSe
 
     private fun Operation.replaceMessagesWithReferences() {
         val messages = (message as OneOfReferencableMessages?)?.oneOf
-        val messageNames = messages?.filterIsInstance<Message>()?.mapNotNull { it.name }
-        messageNames?.forEach { messages.replaceWithReference(it) }
+        messages?.filterIsInstance<Message>()?.forEach { messages.replaceWithReference(it) }
     }
 
-    private fun ReferencableMessagesList.replaceWithReference(name: String) {
-        reference { ref("https://raw.githubusercontent.com/ministryofjustice/hmpps-domain-events/main/spec/schemas/$name.yml") }
-        removeIf { it is Message && it.name == name }
+    private fun ReferencableMessagesList.replaceWithReference(message: Message) {
+        val name = message.name
+        if (message.name != null) {
+            // If the name is populated, replace with remote schema reference
+            reference { ref("https://raw.githubusercontent.com/ministryofjustice/hmpps-domain-events/main/spec/schemas/$name.yml") }
+            removeIf { it is Message && it.name == name }
+        } else if (message.title != null) {
+            // Otherwise update the name to match the title
+            message.name = message.title
+        }
     }
 }

--- a/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/Handler.kt
+++ b/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/Handler.kt
@@ -29,10 +29,10 @@ class Handler(
             Message(name = "approved-premises/application-withdrawn"),
             Message(name = "approved-premises/booking-made"),
             Message(name = "approved-premises/booking-cancelled"),
-            Message(messageId = "approved-premises.booking.changed", payload = Schema(HmppsDomainEvent::class)),
-            Message(messageId = "approved-premises.person.not-arrived", payload = Schema(HmppsDomainEvent::class)),
-            Message(messageId = "approved-premises.person.arrived", payload = Schema(HmppsDomainEvent::class)),
-            Message(messageId = "approved-premises.person.departed", payload = Schema(HmppsDomainEvent::class)),
+            Message(title = "approved-premises.booking.changed", payload = Schema(HmppsDomainEvent::class)),
+            Message(title = "approved-premises.person.not-arrived", payload = Schema(HmppsDomainEvent::class)),
+            Message(title = "approved-premises.person.arrived", payload = Schema(HmppsDomainEvent::class)),
+            Message(title = "approved-premises.person.departed", payload = Schema(HmppsDomainEvent::class)),
         ]
     )
     override fun handle(notification: Notification<HmppsDomainEvent>) {

--- a/projects/assessment-summary-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/Handler.kt
+++ b/projects/assessment-summary-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/Handler.kt
@@ -27,7 +27,7 @@ class Handler(
     private val featureFlags: FeatureFlags,
     private val telemetryService: TelemetryService
 ) : NotificationHandler<HmppsDomainEvent> {
-    @Publish(messages = [Message(messageId = AssessmentSummaryProduced, payload = Schema(HmppsDomainEvent::class))])
+    @Publish(messages = [Message(title = AssessmentSummaryProduced, payload = Schema(HmppsDomainEvent::class))])
     override fun handle(notification: Notification<HmppsDomainEvent>) {
         try {
             if (notification.message.eventType == AssessmentSummaryProduced && featureFlags.enabled("assessment-summary-produced")) {

--- a/projects/cas2-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/Handler.kt
+++ b/projects/cas2-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/Handler.kt
@@ -26,11 +26,11 @@ class Handler(
     @Publish(
         messages = [
             Message(
-                messageId = "applications.cas2.application.submitted",
+                title = "applications.cas2.application.submitted",
                 payload = Schema(HmppsDomainEvent::class)
             ),
             Message(
-                messageId = "applications.cas2.application.status-updated",
+                title = "applications.cas2.application.status-updated",
                 payload = Schema(HmppsDomainEvent::class)
             ),
         ]

--- a/projects/cas3-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/Handler.kt
+++ b/projects/cas3-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/Handler.kt
@@ -33,39 +33,39 @@ class Handler(
     @Publish(
         messages = [
             Message(
-                messageId = "accommodation.cas3.referral.submitted",
+                title = "accommodation.cas3.referral.submitted",
                 payload = Schema(HmppsDomainEvent::class)
             ),
             Message(
-                messageId = "accommodation.cas3.booking.cancelled",
+                title = "accommodation.cas3.booking.cancelled",
                 payload = Schema(HmppsDomainEvent::class)
             ),
             Message(
-                messageId = "accommodation.cas3.booking.confirmed",
+                title = "accommodation.cas3.booking.confirmed",
                 payload = Schema(HmppsDomainEvent::class)
             ),
             Message(
-                messageId = "accommodation.cas3.booking.provisionally-made",
+                title = "accommodation.cas3.booking.provisionally-made",
                 payload = Schema(HmppsDomainEvent::class)
             ),
             Message(
-                messageId = "accommodation.cas3.person.arrived",
+                title = "accommodation.cas3.person.arrived",
                 payload = Schema(HmppsDomainEvent::class)
             ),
             Message(
-                messageId = "accommodation.cas3.person.departed",
+                title = "accommodation.cas3.person.departed",
                 payload = Schema(HmppsDomainEvent::class)
             ),
             Message(
-                messageId = "accommodation.cas3.person.arrived.updated",
+                title = "accommodation.cas3.person.arrived.updated",
                 payload = Schema(HmppsDomainEvent::class)
             ),
             Message(
-                messageId = "accommodation.cas3.person.departed.updated",
+                title = "accommodation.cas3.person.departed.updated",
                 payload = Schema(HmppsDomainEvent::class)
             ),
             Message(
-                messageId = "accommodation.cas3.booking.cancelled.updated",
+                title = "accommodation.cas3.booking.cancelled.updated",
                 payload = Schema(HmppsDomainEvent::class)
             ),
         ]

--- a/projects/court-case-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/Handler.kt
+++ b/projects/court-case-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/Handler.kt
@@ -33,7 +33,7 @@ class Handler(
         val log: Logger = LoggerFactory.getLogger(this::class.java)
     }
 
-    @Publish(messages = [Message(messageId = "court-case-note.published", payload = Schema(HmppsDomainEvent::class))])
+    @Publish(messages = [Message(title = "court-case-note.published", payload = Schema(HmppsDomainEvent::class))])
     override fun handle(notification: Notification<HmppsDomainEvent>) {
         telemetryService.notificationReceived(notification)
         val event = notification.message

--- a/projects/custody-key-dates-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/Handler.kt
+++ b/projects/custody-key-dates-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/Handler.kt
@@ -26,15 +26,15 @@ class Handler(
 ) : NotificationHandler<Any> {
     @Publish(
         messages = [
-            Message(messageId = "probation-case.prison-identifier.added", payload = Schema(HmppsDomainEvent::class)),
-            Message(messageId = "probation-case.prison-identifier.updated", payload = Schema(HmppsDomainEvent::class)),
-            Message(messageId = "SENTENCE_DATES-CHANGED", payload = Schema(CustodyDateChanged::class)),
-            Message(messageId = "CONFIRMED_RELEASE_DATE-CHANGED", payload = Schema(CustodyDateChanged::class)),
-            Message(messageId = "KEY_DATE_ADJUSTMENT_UPSERTED", payload = Schema(CustodyDateChanged::class)),
-            Message(messageId = "KEY_DATE_ADJUSTMENT_DELETED", payload = Schema(CustodyDateChanged::class)),
-            Message(messageId = "SENTENCE_CHANGED", payload = Schema(ProbationOffenderEvent::class)),
+            Message(title = "probation-case.prison-identifier.added", payload = Schema(HmppsDomainEvent::class)),
+            Message(title = "probation-case.prison-identifier.updated", payload = Schema(HmppsDomainEvent::class)),
+            Message(title = "SENTENCE_DATES-CHANGED", payload = Schema(CustodyDateChanged::class)),
+            Message(title = "CONFIRMED_RELEASE_DATE-CHANGED", payload = Schema(CustodyDateChanged::class)),
+            Message(title = "KEY_DATE_ADJUSTMENT_UPSERTED", payload = Schema(CustodyDateChanged::class)),
+            Message(title = "KEY_DATE_ADJUSTMENT_DELETED", payload = Schema(CustodyDateChanged::class)),
+            Message(title = "SENTENCE_CHANGED", payload = Schema(ProbationOffenderEvent::class)),
             Message(
-                messageId = "custody-key-dates.internal.bulk-update",
+                title = "custody-key-dates.internal.bulk-update",
                 summary = "Internal use - bulk key date update",
                 payload = Schema(HmppsDomainEvent::class)
             ),

--- a/projects/custody-key-dates-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/Notifier.kt
+++ b/projects/custody-key-dates-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/Notifier.kt
@@ -26,7 +26,7 @@ class Notifier(
     }
 
     @Transactional
-    @Subscribe(messages = [Message(messageId = BULK_KEY_DATE_UPDATE, payload = Schema(HmppsDomainEvent::class))])
+    @Subscribe(messages = [Message(title = BULK_KEY_DATE_UPDATE, payload = Schema(HmppsDomainEvent::class))])
     fun requestBulkUpdate(nomsIds: List<String>, dryRun: Boolean) {
         var count = 0
         nomsIds.asSequence()

--- a/projects/make-recall-decisions-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/Handler.kt
+++ b/projects/make-recall-decisions-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/Handler.kt
@@ -25,9 +25,9 @@ class Handler(
     @Publish(
         messages = [
             Message(name = "consider-a-recall/management_oversight"),
-            Message(messageId = "prison-recall.recommendation.deleted", payload = Schema(HmppsDomainEvent::class)),
+            Message(title = "prison-recall.recommendation.deleted", payload = Schema(HmppsDomainEvent::class)),
             Message(
-                messageId = "prison-recall.recommendation.consideration",
+                title = "prison-recall.recommendation.consideration",
                 payload = Schema(HmppsDomainEvent::class)
             ),
         ]

--- a/projects/manage-pom-cases-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/Notifier.kt
+++ b/projects/manage-pom-cases-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/Notifier.kt
@@ -28,7 +28,7 @@ class Notifier(
     }
 
     @Transactional
-    @Subscribe(messages = [Message(messageId = BULK_HANDOVER_DATE_UPDATE, payload = Schema(HmppsDomainEvent::class))])
+    @Subscribe(messages = [Message(title = BULK_HANDOVER_DATE_UPDATE, payload = Schema(HmppsDomainEvent::class))])
     fun requestBulkUpdate(dryRun: Boolean) {
         var count = 0
         personRepository.findNomsSingleCustodial().asSequence()

--- a/projects/manage-pom-cases-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/PomCaseMessageHandler.kt
+++ b/projects/manage-pom-cases-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/PomCaseMessageHandler.kt
@@ -37,9 +37,9 @@ class PomCaseMessageHandler(
         messages = [
             Message(name = "offender-management/handover-changed"),
             Message(name = "offender-management/pom-allocated"),
-            Message(messageId = "SENTENCE_CHANGED", payload = Schema(ProbationOffenderEvent::class)),
+            Message(title = "SENTENCE_CHANGED", payload = Schema(ProbationOffenderEvent::class)),
             Message(
-                messageId = "pom-handover-dates.internal.bulk-update",
+                title = "pom-handover-dates.internal.bulk-update",
                 summary = "Internal use - pom handover date update",
                 payload = Schema(HmppsDomainEvent::class)
             )

--- a/projects/opd-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/Handler.kt
+++ b/projects/opd-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/Handler.kt
@@ -24,7 +24,7 @@ class Handler(
     private val telemetryService: TelemetryService,
     private val opdService: OpdService,
 ) : NotificationHandler<HmppsDomainEvent> {
-    @Publish(messages = [Message(messageId = OpdProduced, payload = Schema(HmppsDomainEvent::class))])
+    @Publish(messages = [Message(title = OpdProduced, payload = Schema(HmppsDomainEvent::class))])
     override fun handle(notification: Notification<HmppsDomainEvent>) {
         if (notification.message.eventType != OpdProduced) return
         val opdAssessment = notification.message.opdAssessment()

--- a/projects/prison-custody-status-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/Handler.kt
+++ b/projects/prison-custody-status-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/Handler.kt
@@ -35,10 +35,10 @@ class Handler(
 
     @Publish(
         messages = [
-            Message(messageId = "prison-offender-events.prisoner.released", payload = Schema(HmppsDomainEvent::class)),
-            Message(messageId = "prison-offender-events.prisoner.received", payload = Schema(HmppsDomainEvent::class)),
-            Message(messageId = "probation-case.prison-identifier.added", payload = Schema(HmppsDomainEvent::class)),
-            Message(messageId = "probation-case.prison-identifier.updated", payload = Schema(HmppsDomainEvent::class)),
+            Message(title = "prison-offender-events.prisoner.released", payload = Schema(HmppsDomainEvent::class)),
+            Message(title = "prison-offender-events.prisoner.received", payload = Schema(HmppsDomainEvent::class)),
+            Message(title = "probation-case.prison-identifier.added", payload = Schema(HmppsDomainEvent::class)),
+            Message(title = "probation-case.prison-identifier.updated", payload = Schema(HmppsDomainEvent::class)),
         ]
     )
     override fun handle(notification: Notification<HmppsDomainEvent>) {

--- a/projects/prison-identifier-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/Handler.kt
+++ b/projects/prison-identifier-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/Handler.kt
@@ -25,23 +25,23 @@ class Handler(
     @Publish(
         messages = [
             Message(
-                messageId = "prison-offender-events.prisoner.sentence-dates-changed",
+                title = "prison-offender-events.prisoner.sentence-dates-changed",
                 payload = Schema(HmppsDomainEvent::class)
             ),
             Message(
-                messageId = "prison-offender-events.prisoner.imprisonment-status-changed",
+                title = "prison-offender-events.prisoner.imprisonment-status-changed",
                 payload = Schema(HmppsDomainEvent::class)
             ),
-            Message(messageId = "prison-offender-events.prisoner.merged", payload = Schema(HmppsDomainEvent::class)),
-            Message(messageId = "OFFENDER_DETAILS_CHANGED", payload = Schema(OffenderEvent::class)),
-            Message(messageId = "SENTENCE_CHANGED", payload = Schema(OffenderEvent::class)),
+            Message(title = "prison-offender-events.prisoner.merged", payload = Schema(HmppsDomainEvent::class)),
+            Message(title = "OFFENDER_DETAILS_CHANGED", payload = Schema(OffenderEvent::class)),
+            Message(title = "SENTENCE_CHANGED", payload = Schema(OffenderEvent::class)),
             Message(
-                messageId = "prison-identifier.internal.prison-match-requested",
+                title = "prison-identifier.internal.prison-match-requested",
                 summary = "Internal use - attempt to match a case",
                 payload = Schema(HmppsDomainEvent::class)
             ),
             Message(
-                messageId = "prison-identifier.internal.probation-match-requested",
+                title = "prison-identifier.internal.probation-match-requested",
                 summary = "Internal use - attempt to match a case",
                 payload = Schema(HmppsDomainEvent::class)
             ),

--- a/projects/prison-identifier-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/Notifier.kt
+++ b/projects/prison-identifier-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/Notifier.kt
@@ -49,8 +49,8 @@ class Notifier(
 
     @Subscribe(
         messages = [
-            Message(messageId = "probation-case.prison-identifier.added", payload = Schema(HmppsDomainEvent::class)),
-            Message(messageId = "probation-case.prison-identifier.updated", payload = Schema(HmppsDomainEvent::class)),
+            Message(title = "probation-case.prison-identifier.added", payload = Schema(HmppsDomainEvent::class)),
+            Message(title = "probation-case.prison-identifier.updated", payload = Schema(HmppsDomainEvent::class)),
         ]
     )
     fun identifierAdded(crn: String, prisonIdentifiers: PrisonIdentifiers) {

--- a/templates/projects/message-listener-with-api-client/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/Handler.kt
+++ b/templates/projects/message-listener-with-api-client/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/Handler.kt
@@ -19,7 +19,7 @@ class Handler(
         messages = [
             // TODO list the event types here that this service will subscribe to. For example,
             // Message(name = "approved-premises/application-assessed"),
-            // Message(messageId = "probation-case.prison-identifier.added"),
+            // Message(title = "probation-case.prison-identifier.added"),
         ]
     )
     override fun handle(notification: Notification<HmppsDomainEvent>) {

--- a/templates/projects/message-listener/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/Handler.kt
+++ b/templates/projects/message-listener/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/Handler.kt
@@ -19,7 +19,7 @@ class Handler(
         messages = [
             // TODO list the event types here that this service will subscribe to. For example,
             // Message(name = "approved-premises/application-assessed"),
-            // Message(messageId = "probation-case.prison-identifier.added"),
+            // Message(title = "probation-case.prison-identifier.added"),
         ]
     )
     override fun handle(notification: Notification<HmppsDomainEvent>) {


### PR DESCRIPTION
Using `messageId` caused a conflict if the same `messageId` was referenced multiple times. This switches to use `title` instead, which results in the same output.