### PR TITLE
PI-2401 Move telemetry out of offence creation transaction

### DIFF
--- a/projects/manage-offences-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/Handler.kt
+++ b/projects/manage-offences-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/Handler.kt
@@ -4,34 +4,23 @@ import org.openfolder.kotlinasyncapi.annotation.channel.Channel
 import org.openfolder.kotlinasyncapi.annotation.channel.Message
 import org.openfolder.kotlinasyncapi.annotation.channel.Publish
 import org.springframework.stereotype.Component
-import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.client.ManageOffencesClient
 import uk.gov.justice.digital.hmpps.client.Offence
 import uk.gov.justice.digital.hmpps.config.IgnoredOffence.Companion.IGNORED_OFFENCES
 import uk.gov.justice.digital.hmpps.converter.NotificationConverter
-import uk.gov.justice.digital.hmpps.entity.DetailedOffence
-import uk.gov.justice.digital.hmpps.entity.OffenceRepository
-import uk.gov.justice.digital.hmpps.entity.ReferenceOffence
-import uk.gov.justice.digital.hmpps.entity.getByCode
-import uk.gov.justice.digital.hmpps.exception.NotFoundException
 import uk.gov.justice.digital.hmpps.message.HmppsDomainEvent
 import uk.gov.justice.digital.hmpps.message.Notification
-import uk.gov.justice.digital.hmpps.repository.DetailedOffenceRepository
-import uk.gov.justice.digital.hmpps.repository.ReferenceDataRepository
-import uk.gov.justice.digital.hmpps.repository.findCourtCategory
+import uk.gov.justice.digital.hmpps.service.OffenceService
 import uk.gov.justice.digital.hmpps.telemetry.TelemetryMessagingExtensions.notificationReceived
 import uk.gov.justice.digital.hmpps.telemetry.TelemetryService
 
 @Component
-@Transactional
 @Channel("manage-offences-and-delius-queue")
 class Handler(
     override val converter: NotificationConverter<HmppsDomainEvent>,
     private val telemetryService: TelemetryService,
     private val manageOffencesClient: ManageOffencesClient,
-    private val detailedOffenceRepository: DetailedOffenceRepository,
-    private val offenceRepository: OffenceRepository,
-    private val referenceDataRepository: ReferenceDataRepository
+    private val offenceService: OffenceService,
 ) : NotificationHandler<HmppsDomainEvent> {
     @Publish(messages = [Message(name = "manage-offences/offence-changed")])
     override fun handle(notification: Notification<HmppsDomainEvent>) {
@@ -44,68 +33,12 @@ class Handler(
             return
         }
 
-        mergeDetailedOffence(offence)
-        val isNew = createReferenceOffence(offence)
+        val isNew = offenceService.createOffence(offence)
 
         if (isNew) {
             telemetryService.trackEvent("OffenceCodeCreated", offence.telemetry)
         }
     }
-
-    private fun mergeDetailedOffence(offence: Offence) {
-        val existingEntity = detailedOffenceRepository.findByCode(offence.code)
-        detailedOffenceRepository.save(existingEntity.mergeWith(offence.toDetailedOffence()))
-    }
-
-    private fun createReferenceOffence(offence: Offence): Boolean {
-        val homeOfficeCode = offence.homeOfficeCode
-        return if (homeOfficeCode != null && offenceRepository.findByCode(homeOfficeCode) == null) {
-            val highLevelOffence = offenceRepository.getByCode(offence.highLevelCode!!)
-            offenceRepository.save(offence.toReferenceOffence(highLevelOffence))
-            true
-        } else false // entity already exists, don't update it
-    }
-
-    private fun Offence.toDetailedOffence() = DetailedOffence(
-        code = code,
-        description = description,
-        startDate = startDate,
-        endDate = endDate,
-        homeOfficeCode = homeOfficeStatsCode,
-        homeOfficeDescription = homeOfficeDescription,
-        legislation = legislation,
-        category = referenceDataRepository.findCourtCategory(offenceType)
-            ?: throw NotFoundException("Court category", "code", offenceType),
-        schedule15ViolentOffence = schedule15ViolentOffence,
-        schedule15SexualOffence = schedule15SexualOffence
-    )
-
-    private fun Offence.toReferenceOffence(highLevelOffence: ReferenceOffence) = ReferenceOffence(
-        code = homeOfficeCode!!,
-        description = "$homeOfficeDescription - $homeOfficeCode",
-        mainCategoryCode = mainCategoryCode!!,
-        selectable = false,
-        mainCategoryDescription = highLevelOffence.description.take(200),
-        mainCategoryAbbreviation = highLevelOffence.description.take(50),
-        ogrsOffenceCategoryId = highLevelOffence.ogrsOffenceCategoryId,
-        subCategoryCode = subCategoryCode!!,
-        subCategoryDescription = homeOfficeDescription!!.take(200),
-        form20Code = highLevelOffence.form20Code,
-        childAbduction = null,
-        schedule15ViolentOffence = schedule15ViolentOffence,
-        schedule15SexualOffence = schedule15SexualOffence
-    )
-
-    private fun DetailedOffence?.mergeWith(newEntity: DetailedOffence) = this?.apply {
-        code = newEntity.code
-        description = newEntity.description
-        startDate = newEntity.startDate
-        endDate = newEntity.endDate
-        homeOfficeCode = newEntity.homeOfficeCode
-        homeOfficeDescription = newEntity.homeOfficeDescription
-        legislation = newEntity.legislation
-        category = newEntity.category
-    } ?: newEntity
 }
 
 val HmppsDomainEvent.offenceCode get() = additionalInformation["offenceCode"] as String

