### PR TITLE
APS-1639 - Add StaffReponse.staffIdentifier in ap-and-delius

### DIFF
--- a/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/model/StaffResponse.kt
+++ b/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/model/StaffResponse.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.model
 
 data class StaffResponse(
     val code: String,
+    val staffIdentifier: Long,
     val name: PersonName,
     val grade: StaffGrade?,
     val keyWorker: Boolean

--- a/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/StaffService.kt
+++ b/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/StaffService.kt
@@ -52,6 +52,7 @@ class StaffService(
 
     fun Staff.toResponse(approvedPremisesCode: String) = StaffResponse(
         code = code,
+        staffIdentifier = id,
         name = PersonName(forename, surname, middleName),
         grade = grade?.let { grade -> StaffGrade(grade.code, grade.description) },
         keyWorker = approvedPremises.map { ap -> ap.code.code }.contains(approvedPremisesCode)

--- a/projects/approved-premises-and-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/service/StaffServiceTest.kt
+++ b/projects/approved-premises-and-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/service/StaffServiceTest.kt
@@ -74,6 +74,7 @@ internal class StaffServiceTest {
         assertThat(results.content.map { it.name.surname }, equalTo(listOf("Staff 1", "Staff 2")))
         assertThat(results.content.map { it.keyWorker }, equalTo(listOf(false, true)))
         assertThat(results.content[0].code, equalTo(staffEntities[0].code))
+        assertThat(results.content[0].staffIdentifier, equalTo(staffEntities[0].id))
         assertThat(results.content[0].name.forename, equalTo(staffEntities[0].forename))
         assertThat(results.content[0].name.middleName, equalTo(staffEntities[0].middleName))
         assertThat(results.content[0].name.surname, equalTo(staffEntities[0].surname))


### PR DESCRIPTION
This commits adds the `staffIdentifier` field to `StaffResponse`, matching the field already provided by `StaffDetail`. This helps approved-premise limit the number of requests required to build domain events involving keyworkers.