### PR TITLE
PI-2713 Fix deployments for projects with disabled batch jobs

### DIFF
--- a/.github/actions/merge-changes/check-deployments.sh
+++ b/.github/actions/merge-changes/check-deployments.sh
@@ -12,7 +12,7 @@ function deploymentEnabled() {
   env=$1
   while IFS= read -r project; do
     file="projects/$project/deploy/values-$env.yml"
-    if [ -f "$file" ] && ! grep -q 'enabled: false' "$file"; then echo "$project"; fi
+    if [ -f "$file" ] && ! grep -q '^enabled: false' "$file"; then echo "$project"; fi
   done
 }
 


### PR DESCRIPTION
These were triggering a false-positive when `enabled: false` was set on the cron jobs.