### PR TITLE
PI-2946 Arrival/departure changes for CAS1 integration

### DIFF
--- a/libs/commons/src/main/kotlin/uk/gov/justice/digital/hmpps/datetime/DeliusDateTimeFormatter.kt
+++ b/libs/commons/src/main/kotlin/uk/gov/justice/digital/hmpps/datetime/DeliusDateTimeFormatter.kt
@@ -6,7 +6,7 @@ import java.time.temporal.Temporal
 
 val DeliusDateTimeFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss")
 val DeliusDateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
-fun Temporal.toDeliusDate(): String = DeliusDateFormatter.format(this)
-fun Temporal.toDeliusDateTime(): String = DeliusDateTimeFormatter.format(this)
+fun Temporal?.toDeliusDate(): String = DeliusDateFormatter.format(this)
+fun Temporal?.toDeliusDateTime(): String = DeliusDateTimeFormatter.format(this)
 
 val EuropeLondon: ZoneId = ZoneId.of("Europe/London")

--- a/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/AddressGenerator.kt
+++ b/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/AddressGenerator.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.data.generator
 import uk.gov.justice.digital.hmpps.integrations.delius.approvedpremises.entity.Address
 import uk.gov.justice.digital.hmpps.integrations.delius.person.address.PersonAddress
 import uk.gov.justice.digital.hmpps.integrations.delius.referencedata.ReferenceData
