### PR TITLE
PI-2551 Fix reminder appearing when there are no deployments

### DIFF
--- a/.github/workflows/reminders.yml
+++ b/.github/workflows/reminders.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Transform results into Slack message
         id: transform
-        if: fromJson(steps.runs.outputs.pending) != '[]'
+        if: steps.runs.outputs.pending != '[]'
         shell: bash
         run: |
           echo "result=$(echo "$pending_runs" | jq -rc '. |
@@ -62,7 +62,7 @@ jobs:
           pending_runs: ${{ steps.runs.outputs.pending }}
 
       - name: Send message to Slack
-        if: fromJSON(steps.runs.outputs.pending) != '[]'
+        if: steps.runs.outputs.pending != '[]'
         uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
         with:
           channel-id: probation-integration-notifications


### PR DESCRIPTION
Tested here: https://github.com/ministryofjustice/hmpps-probation-integration-services/actions/runs/11048772817