--- a/projects/manage-offences-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/OffenceService.kt
+++ b/projects/manage-offences-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/OffenceService.kt
@@ -1,0 +1,82 @@
+package uk.gov.justice.digital.hmpps.service
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.client.Offence
+import uk.gov.justice.digital.hmpps.entity.DetailedOffence
+import uk.gov.justice.digital.hmpps.entity.OffenceRepository
+import uk.gov.justice.digital.hmpps.entity.ReferenceOffence
+import uk.gov.justice.digital.hmpps.entity.getByCode
+import uk.gov.justice.digital.hmpps.exception.NotFoundException
+import uk.gov.justice.digital.hmpps.repository.DetailedOffenceRepository
+import uk.gov.justice.digital.hmpps.repository.ReferenceDataRepository
+import uk.gov.justice.digital.hmpps.repository.findCourtCategory
+
+@Service
+@Transactional
+class OffenceService(
+    private val detailedOffenceRepository: DetailedOffenceRepository,
+    private val offenceRepository: OffenceRepository,
+    private val referenceDataRepository: ReferenceDataRepository
+) {
+    fun createOffence(offence: Offence): Boolean {
+        mergeDetailedOffence(offence)
+        val isNew = createReferenceOffence(offence)
+        return isNew
+    }
+
+    private fun mergeDetailedOffence(offence: Offence) {
+        val existingEntity = detailedOffenceRepository.findByCode(offence.code)
+        detailedOffenceRepository.save(existingEntity.mergeWith(offence.toDetailedOffence()))
+    }
+
+    private fun createReferenceOffence(offence: Offence): Boolean {
+        val homeOfficeCode = offence.homeOfficeCode
+        return if (homeOfficeCode != null && offenceRepository.findByCode(homeOfficeCode) == null) {
+            val highLevelOffence = offenceRepository.getByCode(offence.highLevelCode!!)
+            offenceRepository.save(offence.toReferenceOffence(highLevelOffence))
+            true
+        } else false // entity already exists, don't update it
+    }
+
+    private fun Offence.toDetailedOffence() = DetailedOffence(
+        code = code,
+        description = description,
+        startDate = startDate,
+        endDate = endDate,
+        homeOfficeCode = homeOfficeStatsCode,
+        homeOfficeDescription = homeOfficeDescription,
+        legislation = legislation,
+        category = referenceDataRepository.findCourtCategory(offenceType)
+            ?: throw NotFoundException("Court category", "code", offenceType),
+        schedule15ViolentOffence = schedule15ViolentOffence,
+        schedule15SexualOffence = schedule15SexualOffence
+    )
+
+    private fun Offence.toReferenceOffence(highLevelOffence: ReferenceOffence) = ReferenceOffence(
+        code = homeOfficeCode!!,
+        description = "$homeOfficeDescription - $homeOfficeCode",
+        mainCategoryCode = mainCategoryCode!!,
+        selectable = false,
+        mainCategoryDescription = highLevelOffence.description.take(200),
+        mainCategoryAbbreviation = highLevelOffence.description.take(50),
+        ogrsOffenceCategoryId = highLevelOffence.ogrsOffenceCategoryId,
+        subCategoryCode = subCategoryCode!!,
+        subCategoryDescription = homeOfficeDescription!!.take(200),
+        form20Code = highLevelOffence.form20Code,
+        childAbduction = null,
+        schedule15ViolentOffence = schedule15ViolentOffence,
+        schedule15SexualOffence = schedule15SexualOffence
+    )
+
+    private fun DetailedOffence?.mergeWith(newEntity: DetailedOffence) = this?.apply {
+        code = newEntity.code
+        description = newEntity.description
+        startDate = newEntity.startDate
+        endDate = newEntity.endDate
+        homeOfficeCode = newEntity.homeOfficeCode
+        homeOfficeDescription = newEntity.homeOfficeDescription
+        legislation = newEntity.legislation
+        category = newEntity.category
+    } ?: newEntity
+}

