### PR TITLE
PI-2676 Don't create a release if there is already an un-recalled release

### DIFF
--- a/projects/prison-custody-status-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/PrisonerMovement.kt
+++ b/projects/prison-custody-status-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/PrisonerMovement.kt
@@ -67,13 +67,15 @@ sealed interface PrisonerMovement {
 }
 
 fun PrisonerMovement.releaseDateValid(custody: Custody): Boolean {
-    return !occurredAt.isBefore(custody.disposal.date) &&
-        !(custody.mostRecentRelease()?.recall?.date?.let { occurredAt.isBefore(it) } ?: false)
+    val release = custody.mostRecentRelease()
+    val recallDate = release?.recall?.date
+    return occurredAt >= custody.disposal.date && (release == null || (recallDate != null && occurredAt >= recallDate))
 }
 
-fun PrisonerMovement.receivedDateValid(custody: Custody): Boolean =
-    !occurredAt.isAfter(ZonedDateTime.now()) && (custody.mostRecentRelease()?.date?.let { !occurredAt.isBefore(it) }
-        ?: true)
+fun PrisonerMovement.receivedDateValid(custody: Custody): Boolean {
+    val releaseDate = custody.mostRecentRelease()?.date
+    return occurredAt <= ZonedDateTime.now() && (releaseDate == null || occurredAt >= releaseDate)
+}
 
 fun PrisonerMovement.statusDateValid(custody: Custody): Boolean =
     occurredAt <= ZonedDateTime.now() && occurredAt.toLocalDate() >= custody.statusChangeDate

--- a/projects/prison-custody-status-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/actions/UpdateLocationAction.kt
+++ b/projects/prison-custody-status-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/actions/UpdateLocationAction.kt
@@ -117,13 +117,25 @@ class UpdateLocationAction(
     }
 
     private fun checkPreconditions(prisonerMovement: PrisonerMovement, custody: Custody): ActionResult? {
-        if ((prisonerMovement is PrisonerMovement.Received && custody.institution?.nomisCdeCode == prisonerMovement.toPrisonId) ||
-            (prisonerMovement is PrisonerMovement.Received && !prisonerMovement.receivedDateValid(custody)) ||
-            (prisonerMovement is PrisonerMovement.Released && !prisonerMovement.releaseDateValid(custody)) ||
-            !prisonerMovement.locationDateValid(custody)
+        if (prisonerMovement is PrisonerMovement.Received && custody.institution?.nomisCdeCode == prisonerMovement.toPrisonId) {
+            return ActionResult.Ignored("PrisonerLocationCorrect", prisonerMovement.telemetryProperties())
+        }
+
+        if (prisonerMovement is PrisonerMovement.Received && !prisonerMovement.receivedDateValid(custody)) {
+            return ActionResult.Ignored("PrisonerLocationCorrect", prisonerMovement.telemetryProperties())
+        }
+
+        if (prisonerMovement is PrisonerMovement.Released &&
+            !(prisonerMovement.isHospitalRelease() || prisonerMovement.isIrcRelease() || prisonerMovement.isAbsconded()) &&
+            !prisonerMovement.releaseDateValid(custody)
         ) {
             return ActionResult.Ignored("PrisonerLocationCorrect", prisonerMovement.telemetryProperties())
         }
+
+        if (!prisonerMovement.locationDateValid(custody)) {
+            return ActionResult.Ignored("PrisonerLocationCorrect", prisonerMovement.telemetryProperties())
+        }
+
         return null
     }
 }

--- a/projects/prison-custody-status-to-delius/src/main/resources/application-prisoner-movement.yml
+++ b/projects/prison-custody-status-to-delius/src/main/resources/application-prisoner-movement.yml
@@ -29,7 +29,7 @@ prisoner.movement.configs:
       # Unlawfully at large
       - UAL
       - UAL_ECL
-      # IRC
+      # Immigration removal centre
       - DD
       - DE
       - DL

--- a/projects/prison-custody-status-to-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/messaging/actions/UpdateLocationActionTest.kt
+++ b/projects/prison-custody-status-to-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/messaging/actions/UpdateLocationActionTest.kt
@@ -5,7 +5,6 @@ import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.instanceOf
 import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -20,7 +19,6 @@ import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.data.generator.*
 import uk.gov.justice.digital.hmpps.data.generator.EventGenerator.custodialEvent
 import uk.gov.justice.digital.hmpps.data.generator.EventGenerator.previouslyReleasedEvent
-import uk.gov.justice.digital.hmpps.exception.IgnorableMessageException
 import uk.gov.justice.digital.hmpps.integrations.delius.contact.ContactService
 import uk.gov.justice.digital.hmpps.integrations.delius.custody.entity.Custody
 import uk.gov.justice.digital.hmpps.integrations.delius.custody.entity.CustodyHistoryRepository
@@ -65,10 +63,7 @@ internal class UpdateLocationActionTest {
     @ParameterizedTest
     @MethodSource("noChangeMovements")
     fun `no changes made when location is correct`(custody: Custody, prisonerMovement: PrisonerMovement) {
-        if (prisonerMovement.type == RELEASED && prisonerMovement.reason.isBlank()) {
-            whenever(institutionRepository.findByNomisCdeCode(InstitutionGenerator.DEFAULT.nomisCdeCode!!))
-                .thenReturn(InstitutionGenerator.DEFAULT)
-        } else if (prisonerMovement.isAbsconded()) {
+        if (prisonerMovement.isAbsconded()) {
             whenever(institutionRepository.findByNomisCdeCode(InstitutionGenerator.DEFAULT.nomisCdeCode!!))
                 .thenReturn(InstitutionGenerator.DEFAULT)
             whenever(institutionRepository.findByCode(InstitutionCode.UNLAWFULLY_AT_LARGE.code))


### PR DESCRIPTION
The integration service should never create a release where there is already an active release.  Delius expects releases and recalls to be in order and alternating, so you would never have two releases in a row, unless there was a recall between them.

Previously the `releaseDateValid` logic didn't account for an un-recalled release.  If `custody.mostRecentRelease()` is not null, but `custody.mostRecentRelease().recall` _is_ null, then it returned `true` but it should have returned `false`.