### PR TITLE
PI-2543 Update UPW custody check

### DIFF
--- a/projects/appointment-reminders-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/IntegrationTest.kt
+++ b/projects/appointment-reminders-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/IntegrationTest.kt
@@ -34,10 +34,9 @@ internal class IntegrationTest {
                     override val firstName = "Test"
                     override val mobileNumber = "07000000000"
                     override val appointmentDate = "01/01/2000"
-                    override val appointmentTimes = "08:00, 11:00"
                     override val crn = "A123456"
-                    override val eventNumber = "1"
-                    override val upwAppointmentId = "123"
+                    override val eventNumbers = "1"
+                    override val upwAppointmentIds = "123, 456"
                 }
             )
         )
@@ -49,8 +48,8 @@ internal class IntegrationTest {
             .andExpect(
                 content().string(
                     """
-                    firstName,mobileNumber,appointmentDate,appointmentTimes,crn,eventNumber,upwAppointmentId
-                    Test,07000000000,01/01/2000,"08:00, 11:00",A123456,1,123
+                    firstName,mobileNumber,appointmentDate,crn,eventNumbers,upwAppointmentIds
+                    Test,07000000000,01/01/2000,A123456,1,"123, 456"
                     
                     """.trimIndent()
                 )

--- a/projects/appointment-reminders-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/model/UnpaidWorkAppointment.kt
+++ b/projects/appointment-reminders-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/model/UnpaidWorkAppointment.kt
@@ -6,17 +6,15 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder
     "firstName",
     "mobileNumber",
     "appointmentDate",
-    "appointmentTimes",
     "crn",
-    "eventNumber",
-    "upwAppointmentId",
+    "eventNumbers",
+    "upwAppointmentIds",
 )
 interface UnpaidWorkAppointment {
     val firstName: String
     val mobileNumber: String
     val appointmentDate: String
-    val appointmentTimes: String
     val crn: String
-    val eventNumber: String
-    val upwAppointmentId: String
+    val eventNumbers: String
+    val upwAppointmentIds: String
 }

--- a/projects/appointment-reminders-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/repository/UpwAppointmentRepository.kt
+++ b/projects/appointment-reminders-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/repository/UpwAppointmentRepository.kt
@@ -13,17 +13,15 @@ interface UpwAppointmentRepository : JpaRepository<UpwAppointment, Long> {
             any_value(first_name) as "firstName",
             any_value(mobile_number) as "mobileNumber", 
             any_value(to_char(appointment_date, 'DD/MM/YYYY')) as "appointmentDate",
-            listagg(distinct to_char(appointment_time, 'HH24:MI'), ', ') as "appointmentTimes",
             -- for testing --
             crn as "crn",
-            listagg(distinct event_number, ', ') as "eventNumber",
-            listagg(distinct upw_appointment_id, ', ') as "upwAppointmentId"
+            listagg(distinct event_number, ', ') as "eventNumbers",
+            listagg(distinct upw_appointment_id, ', ') as "upwAppointmentIds"
         from (
             select
                 first_name,
                 replace(mobile_number, ' ', '') as mobile_number,
                 upw_appointment.appointment_date as appointment_date,
-                (upw_appointment.start_time - trunc(upw_appointment.start_time)) as appointment_time,
                 crn,
                 event_number,
                 upw_appointment.upw_appointment_id
@@ -37,8 +35,6 @@ interface UpwAppointmentRepository : JpaRepository<UpwAppointment, Long> {
             join upw_project on upw_project.upw_project_id = upw_appointment.upw_project_id
             join r_standard_reference_list upw_project_type on upw_project_type.standard_reference_list_id = upw_project.project_type_id and upw_project_type.code_value in ('ES','ICP','NP1','NP2','PI','PIP','PIP2','PL','PS','PSP','WH1')
             join probation_area on probation_area.probation_area_id = upw_project.probation_area_id and probation_area.code = :providerCode
-            left join custody on custody.disposal_id = disposal.disposal_id and custody.soft_deleted = 0
-            left join r_standard_reference_list custodial_status on custodial_status.standard_reference_list_id = custody.custodial_status_id
             left join exclusion on exclusion.offender_id = offender.offender_id and exclusion_date < current_date and (exclusion_end_date is null or current_date < exclusion_end_date)
             left join restriction on restriction.offender_id = offender.offender_id and restriction_date < current_date and (restriction_end_date is null or current_date < restriction_end_date)
             where offender.soft_deleted = 0 
@@ -49,7 +45,7 @@ interface UpwAppointmentRepository : JpaRepository<UpwAppointment, Long> {
             and (allow_sms is null or allow_sms = 'Y')
             -- no other cases with the same mobile number
             and not exists (
-                select 1 from offender duplicate where duplicate.offender_id <> offender.offender_id and duplicate.soft_deleted = 0 and replace(duplicate.mobile_number, ' ', '') = replace(offender.mobile_number, ' ', '')
+                select 1 from offender duplicate where duplicate.soft_deleted = 0 and replace(duplicate.mobile_number, ' ', '') = replace(offender.mobile_number, ' ', '') and duplicate.offender_id <> offender.offender_id
             )
             -- has an active unpaid work requirement
             and exists (select 1 from rqmnt 
@@ -74,7 +70,11 @@ interface UpwAppointmentRepository : JpaRepository<UpwAppointment, Long> {
             -- appointment does not have an outcome
             and r_contact_outcome_type.description is null
             -- not in custody
-            and (custodial_status.code_value is null or custodial_status.code_value not in ('A', 'C', 'D'))
+            and not exists (select 1 from custody 
+                join disposal custody_disposal on custody_disposal.disposal_id = custody.disposal_id and custody_disposal.active_flag = 1 and custody_disposal.soft_deleted = 0
+                join event custody_event on custody_event.event_id = custody_disposal.event_id and custody_event.offender_id = offender.offender_id and custody_event.active_flag = 1 and custody_event.soft_deleted = 0
+                join r_standard_reference_list custodial_status on custodial_status.standard_reference_list_id = custody.custodial_status_id and custodial_status.code_value in ('A', 'C', 'D')
+                where custody.soft_deleted = 0)
             -- not on remand
             and (current_remand_status is null or (current_remand_status not in ('Warrant With Bail', 'Warrant Without Bail', 'Remanded In Custody', 'Unlawfully at Large') and current_remand_status not like 'UAL%'))
             and not exists (select 1 from personal_circumstance 


### PR DESCRIPTION
The query now excludes cases that have an upcoming unpaid work appointment on one event, but another event showing as "in custody".  This can happen when someone is recalled or receives a new custodial sentence while completing unpaid work, and the future unpaid work appointments haven't yet been cleared down.