### PR TITLE
PI-2624 Remove .git directory during Gradle build

### DIFF
--- a/.github/actions/get-build-info/action.yml
+++ b/.github/actions/get-build-info/action.yml
@@ -28,7 +28,7 @@ runs:
       with:
         cache-encryption-key: ${{ inputs.gradle-encryption-key }}
         cache-read-only: true
-        remove-git-config: false
+        remove-git-dir: false
 
     - name: Get build info
       if: ${{ steps.gradle_file.outputs.files_exists == 'true' }}

--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -14,8 +14,8 @@ inputs:
       A suitable key can be generated with `openssl rand -base64 16`.
       Configuration-cache data will not be saved/restored without an encryption key being provided.
     required: false
-  remove-git-config:
-    description: Whether to remove the git config file to prevent configuration cache invalidation.
+  remove-git-dir:
+    description: Whether to remove the .git directory to prevent configuration cache invalidation.
     required: false
     default: 'true'
 
@@ -35,6 +35,6 @@ runs:
       with:
         path: buildSrc/build
         key: gradle-buildSrc-${{ hashFiles('buildSrc/src/**', 'buildSrc/build.gradle.kts') }}
-    - if: inputs.remove-git-config == 'true'
-      run: rm -f .git/config
+    - if: inputs.remove-git-dir == 'true'
+      run: rm -rf .git
       shell: bash


### PR DESCRIPTION
Fixes cache invalidation errors: https://github.com/ministryofjustice/hmpps-probation-integration-services/actions/runs/11738620858/job/32701483985#step:5:20
```
Calculating task graph as configuration cache cannot be reused because the file system entry '.git/.probe-58218911-f51a-4ad7-bc53-06cd11b090a6' has been removed.
```