### PR TITLE
PI-2616 Don't attempt to drop schema when using TestContainers

### DIFF
--- a/projects/appointment-reminders-and-delius/src/main/resources/application.yml
+++ b/projects/appointment-reminders-and-delius/src/main/resources/application.yml
@@ -62,7 +62,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/projects/arns-and-delius/src/main/resources/application.yml
+++ b/projects/arns-and-delius/src/main/resources/application.yml
@@ -57,7 +57,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/projects/assessment-summary-and-delius/src/main/resources/application.yml
+++ b/projects/assessment-summary-and-delius/src/main/resources/application.yml
@@ -70,7 +70,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/projects/cas2-and-delius/src/main/resources/application.yml
+++ b/projects/cas2-and-delius/src/main/resources/application.yml
@@ -75,7 +75,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/projects/cas3-and-delius/src/main/resources/application.yml
+++ b/projects/cas3-and-delius/src/main/resources/application.yml
@@ -73,7 +73,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/projects/core-person-record-and-delius/src/main/resources/application.yml
+++ b/projects/core-person-record-and-delius/src/main/resources/application.yml
@@ -55,7 +55,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/projects/court-case-and-delius/src/main/resources/application.yml
+++ b/projects/court-case-and-delius/src/main/resources/application.yml
@@ -87,7 +87,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/projects/create-and-vary-a-licence-and-delius/src/main/resources/application.yml
+++ b/projects/create-and-vary-a-licence-and-delius/src/main/resources/application.yml
@@ -80,7 +80,9 @@ messaging.consumer.queue: message-queue
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/projects/custody-key-dates-and-delius/src/main/resources/application.yml
+++ b/projects/custody-key-dates-and-delius/src/main/resources/application.yml
@@ -80,7 +80,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/projects/domain-events-and-delius/src/main/resources/application.yml
+++ b/projects/domain-events-and-delius/src/main/resources/application.yml
@@ -68,7 +68,9 @@ poller:
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/projects/dps-and-delius/src/main/resources/application.yml
+++ b/projects/dps-and-delius/src/main/resources/application.yml
@@ -60,7 +60,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/projects/effective-proposal-framework-and-delius/src/main/resources/application.yml
+++ b/projects/effective-proposal-framework-and-delius/src/main/resources/application.yml
@@ -57,7 +57,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/projects/external-api-and-delius/src/main/resources/application.yml
+++ b/projects/external-api-and-delius/src/main/resources/application.yml
@@ -62,7 +62,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/projects/hdc-licences-and-delius/src/main/resources/application.yml
+++ b/projects/hdc-licences-and-delius/src/main/resources/application.yml
@@ -65,7 +65,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/projects/hmpps-auth-and-delius/src/main/resources/application.yml
+++ b/projects/hmpps-auth-and-delius/src/main/resources/application.yml
@@ -66,7 +66,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/projects/ims-and-delius/src/main/resources/application.yml
+++ b/projects/ims-and-delius/src/main/resources/application.yml
@@ -64,7 +64,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/projects/make-recall-decisions-and-delius/src/main/resources/application.yml
+++ b/projects/make-recall-decisions-and-delius/src/main/resources/application.yml
@@ -78,7 +78,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/projects/manage-offences-and-delius/src/main/resources/application.yml
+++ b/projects/manage-offences-and-delius/src/main/resources/application.yml
@@ -73,7 +73,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/projects/manage-pom-cases-and-delius/src/main/resources/application.yml
+++ b/projects/manage-pom-cases-and-delius/src/main/resources/application.yml
@@ -78,7 +78,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/projects/manage-supervision-and-delius/src/main/resources/application.yml
+++ b/projects/manage-supervision-and-delius/src/main/resources/application.yml
@@ -68,7 +68,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/projects/oasys-and-delius/src/main/resources/application.yml
+++ b/projects/oasys-and-delius/src/main/resources/application.yml
@@ -56,7 +56,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/projects/offender-events-and-delius/src/main/resources/application.yml
+++ b/projects/offender-events-and-delius/src/main/resources/application.yml
@@ -60,7 +60,9 @@ offender-events:
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/projects/opd-and-delius/src/main/resources/application.yml
+++ b/projects/opd-and-delius/src/main/resources/application.yml
@@ -63,7 +63,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/projects/pathfinder-and-delius/src/main/resources/application.yml
+++ b/projects/pathfinder-and-delius/src/main/resources/application.yml
@@ -65,7 +65,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/projects/pre-sentence-reports-to-delius/src/main/resources/application.yml
+++ b/projects/pre-sentence-reports-to-delius/src/main/resources/application.yml
@@ -86,7 +86,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/projects/prison-case-notes-to-probation/src/main/resources/application.yml
+++ b/projects/prison-case-notes-to-probation/src/main/resources/application.yml
@@ -80,7 +80,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/projects/prison-custody-status-to-delius/src/main/resources/application.yml
+++ b/projects/prison-custody-status-to-delius/src/main/resources/application.yml
@@ -71,7 +71,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/projects/prison-education-and-delius/src/main/resources/application.yml
+++ b/projects/prison-education-and-delius/src/main/resources/application.yml
@@ -62,7 +62,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/projects/prison-identifier-and-delius/src/main/resources/application.yml
+++ b/projects/prison-identifier-and-delius/src/main/resources/application.yml
@@ -81,7 +81,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/projects/prisoner-profile-and-delius/src/main/resources/application.yml
+++ b/projects/prisoner-profile-and-delius/src/main/resources/application.yml
@@ -63,7 +63,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/projects/probation-search-and-delius/src/main/resources/application.yml
+++ b/projects/probation-search-and-delius/src/main/resources/application.yml
@@ -58,7 +58,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/projects/refer-and-monitor-and-delius/src/main/resources/application.yml
+++ b/projects/refer-and-monitor-and-delius/src/main/resources/application.yml
@@ -78,7 +78,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/projects/resettlement-passport-and-delius/src/main/resources/application.yml
+++ b/projects/resettlement-passport-and-delius/src/main/resources/application.yml
@@ -63,7 +63,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/projects/sentence-plan-and-delius/src/main/resources/application.yml
+++ b/projects/sentence-plan-and-delius/src/main/resources/application.yml
@@ -57,7 +57,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/projects/soc-and-delius/src/main/resources/application.yml
+++ b/projects/soc-and-delius/src/main/resources/application.yml
@@ -57,7 +57,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/projects/subject-access-requests-and-delius/src/main/resources/application.yml
+++ b/projects/subject-access-requests-and-delius/src/main/resources/application.yml
@@ -57,7 +57,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/projects/tier-to-delius/src/main/resources/application.yml
+++ b/projects/tier-to-delius/src/main/resources/application.yml
@@ -76,7 +76,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/projects/unpaid-work-and-delius/src/main/resources/application.yml
+++ b/projects/unpaid-work-and-delius/src/main/resources/application.yml
@@ -78,7 +78,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/projects/workforce-allocations-to-delius/src/main/resources/application.yml
+++ b/projects/workforce-allocations-to-delius/src/main/resources/application.yml
@@ -89,7 +89,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/templates/projects/api-client-and-server/src/main/resources/application.yml
+++ b/templates/projects/api-client-and-server/src/main/resources/application.yml
@@ -76,7 +76,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/templates/projects/api-server/src/main/resources/application.yml
+++ b/templates/projects/api-server/src/main/resources/application.yml
@@ -57,7 +57,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/templates/projects/message-listener-with-api-client-and-server/src/main/resources/application.yml
+++ b/templates/projects/message-listener-with-api-client-and-server/src/main/resources/application.yml
@@ -78,7 +78,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/templates/projects/message-listener-with-api-client/src/main/resources/application.yml
+++ b/templates/projects/message-listener-with-api-client/src/main/resources/application.yml
@@ -73,7 +73,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db

