### PR TITLE
APS-1482 - Refactor GET case-detail endpoint to include offence categories

### DIFF
--- a/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/OffenceGenerator.kt
+++ b/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/OffenceGenerator.kt
@@ -7,11 +7,11 @@ import uk.gov.justice.digital.hmpps.integrations.delius.person.offence.entity.Of
 import java.time.LocalDate
 
 object OffenceGenerator {
-    val OFFENCE_ONE = generate("OFF1", "Offence One")
-    val OFFENCE_TWO = generate("OFF2", "Offence Two")
+    val OFFENCE_ONE = generate("OFF1", "Murder - OFF1", "Murder", "Murder of spouse")
+    val OFFENCE_TWO = generate("OFF2", "Burglary in a dwelling - OFF2", "Burglary in a dwelling", "Burglary (dwelling) with intent to commit, or the commission of, an offence triable only on indictment")
 
-    fun generate(code: String, description: String, id: Long = IdGenerator.getAndIncrement()) =
-        Offence(code, description, id)
+    fun generate(code: String, description: String, mainCategoryDescription: String, subCategoryDescription: String, id: Long = IdGenerator.getAndIncrement()) =
+        Offence(code, description, mainCategoryDescription, subCategoryDescription, id)
 
     fun generateMainOffence(
         event: Event,

--- a/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/OffenceGenerator.kt
+++ b/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/OffenceGenerator.kt
@@ -8,9 +8,20 @@ import java.time.LocalDate
 
 object OffenceGenerator {
     val OFFENCE_ONE = generate("OFF1", "Murder - OFF1", "Murder", "Murder of spouse")
-    val OFFENCE_TWO = generate("OFF2", "Burglary in a dwelling - OFF2", "Burglary in a dwelling", "Burglary (dwelling) with intent to commit, or the commission of, an offence triable only on indictment")
+    val OFFENCE_TWO = generate(
+        "OFF2",
+        "Burglary in a dwelling - OFF2",
+        "Burglary in a dwelling",
+        "Burglary (dwelling) with intent to commit, or the commission of, an offence triable only on indictment"
+    )
 
-    fun generate(code: String, description: String, mainCategoryDescription: String, subCategoryDescription: String, id: Long = IdGenerator.getAndIncrement()) =
+    fun generate(
+        code: String,
+        description: String,
+        mainCategoryDescription: String,
+        subCategoryDescription: String,
+        id: Long = IdGenerator.getAndIncrement()
+    ) =
         Offence(code, description, mainCategoryDescription, subCategoryDescription, id)
 
     fun generateMainOffence(

--- a/projects/approved-premises-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/ProbationCaseIntegrationTest.kt
+++ b/projects/approved-premises-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/ProbationCaseIntegrationTest.kt
@@ -71,12 +71,16 @@ class ProbationCaseIntegrationTest {
         assertThat(detail.registrations.map { it.description }, equalTo(listOf("Description of ARSO")))
         val mainOffence = detail.offences.first { it.main }
         assertThat(mainOffence.id, equalTo("M200001"))
-        assertThat(mainOffence.description, equalTo("Offence One"))
+        assertThat(mainOffence.description, equalTo("Murder - OFF1"))
+        assertThat(mainOffence.mainCategoryDescription, equalTo("Murder"))
+        assertThat(mainOffence.subCategoryDescription, equalTo("Murder of spouse"))
         assertThat(mainOffence.date, equalTo(LocalDate.parse("2024-10-11")))
         assertThat(mainOffence.eventId, equalTo(100001L))
         val otherOffence = detail.offences.first { !it.main }
         assertThat(otherOffence.id, equalTo("A300001"))
-        assertThat(otherOffence.description, equalTo("Offence Two"))
+        assertThat(otherOffence.description, equalTo("Burglary in a dwelling - OFF2"))
+        assertThat(otherOffence.mainCategoryDescription, equalTo("Burglary in a dwelling"))
+        assertThat(otherOffence.subCategoryDescription, equalTo("Burglary (dwelling) with intent to commit, or the commission of, an offence triable only on indictment"))
         assertThat(otherOffence.date, equalTo(LocalDate.parse("2024-10-21")))
         assertThat(otherOffence.eventId, equalTo(100001L))
         assertThat(detail.careLeaver, equalTo(false))

--- a/projects/approved-premises-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/ProbationCaseIntegrationTest.kt
+++ b/projects/approved-premises-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/ProbationCaseIntegrationTest.kt
@@ -80,7 +80,10 @@ class ProbationCaseIntegrationTest {
         assertThat(otherOffence.id, equalTo("A300001"))
         assertThat(otherOffence.description, equalTo("Burglary in a dwelling - OFF2"))
         assertThat(otherOffence.mainCategoryDescription, equalTo("Burglary in a dwelling"))
-        assertThat(otherOffence.subCategoryDescription, equalTo("Burglary (dwelling) with intent to commit, or the commission of, an offence triable only on indictment"))
+        assertThat(
+            otherOffence.subCategoryDescription,
+            equalTo("Burglary (dwelling) with intent to commit, or the commission of, an offence triable only on indictment")
+        )
         assertThat(otherOffence.date, equalTo(LocalDate.parse("2024-10-21")))
         assertThat(otherOffence.eventId, equalTo(100001L))
         assertThat(detail.careLeaver, equalTo(false))

--- a/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/person/offence/entity/Offence.kt
+++ b/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/person/offence/entity/Offence.kt
@@ -12,6 +12,8 @@ interface CaseOffence {
     val id: Long
     val code: String
     val description: String
+    val mainCategoryDescription: String
+    val subCategoryDescription: String
     val date: LocalDate?
     val main: Boolean
     val eventNumber: String
@@ -79,6 +81,12 @@ class Offence(
     @Column
     val description: String,
 
+    @Column(name = "main_category_description")
+    private var mainCategoryDescription: String,
+
+    @Column(name = "sub_category_description")
+    private val subCategoryDescription: String,
+
     @Id
     @Column(name = "offence_id")
     val id: Long
@@ -91,6 +99,8 @@ interface MainOffenceRepository : JpaRepository<MainOffence, Long> {
             mo.id as id,
             mo.offence.code as code, 
             mo.offence.description as description, 
+            mo.offence.mainCategoryDescription as mainCategoryDescription, 
+            mo.offence.subCategoryDescription as subCategoryDescription, 
             mo.date as date, 
             true as main, 
             mo.event.number as eventNumber,
@@ -102,6 +112,8 @@ interface MainOffenceRepository : JpaRepository<MainOffence, Long> {
             ao.id,
             ao.offence.code, 
             ao.offence.description, 
+            ao.offence.mainCategoryDescription as mainCategoryDescription, 
+            ao.offence.subCategoryDescription as subCategoryDescription, 
             ao.date, 
             false, 
             ao.event.number,

--- a/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/model/CaseDetail.kt
+++ b/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/model/CaseDetail.kt
@@ -62,6 +62,8 @@ data class Offence(
     val id: String,
     val code: String,
     val description: String,
+    val mainCategoryDescription: String,
+    val subCategoryDescription: String,
     val date: LocalDate?,
     val main: Boolean,
     val eventId: Long,

--- a/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/CaseService.kt
+++ b/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/CaseService.kt
@@ -88,7 +88,17 @@ fun CommunityManager.team() = Team(
 )
 
 fun CaseOffence.asOffence() =
-    Offence(id = if (main) "M$id" else "A$id", code, description, mainCategoryDescription, subCategoryDescription, date, main, eventId, eventNumber)
+    Offence(
+        id = if (main) "M$id" else "A$id",
+        code,
+        description,
+        mainCategoryDescription,
+        subCategoryDescription,
+        date,
+        main,
+        eventId,
+        eventNumber
+    )
 
 fun Registration.asRegistration() = uk.gov.justice.digital.hmpps.model.Registration(type.code, type.description, date)
 fun Registration.asMappa() = MappaDetail(

--- a/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/CaseService.kt
+++ b/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/CaseService.kt
@@ -88,7 +88,7 @@ fun CommunityManager.team() = Team(
 )
 
 fun CaseOffence.asOffence() =
-    Offence(id = if (main) "M$id" else "A$id", code, description, date, main, eventId, eventNumber)
+    Offence(id = if (main) "M$id" else "A$id", code, description, mainCategoryDescription, subCategoryDescription, date, main, eventId, eventNumber)
 
 fun Registration.asRegistration() = uk.gov.justice.digital.hmpps.model.Registration(type.code, type.description, date)
 fun Registration.asMappa() = MappaDetail(


### PR DESCRIPTION
**Background**
- The `Community API`'s endpoint: `GET /secure/offenders/crn/{crn}/convictions` includes offence categories in the response
- We need these in the `Approved Premises` API to build offence descriptions

**PR Includes**
- For the `GET /probation-cases/{crn}/details` endpoint, retrieve the the extra offence categories from the DB and surface on the API response