### PR TITLE
PI-2572 Only end CAS3 address if start date is before end date

### DIFF
--- a/projects/cas3-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/CASIntegrationTest.kt
+++ b/projects/cas3-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/CASIntegrationTest.kt
@@ -19,7 +19,7 @@ import org.springframework.boot.test.mock.mockito.MockBean
 import uk.gov.justice.digital.hmpps.data.generator.ProviderGenerator
 import uk.gov.justice.digital.hmpps.datetime.DeliusDateTimeFormatter
 import uk.gov.justice.digital.hmpps.datetime.EuropeLondon
-import uk.gov.justice.digital.hmpps.integrations.approvedpremesis.*
+import uk.gov.justice.digital.hmpps.integrations.approvedpremises.*
 import uk.gov.justice.digital.hmpps.integrations.delius.entity.ContactRepository
 import uk.gov.justice.digital.hmpps.integrations.delius.entity.PersonAddressRepository
 import uk.gov.justice.digital.hmpps.integrations.delius.entity.PersonRepository

--- a/projects/cas3-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/config/RestClientConfig.kt
+++ b/projects/cas3-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/config/RestClientConfig.kt
@@ -4,7 +4,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.client.RestClient
 import uk.gov.justice.digital.hmpps.config.security.createClient
-import uk.gov.justice.digital.hmpps.integrations.approvedpremesis.Cas3ApiClient
+import uk.gov.justice.digital.hmpps.integrations.approvedpremises.Cas3ApiClient
 
 @Configuration
 class RestClientConfig(private val oauth2Client: RestClient) {

--- a/projects/cas3-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/approvedpremises/Cas3ApiClient.kt
+++ b/projects/cas3-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/approvedpremises/Cas3ApiClient.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.integrations.approvedpremesis
+package uk.gov.justice.digital.hmpps.integrations.approvedpremises
 
 import org.springframework.web.service.annotation.GetExchange
 import java.net.URI

--- a/projects/cas3-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/approvedpremises/EventDetails.kt
+++ b/projects/cas3-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/approvedpremises/EventDetails.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.integrations.approvedpremesis
+package uk.gov.justice.digital.hmpps.integrations.approvedpremises
 
 import uk.gov.justice.digital.hmpps.datetime.DeliusDateFormatter
 import uk.gov.justice.digital.hmpps.integrations.delius.entity.ContactType

--- a/projects/cas3-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/AddressService.kt
+++ b/projects/cas3-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/AddressService.kt
@@ -1,10 +1,9 @@
 package uk.gov.justice.digital.hmpps.integrations.delius
 
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.integrations.approvedpremesis.PersonArrived
+import uk.gov.justice.digital.hmpps.integrations.approvedpremises.PersonArrived
 import uk.gov.justice.digital.hmpps.integrations.delius.entity.*
 import java.time.LocalDate
-import java.time.ZonedDateTime
 
 @Service
 class AddressService(
@@ -44,14 +43,14 @@ class AddressService(
         }
     }
 
-    fun endMainCAS3Address(person: Person, endDate: ZonedDateTime) {
+    fun endMainCAS3Address(person: Person, endDate: LocalDate) {
         personRepository.findForUpdate(person.id)
         val currentMain = personAddressRepository.findMainAddress(person.id)
         currentMain?.apply {
-            if (currentMain.type.code == AddressTypeCode.CAS3.code) {
+            if (currentMain.type.code == AddressTypeCode.CAS3.code && currentMain.startDate <= endDate) {
                 val previousStatus = referenceDataRepository.previousAddressStatus()
                 currentMain.status = previousStatus
-                currentMain.endDate = endDate.toLocalDate()
+                currentMain.endDate = endDate
             }
         }
     }

--- a/projects/cas3-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/ContactService.kt
+++ b/projects/cas3-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/ContactService.kt
@@ -4,10 +4,10 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.audit.service.AuditableService
 import uk.gov.justice.digital.hmpps.audit.service.AuditedInteractionService
 import uk.gov.justice.digital.hmpps.exception.NotFoundException
-import uk.gov.justice.digital.hmpps.integrations.approvedpremesis.By
-import uk.gov.justice.digital.hmpps.integrations.approvedpremesis.Cas3Event
-import uk.gov.justice.digital.hmpps.integrations.approvedpremesis.EventDetails
-import uk.gov.justice.digital.hmpps.integrations.approvedpremesis.Recordable
+import uk.gov.justice.digital.hmpps.integrations.approvedpremises.By
+import uk.gov.justice.digital.hmpps.integrations.approvedpremises.Cas3Event
+import uk.gov.justice.digital.hmpps.integrations.approvedpremises.EventDetails
+import uk.gov.justice.digital.hmpps.integrations.approvedpremises.Recordable
 import uk.gov.justice.digital.hmpps.integrations.delius.audit.BusinessInteractionCode
 import uk.gov.justice.digital.hmpps.integrations.delius.entity.*
 import uk.gov.justice.digital.hmpps.telemetry.TelemetryService

--- a/projects/cas3-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/ProviderService.kt
+++ b/projects/cas3-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/ProviderService.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.integrations.delius
 
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.integrations.approvedpremesis.By
+import uk.gov.justice.digital.hmpps.integrations.approvedpremises.By
 import uk.gov.justice.digital.hmpps.integrations.delius.entity.*
 import uk.gov.justice.digital.hmpps.telemetry.TelemetryService
 

--- a/projects/cas3-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/Handler.kt
+++ b/projects/cas3-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/Handler.kt
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.converter.NotificationConverter
 import uk.gov.justice.digital.hmpps.datetime.DeliusDateTimeFormatter
-import uk.gov.justice.digital.hmpps.integrations.approvedpremesis.Cas3ApiClient
+import uk.gov.justice.digital.hmpps.integrations.approvedpremises.Cas3ApiClient
 import uk.gov.justice.digital.hmpps.integrations.delius.AddressService
 import uk.gov.justice.digital.hmpps.integrations.delius.ContactService
 import uk.gov.justice.digital.hmpps.integrations.delius.entity.PersonRepository
@@ -118,7 +118,7 @@ class Handler(
                 contactService.createOrUpdateContact(event.crn(), person) {
                     detail
                 }
-                addressService.endMainCAS3Address(person, detail.eventDetails.departedAt)
+                addressService.endMainCAS3Address(person, detail.eventDetails.departedAt.toLocalDate())
                 telemetryService.trackEvent("PersonDeparted", event.telemetryProperties())
             }
 

--- a/projects/cas3-and-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/integrations/approvedpremises/AddressTest.kt
+++ b/projects/cas3-and-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/integrations/approvedpremises/AddressTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.integrations.approvedpremesis
+package uk.gov.justice.digital.hmpps.integrations.approvedpremises
 
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo

--- a/projects/cas3-and-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/integrations/approvedpremises/EventDetailsTest.kt
+++ b/projects/cas3-and-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/integrations/approvedpremises/EventDetailsTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.integrations.approvedpremesis
+package uk.gov.justice.digital.hmpps.integrations.approvedpremises
 
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo

--- a/projects/cas3-and-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/ProviderServiceTest.kt
+++ b/projects/cas3-and-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/ProviderServiceTest.kt
@@ -8,7 +8,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.data.generator.ProviderGenerator
-import uk.gov.justice.digital.hmpps.integrations.approvedpremesis.By
+import uk.gov.justice.digital.hmpps.integrations.approvedpremises.By
 import uk.gov.justice.digital.hmpps.integrations.delius.entity.ProviderRepository
 import uk.gov.justice.digital.hmpps.integrations.delius.entity.StaffRepository
 import uk.gov.justice.digital.hmpps.integrations.delius.entity.TeamRepository


### PR DESCRIPTION
If the start date is unexpectedly after the end date, then the case must have moved on and the current CAS3 address will be for a different booking.

Also fixed typo in package name.