### PR TITLE
PI-2526 Ignore missing notes when stripping out punctuation

### DIFF
--- a/projects/person-search-index-from-delius/container/pipelines/contact/index/ingest-pipeline.tpl.json
+++ b/projects/person-search-index-from-delius/container/pipelines/contact/index/ingest-pipeline.tpl.json
@@ -6,7 +6,9 @@
         "tag": "Remove any repeated non-alphanumeric strings. The pattern looks for 2 or more non-alphanumeric characters surrounded by whitespace.",
         "field": "notes",
         "pattern": "(^|\\s)[^\\w\\s]{2,}(\\s|$)",
-        "replacement": " "
+        "replacement": " ",
+        "ignore_missing": true,
+        "ignore_failure": true
       }
     },
     {


### PR DESCRIPTION
To fix:
```
OpenSearch exception [type=illegal_argument_exception, reason=field [notes] is null, cannot process it.]
```