### PR TITLE
PI-2526 Remove repeated punctuation strings

### DIFF
--- a/projects/person-search-index-from-delius/container/pipelines/contact/index/ingest-pipeline.tpl.json
+++ b/projects/person-search-index-from-delius/container/pipelines/contact/index/ingest-pipeline.tpl.json
@@ -2,6 +2,14 @@
   "description": "Split text into chunks and generate embeddings",
   "processors": [
     {
+      "gsub": {
+        "tag": "Remove any repeated non-alphanumeric strings. The pattern looks for 2 or more non-alphanumeric characters surrounded by whitespace.",
+        "field": "notes",
+        "pattern": "(^|\\s)[^\\w\\s]{2,}(\\s|$)",
+        "replacement": " "
+      }
+    },
+    {
       "text_chunking": {
         "algorithm": {
           "fixed_token_length": {


### PR DESCRIPTION
to prevent model errors due to "too many tokens":
```
Input validation error: `inputs` must have less than 512 tokens Given: 566
```

caused by strings such as:
```
---------------------------------------------------------
Comment added by name on 01/02/2023 at 12:34
Report Edited: 01/02/2023 at 12:34
---------------------------------------------------------
Comment added by name on 01/02/2023 at 12:34
Report Edited: 01/02/2023 at 12:34
...
```