+import java.time.LocalDate
 
 object AddressGenerator {
 
@@ -24,6 +25,11 @@ object AddressGenerator {
     )
 
     var INACTIVE_PERSON_ADDRESS_ID: Long? = null
+
+    var PERSON_AP_ADDRESS = generatePersonAddress(
+        type = ReferenceDataGenerator.AP_ADDRESS_TYPE,
+        startDate = LocalDate.of(2025, 1, 1),
+    )
 
     val Q001 = generateAddress(
         addressNumber = "1",
@@ -200,6 +206,7 @@ object AddressGenerator {
         county: String? = null,
         postcode: String? = null,
         telephoneNumber: String? = null,
+        startDate: LocalDate = LocalDate.now(),
     ) = PersonAddress(
         personId,
         type,
@@ -212,5 +219,6 @@ object AddressGenerator {
         county,
         postcode,
         telephoneNumber,
+        startDate = startDate
     )
 }

--- a/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/ReferralGenerator.kt
+++ b/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/ReferralGenerator.kt
@@ -123,6 +123,7 @@ object ReferralGenerator {
         referral.id,
         approvedPremisesId,
         arrivalDateTime.truncatedTo(ChronoUnit.SECONDS),
+        departureDateTime?.toLocalDate(),
         arrivalNotes,
         keyWorkerStaffId
     ).apply {

--- a/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/approvedpremises/referral/entity/Residence.kt
+++ b/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/approvedpremises/referral/entity/Residence.kt
@@ -9,6 +9,7 @@ import org.springframework.data.annotation.LastModifiedBy
 import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import org.springframework.data.jpa.repository.JpaRepository
+import java.time.LocalDate
 import java.time.ZonedDateTime
 
 @Entity
@@ -24,9 +25,12 @@ class Residence(
     val referralId: Long,
 
     @Column(name = "approved_premises_id")
-    val approvedPremisesId: Long,
+    var approvedPremisesId: Long,
 
-    val arrivalDate: ZonedDateTime,
+    var arrivalDate: ZonedDateTime,
+
+    var expectedDepartureDate: LocalDate?,
+
     @Lob
     val arrivalNotes: String?,
 

--- a/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/AddressService.kt
+++ b/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/AddressService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.service
 
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.integrations.approvedpremises.PersonArrived
+import uk.gov.justice.digital.hmpps.integrations.delius.address.AddressTypeCode
 import uk.gov.justice.digital.hmpps.integrations.delius.approvedpremises.entity.ApprovedPremises
 import uk.gov.justice.digital.hmpps.integrations.delius.person.Person
 import uk.gov.justice.digital.hmpps.integrations.delius.person.address.PersonAddress
@@ -17,26 +18,30 @@ class AddressService(
     private val personAddressRepository: PersonAddressRepository,
     private val referenceDataRepository: ReferenceDataRepository
 ) {
-    fun updateMainAddress(
+    fun updateMainAddressOnArrival(
         person: Person,
         details: PersonArrived,
         ap: ApprovedPremises
     ): Pair<PersonAddress?, PersonAddress> {
-        val previous = endMainAddress(person, details.arrivedAt.toLocalDate())
-        val current = ap.arrival(person, details).let(personAddressRepository::save)
+        val previous = personAddressRepository.findMainAddress(person.id)
+            ?.also { it.endMainAddress(details.arrivedAt.toLocalDate()) }
+        val current = personAddressRepository.save(ap.toAddress(person, details))
         return previous to current
     }
 
-    fun endMainAddress(person: Person, endDate: LocalDate): PersonAddress? {
-        val currentMain = personAddressRepository.findMainAddress(person.id)
-        return currentMain?.also {
-            val previousStatus = referenceDataRepository.previousAddressStatus()
-            currentMain.status = previousStatus
-            currentMain.endDate = endDate
-        }
+    fun endMainAddressOnDeparture(person: Person, endDate: LocalDate): PersonAddress? {
+        return personAddressRepository.findMainAddress(person.id)
+            ?.takeIf { it.type.code == AddressTypeCode.APPROVED_PREMISES.code && it.startDate <= endDate }
+            ?.also { it.endMainAddress(endDate) }
     }
 
-    private fun ApprovedPremises.arrival(person: Person, details: PersonArrived) = PersonAddress(
+    fun PersonAddress.endMainAddress(endDate: LocalDate) {
+        val previousStatus = referenceDataRepository.previousAddressStatus()
+        this.status = previousStatus
+        this.endDate = endDate
+    }
+
+    private fun ApprovedPremises.toAddress(person: Person, details: PersonArrived) = PersonAddress(
         person.id,
         referenceDataRepository.approvedPremisesAddressType(),
         referenceDataRepository.mainAddressStatus(),

--- a/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/NsiService.kt
+++ b/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/NsiService.kt
@@ -73,7 +73,7 @@ class NsiService(
                 probationAreaCode = ap.probationArea.code
             )
             referralService.personArrived(person, ap, details)
-            return addressService.updateMainAddress(person, details, ap)
+            return addressService.updateMainAddressOnArrival(person, details, ap)
         }
         return null
     }
@@ -110,7 +110,7 @@ class NsiService(
             probationAreaCode = ap.probationArea.code
         )
         referralService.personDeparted(person, details)
-        return addressService.endMainAddress(person, details.departedAt.toLocalDate())
+        return addressService.endMainAddressOnDeparture(person, details.departedAt.toLocalDate())
     }
 
     private fun findNsi(person: Person, type: NsiTypeCode, externalReference: String) =

--- a/projects/approved-premises-and-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/service/AddressServiceTest.kt
+++ b/projects/approved-premises-and-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/service/AddressServiceTest.kt
@@ -1,0 +1,56 @@
+package uk.gov.justice.digital.hmpps.service
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.nullValue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.data.generator.AddressGenerator
+import uk.gov.justice.digital.hmpps.data.generator.DatasetGenerator.ADDRESS_STATUS
+import uk.gov.justice.digital.hmpps.data.generator.PersonGenerator
+import uk.gov.justice.digital.hmpps.data.generator.ReferenceDataGenerator.MAIN_ADDRESS_STATUS
+import uk.gov.justice.digital.hmpps.data.generator.ReferenceDataGenerator.PREV_ADDRESS_STATUS
+import uk.gov.justice.digital.hmpps.integrations.delius.person.address.PersonAddressRepository
+import uk.gov.justice.digital.hmpps.integrations.delius.referencedata.ReferenceDataRepository
+import java.time.LocalDate
+
+@ExtendWith(MockitoExtension::class)
+internal class AddressServiceTest {
+    @Mock
+    lateinit var personAddressRepository: PersonAddressRepository
+
+    @Mock
+    lateinit var referenceDataRepository: ReferenceDataRepository
+
+    @InjectMocks
+    lateinit var addressService: AddressService
+
+    @Test
+    fun `end-dates main address on departure if it is an approved premises address`() {
+        whenever(personAddressRepository.findMainAddress(PersonGenerator.DEFAULT.id))
+            .thenReturn(AddressGenerator.PERSON_AP_ADDRESS)
+        whenever(referenceDataRepository.findByCodeAndDatasetCode(PREV_ADDRESS_STATUS.code, ADDRESS_STATUS.code))
+            .thenReturn(PREV_ADDRESS_STATUS)
+
+        val updatedAddress = addressService.endMainAddressOnDeparture(PersonGenerator.DEFAULT, LocalDate.of(2025, 3, 1))!!
+
+        assertThat(updatedAddress.endDate, equalTo(LocalDate.of(2025, 3, 1)))
+        assertThat(updatedAddress.status.code, equalTo(PREV_ADDRESS_STATUS.code))
+    }
+
+    @Test
+    fun `does not end-date main address on departure if it isn't an approved premises address`() {
+        whenever(personAddressRepository.findMainAddress(PersonGenerator.DEFAULT.id))
+            .thenReturn(AddressGenerator.PERSON_ADDRESS)
+
+        val updatedAddress = addressService.endMainAddressOnDeparture(PersonGenerator.DEFAULT, LocalDate.of(2025, 3, 1))
+
+        assertThat(updatedAddress, nullValue())
+        assertThat(AddressGenerator.PERSON_ADDRESS.endDate, nullValue())
+        assertThat(AddressGenerator.PERSON_ADDRESS.status.code, equalTo(MAIN_ADDRESS_STATUS.code))
+    }
+}

--- a/projects/approved-premises-and-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/service/AddressServiceTest.kt
+++ b/projects/approved-premises-and-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/service/AddressServiceTest.kt
@@ -36,7 +36,8 @@ internal class AddressServiceTest {
         whenever(referenceDataRepository.findByCodeAndDatasetCode(PREV_ADDRESS_STATUS.code, ADDRESS_STATUS.code))
             .thenReturn(PREV_ADDRESS_STATUS)
 
-        val updatedAddress = addressService.endMainAddressOnDeparture(PersonGenerator.DEFAULT, LocalDate.of(2025, 3, 1))!!
+        val updatedAddress =
+            addressService.endMainAddressOnDeparture(PersonGenerator.DEFAULT, LocalDate.of(2025, 3, 1))!!
 
         assertThat(updatedAddress.endDate, equalTo(LocalDate.of(2025, 3, 1)))
         assertThat(updatedAddress.status.code, equalTo(PREV_ADDRESS_STATUS.code))

--- a/projects/approved-premises-and-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/service/ApprovedPremisesServiceTest.kt
+++ b/projects/approved-premises-and-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/service/ApprovedPremisesServiceTest.kt
@@ -598,7 +598,12 @@ internal class ApprovedPremisesServiceTest {
                     override val residence get() = null
                 })
         } else {
-            whenever(referralRepository.findByPersonIdAndExternalReference(person.id, EXT_REF_BOOKING_PREFIX + bookingId))
+            whenever(
+                referralRepository.findByPersonIdAndExternalReference(
+                    person.id,
+                    EXT_REF_BOOKING_PREFIX + bookingId
+                )
+            )
                 .thenReturn(ref)
         }
         return ref


### PR DESCRIPTION
* On arrival, set the expected departure date on the residence
* On arrival, update any existing residence record in-place to prevent duplicates
* On booking changed, set the expected departure date on the residence if there is one
* On departure, only add an end-date to the main address if it is an AP address, and it was added before the departure date