--- a/templates/projects/message-listener/src/main/resources/application.yml
+++ b/templates/projects/message-listener/src/main/resources/application.yml
@@ -53,7 +53,9 @@ spring.datasource.url: jdbc:h2:mem:./test;MODE=Oracle;DEFAULT_NULL_ORDERING=HIGH
 
 ---
 spring.config.activate.on-profile: oracle
-spring.datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+spring:
+  datasource.url: 'jdbc:tc:oracle:slim-faststart:///XEPDB1'
+  jpa.hibernate.ddl-auto: create
 
 ---
 spring.config.activate.on-profile: delius-db


### PR DESCRIPTION
This resolves connection errors at the end of the integration tests, and it shaves ~1 minute off the build time for each project - which is a nice saving

* Before:
```
SPRING_PROFILES_ACTIVE=integration-test,oracle ./gradlew clean approved-premises-and-delius:integrationTest --no-build-cache
...
BUILD SUCCESSFUL in 3m 41s
89 actionable tasks: 26 executed, 63 up-to-date
```

* After:
```
SPRING_PROFILES_ACTIVE=integration-test,oracle ./gradlew clean approved-premises-and-delius:integrationTest --no-build-cache
...
BUILD SUCCESSFUL in 2m 46s
89 actionable tasks: 26 executed, 63 up-to-date
```