### PR TITLE
PI-2753 Switch to Oracle Free image

### DIFF
--- a/projects/appointment-reminders-and-delius/build.gradle.kts
+++ b/projects/appointment-reminders-and-delius/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/approved-premises-and-delius/build.gradle.kts
+++ b/projects/approved-premises-and-delius/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     dev(project(":libs:dev-tools"))
     dev("com.unboundid:unboundid-ldapsdk")
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/arns-and-delius/build.gradle.kts
+++ b/projects/arns-and-delius/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/assess-for-early-release-and-delius/build.gradle.kts
+++ b/projects/assess-for-early-release-and-delius/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     dev(project(":libs:dev-tools"))
     dev("com.unboundid:unboundid-ldapsdk")
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/assessment-summary-and-delius/build.gradle.kts
+++ b/projects/assessment-summary-and-delius/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/cas2-and-delius/build.gradle.kts
+++ b/projects/cas2-and-delius/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/cas3-and-delius/build.gradle.kts
+++ b/projects/cas3-and-delius/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/common-platform-and-delius/build.gradle.kts
+++ b/projects/common-platform-and-delius/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/core-person-record-and-delius/build.gradle.kts
+++ b/projects/core-person-record-and-delius/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/court-case-and-delius/build.gradle.kts
+++ b/projects/court-case-and-delius/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     dev(project(":libs:dev-tools"))
     dev("com.unboundid:unboundid-ldapsdk")
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/create-and-vary-a-licence-and-delius/build.gradle.kts
+++ b/projects/create-and-vary-a-licence-and-delius/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
     dev(project(":libs:dev-tools"))
     dev("com.unboundid:unboundid-ldapsdk")
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/custody-key-dates-and-delius/build.gradle.kts
+++ b/projects/custody-key-dates-and-delius/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/domain-events-and-delius/build.gradle.kts
+++ b/projects/domain-events-and-delius/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/dps-and-delius/build.gradle.kts
+++ b/projects/dps-and-delius/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/effective-proposal-framework-and-delius/build.gradle.kts
+++ b/projects/effective-proposal-framework-and-delius/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/external-api-and-delius/build.gradle.kts
+++ b/projects/external-api-and-delius/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     dev(project(":libs:dev-tools"))
     dev("com.unboundid:unboundid-ldapsdk")
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/hdc-licences-and-delius/build.gradle.kts
+++ b/projects/hdc-licences-and-delius/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     dev(project(":libs:dev-tools"))
     dev("com.unboundid:unboundid-ldapsdk")
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/hmpps-auth-and-delius/build.gradle.kts
+++ b/projects/hmpps-auth-and-delius/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
     dev("com.unboundid:unboundid-ldapsdk")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")

--- a/projects/ims-and-delius/build.gradle.kts
+++ b/projects/ims-and-delius/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     dev(project(":libs:dev-tools"))
     dev("com.unboundid:unboundid-ldapsdk")
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/justice-email-and-delius/build.gradle.kts
+++ b/projects/justice-email-and-delius/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
     dev(project(":libs:dev-tools"))
     dev("com.unboundid:unboundid-ldapsdk")
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/make-recall-decisions-and-delius/build.gradle.kts
+++ b/projects/make-recall-decisions-and-delius/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
     dev(project(":libs:dev-tools"))
     dev("com.unboundid:unboundid-ldapsdk")
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/manage-offences-and-delius/build.gradle.kts
+++ b/projects/manage-offences-and-delius/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/manage-pom-cases-and-delius/build.gradle.kts
+++ b/projects/manage-pom-cases-and-delius/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     dev(project(":libs:dev-tools"))
     dev("com.unboundid:unboundid-ldapsdk")
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/manage-supervision-and-delius/build.gradle.kts
+++ b/projects/manage-supervision-and-delius/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
     dev(project(":libs:dev-tools"))
     dev("com.unboundid:unboundid-ldapsdk")
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/oasys-and-delius/build.gradle.kts
+++ b/projects/oasys-and-delius/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/offender-events-and-delius/build.gradle.kts
+++ b/projects/offender-events-and-delius/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/opd-and-delius/build.gradle.kts
+++ b/projects/opd-and-delius/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/pathfinder-and-delius/build.gradle.kts
+++ b/projects/pathfinder-and-delius/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
     dev("com.unboundid:unboundid-ldapsdk")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")

--- a/projects/pre-sentence-reports-to-delius/build.gradle.kts
+++ b/projects/pre-sentence-reports-to-delius/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/prison-case-notes-to-probation/build.gradle.kts
+++ b/projects/prison-case-notes-to-probation/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/prison-custody-status-to-delius/build.gradle.kts
+++ b/projects/prison-custody-status-to-delius/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/prison-education-and-delius/build.gradle.kts
+++ b/projects/prison-education-and-delius/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     dev(project(":libs:dev-tools"))
     dev("com.unboundid:unboundid-ldapsdk")
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/prison-identifier-and-delius/build.gradle.kts
+++ b/projects/prison-identifier-and-delius/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/prisoner-profile-and-delius/build.gradle.kts
+++ b/projects/prisoner-profile-and-delius/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
     dev("com.unboundid:unboundid-ldapsdk")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")

--- a/projects/probation-search-and-delius/build.gradle.kts
+++ b/projects/probation-search-and-delius/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/refer-and-monitor-and-delius/build.gradle.kts
+++ b/projects/refer-and-monitor-and-delius/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     dev(project(":libs:dev-tools"))
     dev("com.unboundid:unboundid-ldapsdk")
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/resettlement-passport-and-delius/build.gradle.kts
+++ b/projects/resettlement-passport-and-delius/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
     dev("com.unboundid:unboundid-ldapsdk")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")

--- a/projects/risk-assessment-scores-to-delius/build.gradle.kts
+++ b/projects/risk-assessment-scores-to-delius/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/sentence-plan-and-delius/build.gradle.kts
+++ b/projects/sentence-plan-and-delius/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/soc-and-delius/build.gradle.kts
+++ b/projects/soc-and-delius/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/subject-access-requests-and-delius/build.gradle.kts
+++ b/projects/subject-access-requests-and-delius/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/tier-to-delius/build.gradle.kts
+++ b/projects/tier-to-delius/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/unpaid-work-and-delius/build.gradle.kts
+++ b/projects/unpaid-work-and-delius/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/projects/workforce-allocations-to-delius/build.gradle.kts
+++ b/projects/workforce-allocations-to-delius/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
     dev(project(":libs:dev-tools"))
     dev("com.unboundid:unboundid-ldapsdk")
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/templates/projects/api-client-and-server/build.gradle.kts
+++ b/templates/projects/api-client-and-server/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/templates/projects/api-server/build.gradle.kts
+++ b/templates/projects/api-server/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/templates/projects/message-listener-with-api-client-and-server/build.gradle.kts
+++ b/templates/projects/message-listener-with-api-client-and-server/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/templates/projects/message-listener-with-api-client/build.gradle.kts
+++ b/templates/projects/message-listener-with-api-client/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 

--- a/templates/projects/message-listener/build.gradle.kts
+++ b/templates/projects/message-listener/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
 
     dev(project(":libs:dev-tools"))
     dev("com.h2database:h2")
-    dev("org.testcontainers:oracle-xe")
+    dev("org.testcontainers:oracle-free")
 
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
 


### PR DESCRIPTION
Oracle Free is the new name for Oracle XE from version 23 onwards, and supports ARM architecture.

Note: The Delius database is on Oracle 19c, so the version used in the CI tests won't match the real version, but at least it will work on dev machines.