### PR TITLE
APS-1642 - Remove staffIdentifier from ap-and-delius API

### DIFF
--- a/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/EventDetailsGenerator.kt
+++ b/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/EventDetailsGenerator.kt
@@ -98,7 +98,6 @@ object EventDetailsGenerator {
     private fun staffMember(staff: Staff, username: String? = null) = StaffMember(
         username = username,
         staffCode = staff.code,
-        staffIdentifier = staff.id,
         forenames = staff.forename,
         surname = staff.surname
     )

--- a/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/StaffMemberGenerator.kt
+++ b/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/StaffMemberGenerator.kt
@@ -7,13 +7,11 @@ object StaffMemberGenerator {
 
     fun generate(
         staffCode: String = "N54A001",
-        staffIdentifier: Long = 1501234567,
         forenames: String = "John",
         surname: String = "Smith",
         username: String? = null
     ) = StaffMember(
         staffCode = staffCode,
-        staffIdentifier = staffIdentifier,
         forenames = forenames,
         surname = surname,
         username = username

--- a/projects/approved-premises-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/StaffControllerIntegrationTest.kt
+++ b/projects/approved-premises-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/StaffControllerIntegrationTest.kt
@@ -85,7 +85,6 @@ class StaffControllerIntegrationTest {
         assertThat(res.code, equalTo(StaffGenerator.DEFAULT_STAFF.code))
         assertThat(res.email, equalTo("john.smith@moj.gov.uk"))
         assertThat(res.telephoneNumber, equalTo("07321165373"))
-        assertThat(res.staffIdentifier, equalTo(StaffGenerator.DEFAULT_STAFF.id))
         assertThat(res.teams[0].borough?.code, equalTo(StaffGenerator.DEFAULT_STAFF.teams[0].district.borough.code))
         assertThat(
             res.teams[0].borough?.description,

--- a/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/approvedpremises/StaffMember.kt
+++ b/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/approvedpremises/StaffMember.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.integrations.approvedpremises
 
 data class StaffMember(
     val staffCode: String,
-    val staffIdentifier: Long,
     val forenames: String,
     val surname: String,
     val username: String?

--- a/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/model/StaffResponse.kt
+++ b/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/model/StaffResponse.kt
@@ -26,7 +26,6 @@ data class ProbationArea(
 data class StaffDetail(
     val email: String?,
     val telephoneNumber: String?,
-    val staffIdentifier: Long,
     val teams: List<Team> = emptyList(),
     val probationArea: ProbationArea,
     val username: String?,

--- a/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/StaffService.kt
+++ b/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/StaffService.kt
@@ -77,7 +77,6 @@ class StaffService(
             code = probationArea.code,
             description = probationArea.description
         ),
-        active = isActive(),
-        staffIdentifier = id
+        active = isActive()
     )
 }


### PR DESCRIPTION
This commit removes staffIdentifier from the ap-and-delius API and updates the domain events to no longer expect a value for this field (which wasn’t being used anyway)