--- a/projects/manage-offences-and-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/messaging/HandlerTest.kt
+++ b/projects/manage-offences-and-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/messaging/HandlerTest.kt
@@ -1,29 +1,21 @@
 package uk.gov.justice.digital.hmpps.messaging
 
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
-import org.mockito.kotlin.check
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.client.ManageOffencesClient
 import uk.gov.justice.digital.hmpps.client.Offence
 import uk.gov.justice.digital.hmpps.converter.NotificationConverter
 import uk.gov.justice.digital.hmpps.data.generator.DataGenerator.COURT_CATEGORY
-import uk.gov.justice.digital.hmpps.data.generator.DataGenerator.HIGH_LEVEL_OFFENCE
-import uk.gov.justice.digital.hmpps.entity.OffenceRepository
-import uk.gov.justice.digital.hmpps.exception.NotFoundException
 import uk.gov.justice.digital.hmpps.message.HmppsDomainEvent
 import uk.gov.justice.digital.hmpps.message.Notification
-import uk.gov.justice.digital.hmpps.repository.DetailedOffenceRepository
-import uk.gov.justice.digital.hmpps.repository.ReferenceDataRepository
 import uk.gov.justice.digital.hmpps.resourceloader.ResourceLoader
+import uk.gov.justice.digital.hmpps.service.OffenceService
 import uk.gov.justice.digital.hmpps.telemetry.TelemetryMessagingExtensions.notificationReceived
 import uk.gov.justice.digital.hmpps.telemetry.TelemetryService
 import java.time.LocalDate
