### PR TITLE
CBA-412/fix-seed-data-for-local-to-match-dev

### DIFF
--- a/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/ProbationCaseDataLoader.kt
+++ b/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/ProbationCaseDataLoader.kt
@@ -59,6 +59,7 @@ class ProbationCaseDataLoader(
         probationCaseRepository.save(ProbationCaseGenerator.CASE_SIMPLE)
         probationCaseRepository.save(ProbationCaseGenerator.CASE_X320741)
         probationCaseRepository.save(ProbationCaseGenerator.CASE_X320742)
+        probationCaseRepository.save(ProbationCaseGenerator.CASE_X823998)
         probationCaseRepository.save(ProbationCaseGenerator.CASE_X320811)
         probationCaseRepository.save(ProbationCaseGenerator.CASE_LAO_EXCLUSION)
         probationCaseRepository.save(ProbationCaseGenerator.CASE_LAO_RESTRICTED)
@@ -69,6 +70,7 @@ class ProbationCaseDataLoader(
                 ProbationCaseGenerator.generateManager(ProbationCaseGenerator.CASE_SIMPLE).asPersonManager(),
                 ProbationCaseGenerator.generateManager(ProbationCaseGenerator.CASE_X320741).asPersonManager(),
                 ProbationCaseGenerator.generateManager(ProbationCaseGenerator.CASE_X320742).asPersonManager(),
+                ProbationCaseGenerator.generateManager(ProbationCaseGenerator.CASE_X823998).asPersonManager(),
                 ProbationCaseGenerator.generateManager(ProbationCaseGenerator.CASE_X320811).asPersonManager(),
                 ProbationCaseGenerator.generateManager(ProbationCaseGenerator.CASE_LAO_EXCLUSION).asPersonManager(),
                 ProbationCaseGenerator.generateManager(ProbationCaseGenerator.CASE_LAO_RESTRICTED).asPersonManager()
@@ -129,6 +131,12 @@ class ProbationCaseDataLoader(
         )
         generateEventAndAddOffences(
             ProbationCaseGenerator.CASE_X320742,
+            eventId = 100005L,
+            mainOffence = Pair(200002L, LocalDate.parse("2024-10-12")),
+            additionalOffence = Pair(300002L, LocalDate.parse("2024-10-22"))
+        )
+        generateEventAndAddOffences(
+            ProbationCaseGenerator.CASE_X823998,
             eventId = 100005L,
             mainOffence = Pair(200002L, LocalDate.parse("2024-10-12")),
             additionalOffence = Pair(300002L, LocalDate.parse("2024-10-22"))

--- a/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/ProbationCaseGenerator.kt
+++ b/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/ProbationCaseGenerator.kt
@@ -68,6 +68,18 @@ object ProbationCaseGenerator {
         religion = ReferenceDataGenerator.RELIGION_OTHER,
         genderIdentity = ReferenceDataGenerator.GENDER_IDENTITY_PNS,
     )
+    val CASE_X823998 = generate(
+        crn = "X823998",
+        forename = "Marsha",
+        surname = "Crist",
+        dateOfBirth = LocalDate.of(1966, 6, 6),
+        nomsId = "A8767EA",
+        gender = ReferenceDataGenerator.GENDER_FEMALE,
+        ethnicity = ReferenceDataGenerator.ETHNICITY_WHITE,
+        nationality = ReferenceDataGenerator.NATIONALITY_BRITISH,
+        religion = ReferenceDataGenerator.RELIGION_OTHER,
+        genderIdentity = ReferenceDataGenerator.GENDER_IDENTITY_PNS,
+    )
     val CASE_X320811 = generate(
         crn = "X320811",
         forename = "E2E Person",


### PR DESCRIPTION
feat: adds a user to match the NOMS/CRN of an excluded offender in dev env