### PR TITLE
Only create flipt dashboard in dev namespace

### DIFF
--- a/projects/feature-flags/deploy/templates/grafana-dashboards.yml
+++ b/projects/feature-flags/deploy/templates/grafana-dashboards.yml
@@ -1,3 +1,4 @@
+{{- if eq .Release.Namespace "hmpps-probation-integration-services-dev" -}}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -17,3 +18,4 @@ metadata:
     grafana_dashboard: ""
 data:
 {{ (.Files.Glob "grafana/flipt-system.json").AsConfig | indent 2 }}
+{{- end -}}


### PR DESCRIPTION
The dashboard is shared across dev/preprod/prod, so only needs to be created once. Attempting to create it 3 times is currently causing errors in Grafana.