### PR TITLE
PI-2526 Switch to cosine similarity + increase chunk size

### DIFF
--- a/projects/person-search-index-from-delius/container/pipelines/contact/index/index-template-semantic.yml
+++ b/projects/person-search-index-from-delius/container/pipelines/contact/index/index-template-semantic.yml
@@ -799,6 +799,7 @@ template:
           knn:
             type: knn_vector
             dimension: 1024
+            space_type: cosinesimil
       notes:
         copy_to: text
         type: text

--- a/projects/person-search-index-from-delius/container/pipelines/contact/index/ingest-pipeline.tpl.json
+++ b/projects/person-search-index-from-delius/container/pipelines/contact/index/ingest-pipeline.tpl.json
@@ -25,7 +25,7 @@
       "text_chunking": {
         "algorithm": {
           "fixed_token_length": {
-            "token_limit": 64,
+            "token_limit": 128,
             "overlap_rate": 0.125,
             "tokenizer": "standard"
           }


### PR DESCRIPTION
The Data Science team have been using cosing similarity for their testing, whereas OpenSearch defaults to L2 (Euclidean distance).

Also increasing chunk size as a workaround for the batch size limit of 32 in the mxbai model, which limits the length of the notes we can process in one go to 1792 chars (now 3584).