### PR TITLE
PI-2526 Switch to the lucene knn engine

### DIFF
--- a/projects/person-search-index-from-delius/container/pipelines/contact/index/index-template-semantic.yml
+++ b/projects/person-search-index-from-delius/container/pipelines/contact/index/index-template-semantic.yml
@@ -800,6 +800,8 @@ template:
             type: knn_vector
             dimension: 1024
             space_type: cosinesimil
+            method:
+              engine: lucene
       notes:
         copy_to: text
         type: text


### PR DESCRIPTION
Lucene supports radial search (unlike the default hnsw) while maintaining support for the cosine similarity space.

See:
* https://opensearch.org/docs/latest/search-plugins/knn/radial-search-knn/
* https://opensearch.org/docs/latest/search-plugins/knn/knn-index#method-definitions