### PR TITLE
PI-2930 Remove duplicate key dates

### DIFF
--- a/projects/custody-key-dates-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/DataLoader.kt
+++ b/projects/custody-key-dates-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/DataLoader.kt
@@ -117,15 +117,20 @@ class DataLoader(
                 bookingRef
             )
         )
-        keyDateRepository.saveAll(
-            keyDateTypes.map { referenceData ->
-                if (referenceData.code == "LED") {
+        keyDateRepository.saveAll(keyDateTypes.flatMap { referenceData ->
+            when (referenceData.code) {
+                "LED" -> listOf(
                     KeyDate(custody, referenceData, LocalDate.parse("2025-09-11")).also { it.softDeleted = true }
-                } else {
-                    KeyDate(custody, referenceData, LocalDate.parse("2025-12-11")).also { it.softDeleted = false }
-                }
+                )
+
+                "SED" -> listOf(
+                    KeyDate(custody, referenceData, LocalDate.parse("2025-09-10")),
+                    KeyDate(custody, referenceData, LocalDate.parse("2025-09-11")).also { it.softDeleted = true }
+                )
+
+                else -> listOf(KeyDate(custody, referenceData, LocalDate.parse("2025-12-11")))
             }
-        )
+        })
         return custody
     }
 }

--- a/projects/custody-key-dates-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/DataLoader.kt
+++ b/projects/custody-key-dates-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/DataLoader.kt
@@ -124,8 +124,8 @@ class DataLoader(
                 )
 
                 "SED" -> listOf(
-                    KeyDate(custody, referenceData, LocalDate.parse("2025-09-10")),
-                    KeyDate(custody, referenceData, LocalDate.parse("2025-09-11")).also { it.softDeleted = true }
+                    KeyDate(custody, referenceData, LocalDate.parse("2025-09-11")),
+                    KeyDate(custody, referenceData, LocalDate.parse("2025-09-10")).also { it.softDeleted = true }
                 )
 
                 else -> listOf(KeyDate(custody, referenceData, LocalDate.parse("2025-12-11")))

--- a/projects/custody-key-dates-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/custody/date/CustodyDateUpdateService.kt
+++ b/projects/custody-key-dates-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/custody/date/CustodyDateUpdateService.kt
@@ -86,7 +86,7 @@ class CustodyDateUpdateService(
         }
 
     private fun Custody.keyDate(code: String, date: LocalDate?): KeyDate? = date?.let {
-        val existing = keyDates.find(code)
+        val existing = keyDates.filter { it.type.code == code }.removeDuplicates()
         return if (existing != null) {
             existing.changeDate(date)
         } else {
@@ -95,7 +95,10 @@ class CustodyDateUpdateService(
         }
     }
 
-    private fun List<KeyDate>.find(code: String): KeyDate? = firstOrNull { it.type.code == code }
+    private fun List<KeyDate>.removeDuplicates(): KeyDate? {
+        if (size > 1) drop(1).forEach { keyDateRepository.delete(it) }
+        return firstOrNull()
+    }
 
     private fun Booking.telemetry(clientSource: String) = mapOf(
         "nomsNumber" to offenderNo,

--- a/projects/custody-key-dates-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/custody/date/CustodyDateUpdateService.kt
+++ b/projects/custody-key-dates-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/custody/date/CustodyDateUpdateService.kt
@@ -96,7 +96,10 @@ class CustodyDateUpdateService(
     }
 
     private fun List<KeyDate>.removeDuplicates(): KeyDate? {
-        if (size > 1) drop(1).forEach { keyDateRepository.delete(it) }
+        if (size > 1) {
+            drop(1).forEach { keyDateRepository.delete(it) }
+            keyDateRepository.flush() // Required to avoid unique key constraint, by ensuring delete happens before insert
+        }
         return firstOrNull()
     }
 

--- a/projects/custody-key-dates-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/custody/date/Sentence.kt
+++ b/projects/custody-key-dates-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/custody/date/Sentence.kt
@@ -97,7 +97,7 @@ class Custody(
     val disposal: Disposal? = null,
 
     @OneToMany(mappedBy = "custody")
-    val keyDates: List<KeyDate> = listOf(),
+    val keyDates: MutableList<KeyDate> = mutableListOf(),
 
     @Column(columnDefinition = "number", nullable = false)
     @Convert(converter = NumericBooleanConverter::class)


### PR DESCRIPTION
Previously, when we encountered a case that had two key dates of the same type (with different dates), we would try to update the first one we found.  However, there's a chance we update the date to be the same as the date on the other key date - resulting in a key constraint error.  With this change, if we come across a case with multiple key dates of the same type - we delete all but one, then update the remaining one.

Resolves https://ministryofjustice.sentry.io/issues/6279152215