@@ -40,26 +32,10 @@ internal class HandlerTest {
     lateinit var manageOffencesClient: ManageOffencesClient
 
     @Mock
-    lateinit var detailedOffenceRepository: DetailedOffenceRepository
-
-    @Mock
-    lateinit var offenceRepository: OffenceRepository
-
-    @Mock
-    lateinit var referenceDataRepository: ReferenceDataRepository
+    lateinit var offenceService: OffenceService
 
     @InjectMocks
     lateinit var handler: Handler
-
-    @Test
-    fun `missing reference data is thrown`() {
-        val notification = Notification(ResourceLoader.event("offence-changed"))
-        val offenceCode = notification.message.offenceCode
-        whenever(manageOffencesClient.getOffence(offenceCode)).thenReturn(offence(offenceCode))
-
-        assertThrows<NotFoundException> { handler.handle(notification) }
-            .run { assertThat(message, equalTo("Court category with code of CS not found")) }
-    }
 
     @Test
     fun `home office codes of 22222 are ignored`() {
@@ -99,29 +75,13 @@ internal class HandlerTest {
     fun `offence is created`() {
         val notification = Notification(ResourceLoader.event("offence-changed"))
         val offence = offence(notification.message.offenceCode)
-        whenever(manageOffencesClient.getOffence(offence.code)).thenReturn(offence)
-        whenever(referenceDataRepository.findByCodeAndSetName(COURT_CATEGORY.code, COURT_CATEGORY.set.name))
-            .thenReturn(COURT_CATEGORY)
-        whenever(offenceRepository.findByCode(any())).thenReturn(null)
-        whenever(offenceRepository.findByCode(HIGH_LEVEL_OFFENCE.code)).thenReturn(HIGH_LEVEL_OFFENCE)
+        whenever(manageOffencesClient.getOffence(notification.message.offenceCode)).thenReturn(offence)
+        whenever(offenceService.createOffence(offence)).thenReturn(true)
 
         handler.handle(notification)
 
         verify(telemetryService).notificationReceived(notification)
-        verify(detailedOffenceRepository).save(check {
-            assertThat(it.id, equalTo(0))
-            assertThat(it.code, equalTo(offence.code))
-            assertThat(it.category, equalTo(COURT_CATEGORY))
-        })
-        verify(offenceRepository).save(check {
-            assertThat(it.id, equalTo(0))
-            assertThat(it.code, equalTo(offence.homeOfficeCode))
-            assertThat(it.description, equalTo("${offence.homeOfficeDescription} - ${offence.homeOfficeCode}"))
-            assertThat(it.mainCategoryCode, equalTo(HIGH_LEVEL_OFFENCE.mainCategoryCode))
-            assertThat(it.mainCategoryDescription, equalTo(HIGH_LEVEL_OFFENCE.description))
-            assertThat(it.subCategoryCode, equalTo(offence.subCategoryCode))
-            assertThat(it.subCategoryDescription, equalTo(offence.homeOfficeDescription))
-        })
+        verify(offenceService).createOffence(offence)
         verify(telemetryService).trackEvent(
             "OffenceCodeCreated",
             mapOf("offenceCode" to offence.code, "homeOfficeCode" to "09155"),

--- a/projects/manage-offences-and-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/service/OffenceServiceTest.kt
+++ b/projects/manage-offences-and-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/service/OffenceServiceTest.kt
@@ -1,0 +1,86 @@
+package uk.gov.justice.digital.hmpps.service
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.check
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.client.Offence
+import uk.gov.justice.digital.hmpps.data.generator.DataGenerator.COURT_CATEGORY
+import uk.gov.justice.digital.hmpps.data.generator.DataGenerator.HIGH_LEVEL_OFFENCE
+import uk.gov.justice.digital.hmpps.entity.OffenceRepository
+import uk.gov.justice.digital.hmpps.exception.NotFoundException
+import uk.gov.justice.digital.hmpps.message.Notification
+import uk.gov.justice.digital.hmpps.messaging.offenceCode
+import uk.gov.justice.digital.hmpps.repository.DetailedOffenceRepository
+import uk.gov.justice.digital.hmpps.repository.ReferenceDataRepository
+import uk.gov.justice.digital.hmpps.resourceloader.ResourceLoader
+import java.time.LocalDate
+
+@ExtendWith(MockitoExtension::class)
+internal class OffenceServiceTest {
+
+    @Mock
+    lateinit var detailedOffenceRepository: DetailedOffenceRepository
+
+    @Mock
+    lateinit var offenceRepository: OffenceRepository
+
+    @Mock
+    lateinit var referenceDataRepository: ReferenceDataRepository
+
+    @InjectMocks
+    lateinit var offenceService: OffenceService
+
+    @Test
+    fun `missing reference data is thrown`() {
+        val notification = Notification(ResourceLoader.event("offence-changed"))
+        val offenceCode = notification.message.offenceCode
+
+        assertThrows<NotFoundException> { offenceService.createOffence(offence(offenceCode)) }
+            .run { assertThat(message, equalTo("Court category with code of CS not found")) }
+    }
+
+    @Test
+    fun `offence is created`() {
+        val notification = Notification(ResourceLoader.event("offence-changed"))
+        val offence = offence(notification.message.offenceCode)
+        whenever(referenceDataRepository.findByCodeAndSetName(COURT_CATEGORY.code, COURT_CATEGORY.set.name))
+            .thenReturn(COURT_CATEGORY)
+        whenever(offenceRepository.findByCode(any())).thenReturn(null)
+        whenever(offenceRepository.findByCode(HIGH_LEVEL_OFFENCE.code)).thenReturn(HIGH_LEVEL_OFFENCE)
+
+        offenceService.createOffence(offence)
+
+        verify(detailedOffenceRepository).save(check {
+            assertThat(it.id, equalTo(0))
+            assertThat(it.code, equalTo(offence.code))
+            assertThat(it.category, equalTo(COURT_CATEGORY))
+        })
+        verify(offenceRepository).save(check {
+            assertThat(it.id, equalTo(0))
+            assertThat(it.code, equalTo(offence.homeOfficeCode))
+            assertThat(it.description, equalTo("${offence.homeOfficeDescription} - ${offence.homeOfficeCode}"))
+            assertThat(it.mainCategoryCode, equalTo(HIGH_LEVEL_OFFENCE.mainCategoryCode))
+            assertThat(it.mainCategoryDescription, equalTo(HIGH_LEVEL_OFFENCE.description))
+            assertThat(it.subCategoryCode, equalTo(offence.subCategoryCode))
+            assertThat(it.subCategoryDescription, equalTo(offence.homeOfficeDescription))
+        })
+    }
+
+    private fun offence(code: String = "AB12345", homeOfficeCode: String = "091/55") = Offence(
+        code = code,
+        description = "some offence",
+        offenceType = COURT_CATEGORY.code,
+        startDate = LocalDate.now(),
+        homeOfficeStatsCode = homeOfficeCode,
+        homeOfficeDescription = "Some Offence Description",
+    )
+}


### PR DESCRIPTION
To prevent duplicate entries in the offence report for failures