### PR TITLE
PI-2672 Fix Sonar change detection by leaving git directory

### DIFF
--- a/.github/actions/get-build-info/action.yml
+++ b/.github/actions/get-build-info/action.yml
@@ -28,7 +28,6 @@ runs:
       with:
         cache-encryption-key: ${{ inputs.gradle-encryption-key }}
         cache-read-only: true
-        remove-git-dir: false
 
     - name: Get build info
       if: ${{ steps.gradle_file.outputs.files_exists == 'true' }}

--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -14,10 +14,6 @@ inputs:
       A suitable key can be generated with `openssl rand -base64 16`.
       Configuration-cache data will not be saved/restored without an encryption key being provided.
     required: false
-  remove-git-dir:
-    description: Whether to remove the .git directory to prevent configuration cache invalidation.
-    required: false
-    default: 'true'
 
 runs:
   using: "composite"
@@ -35,6 +31,3 @@ runs:
       with:
         path: buildSrc/build
         key: gradle-buildSrc-${{ hashFiles('buildSrc/src/**', 'buildSrc/build.gradle.kts') }}
-    - if: inputs.remove-git-dir == 'true'
-      run: rm -rf .git
-      shell: bash


### PR DESCRIPTION
May result in slightly longer build times due to configuration cache misses, but it's not the end of the world