### PR TITLE
PI-2974: Move probation match to db

### DIFF
--- a/projects/prison-identifier-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/DataLoader.kt
+++ b/projects/prison-identifier-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/DataLoader.kt
@@ -56,6 +56,12 @@ class DataLoader(
         val personWithNomsInDeliusCustody = generateCustody(personWithNomsInDeliusDisposal)
         val personWithNomsInDeliusOrderManager = generateOrderManager(personWithNomsInDeliusEvent)
 
+        val personWithNomsInDeliusEventDb = generateEvent(PersonGenerator.PERSON_WITH_NOMS_DB)
+        val personWithNomsInDeliusDisposalDb =
+            generateDisposal(LocalDate.of(2022, 11, 11), personWithNomsInDeliusEventDb)
+        val personWithNomsInDeliusCustodyDb = generateCustody(personWithNomsInDeliusDisposalDb)
+        val personWithNomsInDeliusOrderManagerDb = generateOrderManager(personWithNomsInDeliusEventDb)
+
         em.saveAll(
             ReferenceDataGenerator.GENDER_SET,
             ReferenceDataGenerator.MALE,
@@ -72,6 +78,9 @@ class DataLoader(
             PersonGenerator.PERSON_WITH_NOMS_IN_DELIUS,
             PersonGenerator.PERSON_WITH_DUPLICATE_NOMS,
             PersonGenerator.PERSON_WITH_EXISTING_NOMS,
+            PersonGenerator.PERSON_WITH_NOMS_DB,
+            PersonGenerator.PERSON_ALIAS_1,
+            PersonGenerator.PERSON_ALIAS_2,
             personWithNomsEvent,
             personWithNomsDisposal,
             personWithNomsCustody,
@@ -92,6 +101,10 @@ class DataLoader(
             personWithNomsInDeliusDisposal,
             personWithNomsInDeliusCustody,
             personWithNomsInDeliusOrderManager,
+            personWithNomsInDeliusEventDb,
+            personWithNomsInDeliusDisposalDb,
+            personWithNomsInDeliusCustodyDb,
+            personWithNomsInDeliusOrderManagerDb,
         )
     }
 

--- a/projects/prison-identifier-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/PersonGenerator.kt
+++ b/projects/prison-identifier-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/PersonGenerator.kt
@@ -13,6 +13,28 @@ object PersonGenerator {
     val PERSON_WITH_DUPLICATE_NOMS = generate("A000006", "G5541UN")
     val PERSON_WITH_EXISTING_NOMS = generate("A000007", "A0007AA")
 
+    val PERSON_WITH_NOMS_DB = generate(
+        crn = "A000010",
+        noms = "A0010DB",
+        pncNumber = "24/0000001Y",
+        croNumber = "00001/24M",
+        dobString = "05/17/1961"
+    )
+
+    val PERSON_ALIAS_1 = generateAlias(
+        offenderId = PERSON_WITH_NOMS_DB.id,
+        forename = "terry",
+        surname = "brown",
+        dobString = "08/12/1962"
+    )
+
+    val PERSON_ALIAS_2 = generateAlias(
+        offenderId = PERSON_WITH_NOMS_DB.id,
+        forename = "arthur",
+        surname = "askew",
+        dobString = "04/13/1969"
+    )
+
     fun generate(
         crn: String,
         noms: String? = null,
@@ -22,8 +44,13 @@ object PersonGenerator {
         surname: String = "smith",
         softDeleted: Boolean = false,
         dobString: String = "12/12/2000",
-        id: Long = IdGenerator.getAndIncrement()
-    ) = Person(
+        id: Long = IdGenerator.getAndIncrement(),
+        immigrationNumber: String? = null,
+        niNumber: String? = null,
+        mostRecentPrisonerNumber: String? = null,
+        croNumber: String? = null,
+
+        ) = Person(
         id,
         crn,
         LocalDate.parse(dobString, DateTimeFormatter.ofPattern("MM/dd/yyyy")),
@@ -31,13 +58,33 @@ object PersonGenerator {
         null,
         null,
         surname,
+        null,
+        null,
+        true,
         noms,
-        null,
-        null,
+        immigrationNumber,
+        niNumber,
+        mostRecentPrisonerNumber,
+        croNumber,
         pncNumber,
         gender,
         listOf(),
         softDeleted = softDeleted
+    )
+
+    fun generateAlias(
+        id: Long = IdGenerator.getAndIncrement(),
+        offenderId: Long,
+        forename: String,
+        surname: String,
+        dobString: String
+    ) = Alias(
+        id = id,
+        offenderId = offenderId,
+        forename = forename,
+        surname = surname,
+        dateOfBirth = LocalDate.parse(dobString, DateTimeFormatter.ofPattern("MM/dd/yyyy")),
+        softDeleted = false,
     )
 
     fun generateEvent(person: Person, id: Long = IdGenerator.getAndIncrement()) =

--- a/projects/prison-identifier-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/ReferenceDataGenerator.kt
+++ b/projects/prison-identifier-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/ReferenceDataGenerator.kt
@@ -17,12 +17,14 @@ object ReferenceDataGenerator {
 
     val CONTACT_TYPE = generateContactType("EDSS")
 
-    fun generateGender(code: String, id: Long = IdGenerator.getAndIncrement()) = ReferenceData(id, code, GENDER_SET)
+    fun generateGender(code: String, id: Long = IdGenerator.getAndIncrement()) =
+        ReferenceData(id, code, "description", GENDER_SET)
+
     fun generateCustodyStatus(code: String, id: Long = IdGenerator.getAndIncrement()) =
-        ReferenceData(id, code, CUSTODY_STATUS_SET)
+        ReferenceData(id, code, "description", CUSTODY_STATUS_SET)
 
     fun generateIdentifierType(code: String, id: Long = IdGenerator.getAndIncrement()) =
-        ReferenceData(id, code, ADDITIONAL_IDENTIFIER_TYPE_SET)
+        ReferenceData(id, code, "description", ADDITIONAL_IDENTIFIER_TYPE_SET)
 
     fun generateReferenceDataSet(name: String, id: Long = IdGenerator.getAndIncrement()) = ReferenceDataSet(id, name)
 

--- a/projects/prison-identifier-and-delius/src/dev/resources/messages/prisoner-status-changed-db-cro.json
+++ b/projects/prison-identifier-and-delius/src/dev/resources/messages/prisoner-status-changed-db-cro.json
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "eventType": "prison-offender-events.prisoner.imprisonment-status-changed",
+  "description": "A prisoner's imprisonment status has been changed",
+  "occurredAt": "2023-08-04T08:09:36.649098+01:00",
+  "publishedAt": "2023-08-04T09:06:46.65281576+01:00",
+  "additionalInformation": {
+    "bookingId": "123"
+  },
+  "personReference": {
+    "identifiers": [
+      {
+        "type": "NOMS",
+        "value": "A0100DB"
+      }
+    ]
+  }
+}

--- a/projects/prison-identifier-and-delius/src/dev/resources/messages/prisoner-status-changed-db-lenient-dob.json
+++ b/projects/prison-identifier-and-delius/src/dev/resources/messages/prisoner-status-changed-db-lenient-dob.json
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "eventType": "prison-offender-events.prisoner.imprisonment-status-changed",
+  "description": "A prisoner's imprisonment status has been changed",
+  "occurredAt": "2023-08-04T08:09:36.649098+01:00",
+  "publishedAt": "2023-08-04T09:06:46.65281576+01:00",
+  "additionalInformation": {
+    "bookingId": "123"
+  },
+  "personReference": {
+    "identifiers": [
+      {
+        "type": "NOMS",
+        "value": "A0102DB"
+      }
+    ]
+  }
+}

--- a/projects/prison-identifier-and-delius/src/dev/resources/messages/prisoner-status-changed-db-name.json
+++ b/projects/prison-identifier-and-delius/src/dev/resources/messages/prisoner-status-changed-db-name.json
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "eventType": "prison-offender-events.prisoner.imprisonment-status-changed",
+  "description": "A prisoner's imprisonment status has been changed",
+  "occurredAt": "2023-08-04T08:09:36.649098+01:00",
+  "publishedAt": "2023-08-04T09:06:46.65281576+01:00",
+  "additionalInformation": {
+    "bookingId": "123"
+  },
+  "personReference": {
+    "identifiers": [
+      {
+        "type": "NOMS",
+        "value": "A0105DB"
+      }
+    ]
+  }
+}

--- a/projects/prison-identifier-and-delius/src/dev/resources/messages/prisoner-status-changed-db-no-match.json
+++ b/projects/prison-identifier-and-delius/src/dev/resources/messages/prisoner-status-changed-db-no-match.json
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "eventType": "prison-offender-events.prisoner.imprisonment-status-changed",
+  "description": "A prisoner's imprisonment status has been changed",
+  "occurredAt": "2023-08-04T08:09:36.649098+01:00",
+  "publishedAt": "2023-08-04T09:06:46.65281576+01:00",
+  "additionalInformation": {
+    "bookingId": "123"
+  },
+  "personReference": {
+    "identifiers": [
+      {
+        "type": "NOMS",
+        "value": "A0106DB"
+      }
+    ]
+  }
+}

--- a/projects/prison-identifier-and-delius/src/dev/resources/messages/prisoner-status-changed-db-partial-name.json
+++ b/projects/prison-identifier-and-delius/src/dev/resources/messages/prisoner-status-changed-db-partial-name.json
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "eventType": "prison-offender-events.prisoner.imprisonment-status-changed",
+  "description": "A prisoner's imprisonment status has been changed",
+  "occurredAt": "2023-08-04T08:09:36.649098+01:00",
+  "publishedAt": "2023-08-04T09:06:46.65281576+01:00",
+  "additionalInformation": {
+    "bookingId": "123"
+  },
+  "personReference": {
+    "identifiers": [
+      {
+        "type": "NOMS",
+        "value": "A0101DB"
+      }
+    ]
+  }
+}

--- a/projects/prison-identifier-and-delius/src/dev/resources/messages/prisoner-status-changed-db-pnc-long.json
+++ b/projects/prison-identifier-and-delius/src/dev/resources/messages/prisoner-status-changed-db-pnc-long.json
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "eventType": "prison-offender-events.prisoner.imprisonment-status-changed",
+  "description": "A prisoner's imprisonment status has been changed",
+  "occurredAt": "2023-08-04T08:09:36.649098+01:00",
+  "publishedAt": "2023-08-04T09:06:46.65281576+01:00",
+  "additionalInformation": {
+    "bookingId": "123"
+  },
+  "personReference": {
+    "identifiers": [
+      {
+        "type": "NOMS",
+        "value": "A0104DB"
+      }
+    ]
+  }
+}

--- a/projects/prison-identifier-and-delius/src/dev/resources/messages/prisoner-status-changed-db-pnc-short.json
+++ b/projects/prison-identifier-and-delius/src/dev/resources/messages/prisoner-status-changed-db-pnc-short.json
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "eventType": "prison-offender-events.prisoner.imprisonment-status-changed",
+  "description": "A prisoner's imprisonment status has been changed",
+  "occurredAt": "2023-08-04T08:09:36.649098+01:00",
+  "publishedAt": "2023-08-04T09:06:46.65281576+01:00",
+  "additionalInformation": {
+    "bookingId": "123"
+  },
+  "personReference": {
+    "identifiers": [
+      {
+        "type": "NOMS",
+        "value": "A0103DB"
+      }
+    ]
+  }
+}

--- a/projects/prison-identifier-and-delius/src/dev/resources/messages/prisoner-status-changed-db.json
+++ b/projects/prison-identifier-and-delius/src/dev/resources/messages/prisoner-status-changed-db.json
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "eventType": "prison-offender-events.prisoner.imprisonment-status-changed",
+  "description": "A prisoner's imprisonment status has been changed",
+  "occurredAt": "2023-08-04T08:09:36.649098+01:00",
+  "publishedAt": "2023-08-04T09:06:46.65281576+01:00",
+  "additionalInformation": {
+    "bookingId": "123"
+  },
+  "personReference": {
+    "identifiers": [
+      {
+        "type": "NOMS",
+        "value": "A0010DB"
+      }
+    ]
+  }
+}

--- a/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/prison-api-A0010DB-booking.json
+++ b/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/prison-api-A0010DB-booking.json
@@ -1,0 +1,12 @@
+{
+  "offenderNo": "A0010DB",
+  "bookingId": 10000001,
+  "bookingNo": "00001A",
+  "offenderId": 10000001,
+  "rootOffenderId": 10000001,
+  "firstName": "Bob",
+  "lastName": "Smith",
+  "dateOfBirth": "1992-03-15",
+  "activeFlag": true,
+  "agencyId": "OUT"
+}

--- a/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/prison-api-A0010DB-prisoner-alias-match.json
+++ b/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/prison-api-A0010DB-prisoner-alias-match.json
@@ -1,0 +1,27 @@
+[
+  {
+    "offenderNo": "A0010DB",
+    "firstName": "Terry",
+    "lastName": "Brown",
+    "dateOfBirth": "1962-08-12",
+    "gender": "Male",
+    "sexCode": "M",
+    "nationalities": "British",
+    "currentlyInPrison": "N",
+    "latestBookingId": 1000001,
+    "latestLocationId": "OUT",
+    "latestLocation": "Outside",
+    "pncNumber": "24/000001Y",
+    "croNumber": "00001/24M",
+    "ethnicity": "White: Eng./Welsh/Scot./N.Irish/British",
+    "ethnicityCode": "W1",
+    "birthCountry": "England",
+    "religion": "No Religion",
+    "religionCode": "NIL",
+    "convictedStatus": "Convicted",
+    "legalStatus": "SENTENCED",
+    "imprisonmentStatus": "ADIMP_ORA20",
+    "imprisonmentStatusDesc": "ORA 2020 Standard Determinate Sentence",
+    "receptionDate": "2024-02-15"
+  }
+]

--- a/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/prison-api-A0010DB-prisoner-match-noms.json
+++ b/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/prison-api-A0010DB-prisoner-match-noms.json
@@ -1,0 +1,27 @@
+[
+  {
+    "offenderNo": "A0010DB",
+    "firstName": "Bryan",
+    "lastName": "Adams",
+    "dateOfBirth": "1955-03-02",
+    "gender": "Male",
+    "sexCode": "M",
+    "nationalities": "British",
+    "currentlyInPrison": "N",
+    "latestBookingId": 1000001,
+    "latestLocationId": "OUT",
+    "latestLocation": "Outside",
+    "pncNumber": "24/000001Z",
+    "croNumber": "00001/24N",
+    "ethnicity": "White: Eng./Welsh/Scot./N.Irish/British",
+    "ethnicityCode": "W1",
+    "birthCountry": "England",
+    "religion": "No Religion",
+    "religionCode": "NIL",
+    "convictedStatus": "Convicted",
+    "legalStatus": "SENTENCED",
+    "imprisonmentStatus": "ADIMP_ORA20",
+    "imprisonmentStatusDesc": "ORA 2020 Standard Determinate Sentence",
+    "receptionDate": "2024-02-15"
+  }
+]

--- a/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/prison-api-A0010DB-prisoner.json
+++ b/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/prison-api-A0010DB-prisoner.json
@@ -1,0 +1,27 @@
+[
+  {
+    "offenderNo": "A0010DB",
+    "firstName": "Bob",
+    "lastName": "Smith",
+    "dateOfBirth": "1961-05-17",
+    "gender": "Male",
+    "sexCode": "M",
+    "nationalities": "British",
+    "currentlyInPrison": "N",
+    "latestBookingId": 1000001,
+    "latestLocationId": "OUT",
+    "latestLocation": "Outside",
+    "pncNumber": "24/000001Y",
+    "croNumber": "00001/24M",
+    "ethnicity": "White: Eng./Welsh/Scot./N.Irish/British",
+    "ethnicityCode": "W1",
+    "birthCountry": "England",
+    "religion": "No Religion",
+    "religionCode": "NIL",
+    "convictedStatus": "Convicted",
+    "legalStatus": "SENTENCED",
+    "imprisonmentStatus": "ADIMP_ORA20",
+    "imprisonmentStatusDesc": "ORA 2020 Standard Determinate Sentence",
+    "receptionDate": "2024-02-15"
+  }
+]

--- a/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/prison-api-A0100DB-booking.json
+++ b/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/prison-api-A0100DB-booking.json
@@ -1,0 +1,12 @@
+{
+  "offenderNo": "A0100DB",
+  "bookingId": 10000001,
+  "bookingNo": "00001A",
+  "offenderId": 10000001,
+  "rootOffenderId": 10000001,
+  "firstName": "John",
+  "lastName": "Smithy",
+  "dateOfBirth": "1992-03-15",
+  "activeFlag": true,
+  "agencyId": "OUT"
+}

--- a/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/prison-api-A0100DB-prisoner-match-cro.json
+++ b/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/prison-api-A0100DB-prisoner-match-cro.json
@@ -1,0 +1,27 @@
+[
+  {
+    "offenderNo": "A0100DB",
+    "firstName": "Brian",
+    "lastName": "Brown",
+    "dateOfBirth": "1962-08-12",
+    "gender": "Male",
+    "sexCode": "M",
+    "nationalities": "British",
+    "currentlyInPrison": "N",
+    "latestBookingId": 1000001,
+    "latestLocationId": "OUT",
+    "latestLocation": "Outside",
+    "pncNumber": "24/000001Z",
+    "croNumber": "00001/24M",
+    "ethnicity": "White: Eng./Welsh/Scot./N.Irish/British",
+    "ethnicityCode": "W1",
+    "birthCountry": "England",
+    "religion": "No Religion",
+    "religionCode": "NIL",
+    "convictedStatus": "Convicted",
+    "legalStatus": "SENTENCED",
+    "imprisonmentStatus": "ADIMP_ORA20",
+    "imprisonmentStatusDesc": "ORA 2020 Standard Determinate Sentence",
+    "receptionDate": "2024-02-15"
+  }
+]

--- a/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/prison-api-A0101DB-booking.json
+++ b/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/prison-api-A0101DB-booking.json
@@ -1,0 +1,12 @@
+{
+  "offenderNo": "A0101DB",
+  "bookingId": 10000001,
+  "bookingNo": "00001A",
+  "offenderId": 10000001,
+  "rootOffenderId": 10000001,
+  "firstName": "John",
+  "lastName": "Smithy",
+  "dateOfBirth": "1992-03-15",
+  "activeFlag": true,
+  "agencyId": "OUT"
+}

--- a/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/prison-api-A0101DB-prisoner-partial-name.json
+++ b/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/prison-api-A0101DB-prisoner-partial-name.json
@@ -1,0 +1,27 @@
+[
+  {
+    "offenderNo": "A0200DB",
+    "firstName": "Terry",
+    "lastName": "Smith",
+    "dateOfBirth": "1961-05-17",
+    "gender": "Male",
+    "sexCode": "M",
+    "nationalities": "British",
+    "currentlyInPrison": "N",
+    "latestBookingId": 1000001,
+    "latestLocationId": "OUT",
+    "latestLocation": "Outside",
+    "pncNumber": "24/000001Z",
+    "croNumber": "00001/24N",
+    "ethnicity": "White: Eng./Welsh/Scot./N.Irish/British",
+    "ethnicityCode": "W1",
+    "birthCountry": "England",
+    "religion": "No Religion",
+    "religionCode": "NIL",
+    "convictedStatus": "Convicted",
+    "legalStatus": "SENTENCED",
+    "imprisonmentStatus": "ADIMP_ORA20",
+    "imprisonmentStatusDesc": "ORA 2020 Standard Determinate Sentence",
+    "receptionDate": "2024-02-15"
+  }
+]

--- a/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/prison-api-A0102DB-booking.json
+++ b/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/prison-api-A0102DB-booking.json
@@ -1,0 +1,12 @@
+{
+  "offenderNo": "A0101DB",
+  "bookingId": 10000001,
+  "bookingNo": "00001A",
+  "offenderId": 10000001,
+  "rootOffenderId": 10000001,
+  "firstName": "John",
+  "lastName": "Smithy",
+  "dateOfBirth": "1992-03-15",
+  "activeFlag": true,
+  "agencyId": "OUT"
+}

--- a/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/prison-api-A0102DB-prisoner-partial-name-lenient-dob.json
+++ b/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/prison-api-A0102DB-prisoner-partial-name-lenient-dob.json
@@ -1,0 +1,27 @@
+[
+  {
+    "offenderNo": "A0102DB",
+    "firstName": "Terry",
+    "lastName": "Smith",
+    "dateOfBirth": "1961-08-17",
+    "gender": "Male",
+    "sexCode": "M",
+    "nationalities": "British",
+    "currentlyInPrison": "N",
+    "latestBookingId": 1000001,
+    "latestLocationId": "OUT",
+    "latestLocation": "Outside",
+    "pncNumber": "24/000001Z",
+    "croNumber": "00001/24N",
+    "ethnicity": "White: Eng./Welsh/Scot./N.Irish/British",
+    "ethnicityCode": "W1",
+    "birthCountry": "England",
+    "religion": "No Religion",
+    "religionCode": "NIL",
+    "convictedStatus": "Convicted",
+    "legalStatus": "SENTENCED",
+    "imprisonmentStatus": "ADIMP_ORA20",
+    "imprisonmentStatusDesc": "ORA 2020 Standard Determinate Sentence",
+    "receptionDate": "2024-02-15"
+  }
+]

--- a/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/prison-api-A0103DB-booking.json
+++ b/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/prison-api-A0103DB-booking.json
@@ -1,0 +1,12 @@
+{
+  "offenderNo": "A0100DB",
+  "bookingId": 10000001,
+  "bookingNo": "00001A",
+  "offenderId": 10000001,
+  "rootOffenderId": 10000001,
+  "firstName": "John",
+  "lastName": "Smithy",
+  "dateOfBirth": "1992-03-15",
+  "activeFlag": true,
+  "agencyId": "OUT"
+}

--- a/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/prison-api-A0103DB-prisoner-match-pnc-short.json
+++ b/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/prison-api-A0103DB-prisoner-match-pnc-short.json
@@ -1,0 +1,27 @@
+[
+  {
+    "offenderNo": "A0300DB",
+    "firstName": "Brian",
+    "lastName": "Brown",
+    "dateOfBirth": "1962-08-12",
+    "gender": "Male",
+    "sexCode": "M",
+    "nationalities": "British",
+    "currentlyInPrison": "N",
+    "latestBookingId": 1000001,
+    "latestLocationId": "OUT",
+    "latestLocation": "Outside",
+    "pncNumber": "24/000001Y",
+    "croNumber": "00001/24N",
+    "ethnicity": "White: Eng./Welsh/Scot./N.Irish/British",
+    "ethnicityCode": "W1",
+    "birthCountry": "England",
+    "religion": "No Religion",
+    "religionCode": "NIL",
+    "convictedStatus": "Convicted",
+    "legalStatus": "SENTENCED",
+    "imprisonmentStatus": "ADIMP_ORA20",
+    "imprisonmentStatusDesc": "ORA 2020 Standard Determinate Sentence",
+    "receptionDate": "2024-02-15"
+  }
+]

--- a/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/prison-api-A0104DB-booking.json
+++ b/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/prison-api-A0104DB-booking.json
@@ -1,0 +1,12 @@
+{
+  "offenderNo": "A0100DB",
+  "bookingId": 10000001,
+  "bookingNo": "00001A",
+  "offenderId": 10000001,
+  "rootOffenderId": 10000001,
+  "firstName": "John",
+  "lastName": "Smithy",
+  "dateOfBirth": "1992-03-15",
+  "activeFlag": true,
+  "agencyId": "OUT"
+}

--- a/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/prison-api-A0104DB-prisoner-match-pnc-long.json
+++ b/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/prison-api-A0104DB-prisoner-match-pnc-long.json
@@ -1,0 +1,27 @@
+[
+  {
+    "offenderNo": "A0400DB",
+    "firstName": "Brian",
+    "lastName": "Brown",
+    "dateOfBirth": "1962-08-12",
+    "gender": "Male",
+    "sexCode": "M",
+    "nationalities": "British",
+    "currentlyInPrison": "N",
+    "latestBookingId": 1000001,
+    "latestLocationId": "OUT",
+    "latestLocation": "Outside",
+    "pncNumber": "2024/000001Y",
+    "croNumber": "00001/24N",
+    "ethnicity": "White: Eng./Welsh/Scot./N.Irish/British",
+    "ethnicityCode": "W1",
+    "birthCountry": "England",
+    "religion": "No Religion",
+    "religionCode": "NIL",
+    "convictedStatus": "Convicted",
+    "legalStatus": "SENTENCED",
+    "imprisonmentStatus": "ADIMP_ORA20",
+    "imprisonmentStatusDesc": "ORA 2020 Standard Determinate Sentence",
+    "receptionDate": "2024-02-15"
+  }
+]

--- a/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/prison-api-A0105DB-booking.json
+++ b/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/prison-api-A0105DB-booking.json
@@ -1,0 +1,12 @@
+{
+  "offenderNo": "A0100DB",
+  "bookingId": 10000001,
+  "bookingNo": "00001A",
+  "offenderId": 10000001,
+  "rootOffenderId": 10000001,
+  "firstName": "John",
+  "lastName": "Smithy",
+  "dateOfBirth": "1992-03-15",
+  "activeFlag": true,
+  "agencyId": "OUT"
+}

--- a/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/prison-api-A0105DB-prisoner-match-name.json
+++ b/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/prison-api-A0105DB-prisoner-match-name.json
@@ -1,0 +1,27 @@
+[
+  {
+    "offenderNo": "A0500DB",
+    "firstName": "Bob",
+    "lastName": "Smith",
+    "dateOfBirth": "1961-05-17",
+    "gender": "Male",
+    "sexCode": "M",
+    "nationalities": "British",
+    "currentlyInPrison": "N",
+    "latestBookingId": 1000001,
+    "latestLocationId": "OUT",
+    "latestLocation": "Outside",
+    "pncNumber": "25/000001Z",
+    "croNumber": "00001/24L",
+    "ethnicity": "White: Eng./Welsh/Scot./N.Irish/British",
+    "ethnicityCode": "W1",
+    "birthCountry": "England",
+    "religion": "No Religion",
+    "religionCode": "NIL",
+    "convictedStatus": "Convicted",
+    "legalStatus": "SENTENCED",
+    "imprisonmentStatus": "ADIMP_ORA20",
+    "imprisonmentStatusDesc": "ORA 2020 Standard Determinate Sentence",
+    "receptionDate": "2024-02-15"
+  }
+]

--- a/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/prison-api-A0106DB-booking.json
+++ b/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/prison-api-A0106DB-booking.json
@@ -1,0 +1,12 @@
+{
+  "offenderNo": "A0100DB",
+  "bookingId": 10000001,
+  "bookingNo": "00001A",
+  "offenderId": 10000001,
+  "rootOffenderId": 10000001,
+  "firstName": "John",
+  "lastName": "Smithy",
+  "dateOfBirth": "1992-03-15",
+  "activeFlag": true,
+  "agencyId": "OUT"
+}

--- a/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/prison-api-A0106DB-prisoner-no-match.json
+++ b/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/prison-api-A0106DB-prisoner-no-match.json
@@ -1,0 +1,27 @@
+[
+  {
+    "offenderNo": "A0600DB",
+    "firstName": "Dave",
+    "lastName": "Jones",
+    "dateOfBirth": "1953-01-14",
+    "gender": "Male",
+    "sexCode": "M",
+    "nationalities": "British",
+    "currentlyInPrison": "N",
+    "latestBookingId": 1000001,
+    "latestLocationId": "OUT",
+    "latestLocation": "Outside",
+    "pncNumber": "25/000001Z",
+    "croNumber": "00001/24L",
+    "ethnicity": "White: Eng./Welsh/Scot./N.Irish/British",
+    "ethnicityCode": "W1",
+    "birthCountry": "England",
+    "religion": "No Religion",
+    "religionCode": "NIL",
+    "convictedStatus": "Convicted",
+    "legalStatus": "SENTENCED",
+    "imprisonmentStatus": "ADIMP_ORA20",
+    "imprisonmentStatusDesc": "ORA 2020 Standard Determinate Sentence",
+    "receptionDate": "2024-02-15"
+  }
+]

--- a/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/probation-search-single-result-db-compare.json
+++ b/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/probation-search-single-result-db-compare.json
@@ -1,0 +1,83 @@
+{
+  "matches": [
+    {
+      "offender": {
+        "offenderId": 1,
+        "title": "Mr",
+        "firstName": "Paul",
+        "middleNames": [],
+        "surname": "Smith",
+        "dateOfBirth": "1961-05-17",
+        "gender": "Smith",
+        "otherIds": {
+          "crn": "A000010",
+          "croNumber": "AB12/123456C",
+          "niNumber": "JJ123456C"
+        },
+        "contactDetails": {
+          "phoneNumbers": [],
+          "emailAddresses": []
+        },
+        "offenderProfile": {
+          "offenderLanguages": {
+            "requiresInterpreter": false
+          },
+          "previousConviction": {
+            "detail": {}
+          }
+        },
+        "offenderManagers": [
+          {
+            "staff": {
+              "code": "N57UATU",
+              "forenames": "Unallocated",
+              "surname": "Staff"
+            },
+            "partitionArea": "National Data",
+            "softDeleted": false,
+            "team": {
+              "code": "N57UAT",
+              "description": "Unallocated Team(N57)",
+              "district": {
+                "code": "N57UAT",
+                "description": "Unallocated Level 3(N57)"
+              },
+              "borough": {
+                "code": "N57UAT",
+                "description": "Unallocated Level2(N57)"
+              }
+            },
+            "probationArea": {
+              "code": "N57",
+              "description": "Kent Surrey Sussex Region",
+              "nps": false
+            },
+            "fromDate": "1900-01-01",
+            "active": true,
+            "allocationReason": {
+              "code": "IN1",
+              "description": "Initial Allocation"
+            }
+          }
+        ],
+        "softDeleted": false,
+        "currentDisposal": "0",
+        "partitionArea": "National Data",
+        "currentRestriction": true,
+        "restrictionMessage": "This is a restricted offender record. Please contact a system administrator",
+        "currentExclusion": false,
+        "exclusionMessage": "You are excluded from viewing this offender record. Please contact a system administrator",
+        "currentTier": "UD0",
+        "activeProbationManagedSentence": false,
+        "probationStatus": {
+          "status": "NOT_SENTENCED",
+          "inBreach": false,
+          "preSentenceActivity": false,
+          "awaitingPsr": false
+        },
+        "age": 63
+      }
+    }
+  ],
+  "matchedBy": "ALL_SUPPLIED"
+}

--- a/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/probation-search-single-result-db-difference.json
+++ b/projects/prison-identifier-and-delius/src/dev/resources/simulations/__files/probation-search-single-result-db-difference.json
@@ -1,0 +1,83 @@
+{
+  "matches": [
+    {
+      "offender": {
+        "offenderId": 1,
+        "title": "Mr",
+        "firstName": "Paul",
+        "middleNames": [],
+        "surname": "Smith",
+        "dateOfBirth": "1961-05-17",
+        "gender": "Smith",
+        "otherIds": {
+          "crn": "A000020",
+          "croNumber": "AB12/123456C",
+          "niNumber": "JJ123456C"
+        },
+        "contactDetails": {
+          "phoneNumbers": [],
+          "emailAddresses": []
+        },
+        "offenderProfile": {
+          "offenderLanguages": {
+            "requiresInterpreter": false
+          },
+          "previousConviction": {
+            "detail": {}
+          }
+        },
+        "offenderManagers": [
+          {
+            "staff": {
+              "code": "N57UATU",
+              "forenames": "Unallocated",
+              "surname": "Staff"
+            },
+            "partitionArea": "National Data",
+            "softDeleted": false,
+            "team": {
+              "code": "N57UAT",
+              "description": "Unallocated Team(N57)",
+              "district": {
+                "code": "N57UAT",
+                "description": "Unallocated Level 3(N57)"
+              },
+              "borough": {
+                "code": "N57UAT",
+                "description": "Unallocated Level2(N57)"
+              }
+            },
+            "probationArea": {
+              "code": "N57",
+              "description": "Kent Surrey Sussex Region",
+              "nps": false
+            },
+            "fromDate": "1900-01-01",
+            "active": true,
+            "allocationReason": {
+              "code": "IN1",
+              "description": "Initial Allocation"
+            }
+          }
+        ],
+        "softDeleted": false,
+        "currentDisposal": "0",
+        "partitionArea": "National Data",
+        "currentRestriction": true,
+        "restrictionMessage": "This is a restricted offender record. Please contact a system administrator",
+        "currentExclusion": false,
+        "exclusionMessage": "You are excluded from viewing this offender record. Please contact a system administrator",
+        "currentTier": "UD0",
+        "activeProbationManagedSentence": false,
+        "probationStatus": {
+          "status": "NOT_SENTENCED",
+          "inBreach": false,
+          "preSentenceActivity": false,
+          "awaitingPsr": false
+        },
+        "age": 63
+      }
+    }
+  ],
+  "matchedBy": "ALL_SUPPLIED"
+}

--- a/projects/prison-identifier-and-delius/src/dev/resources/simulations/mappings/prison-api.json
+++ b/projects/prison-identifier-and-delius/src/dev/resources/simulations/mappings/prison-api.json
@@ -16,6 +16,19 @@
     {
       "request": {
         "method": "GET",
+        "url": "/prison-api/api/prisoners/A0010DB"
+      },
+      "response": {
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "status": 200,
+        "bodyFileName": "prison-api-A0001AA-prisoner.json"
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
         "url": "/prison-api/api/bookings/offenderNo/A0001AA"
       },
       "response": {
@@ -50,6 +63,19 @@
         },
         "status": 200,
         "bodyFileName": "prison-api-A0002AA-booking-inactive.json"
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "/prison-api/api/bookings/offenderNo/A0010DB"
+      },
+      "response": {
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "status": 200,
+        "bodyFileName": "prison-api-A0010DB-booking.json"
       }
     }
   ]

--- a/projects/prison-identifier-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/DatabaseProbationMatchingIntegrationTest.kt
+++ b/projects/prison-identifier-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/DatabaseProbationMatchingIntegrationTest.kt
@@ -1,0 +1,386 @@
+package uk.gov.justice.digital.hmpps
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.*
+import com.github.tomakehurst.wiremock.common.ContentTypes.APPLICATION_JSON
+import com.github.tomakehurst.wiremock.common.ContentTypes.CONTENT_TYPE
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
+import org.mockito.Mockito.anyMap
+import org.mockito.Mockito.verify
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
+import uk.gov.justice.digital.hmpps.entity.AdditionalIdentifierRepository
+import uk.gov.justice.digital.hmpps.entity.CustodyRepository
+import uk.gov.justice.digital.hmpps.entity.PersonRepository
+import uk.gov.justice.digital.hmpps.flags.FeatureFlags
+import uk.gov.justice.digital.hmpps.messaging.HmppsChannelManager
+import uk.gov.justice.digital.hmpps.telemetry.TelemetryService
+
+@AutoConfigureMockMvc
+@TestMethodOrder(OrderAnnotation::class)
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+internal class DatabaseProbationMatchingIntegrationTest {
+
+    @Value("\${messaging.consumer.queue}")
+    lateinit var queueName: String
+
+    @Autowired
+    lateinit var channelManager: HmppsChannelManager
+
+    @Autowired
+    lateinit var wireMockServer: WireMockServer
+
+    @MockitoSpyBean
+    lateinit var personRepository: PersonRepository
+
+    @MockitoSpyBean
+    lateinit var custodyRepository: CustodyRepository
+
+    @MockitoSpyBean
+    lateinit var additionalIdentifierRepository: AdditionalIdentifierRepository
+
+    @MockitoBean
+    lateinit var telemetryService: TelemetryService
+
+    @MockitoSpyBean
+    lateinit var featureFlags: FeatureFlags
+
+    @BeforeEach
+    fun setUp() {
+        whenever(featureFlags.enabled("prison-identifiers-use-db-search")).thenReturn(true)
+        whenever(featureFlags.enabled("prison-identifiers-compare-with-db-search")).thenReturn(false)
+    }
+
+    @Test
+    @Order(1)
+    fun `prisoner received updates identifiers db full match`() {
+        withMatchResponse("probation-search-single-result-db-compare.json")
+        withJsonResponse(
+            "/prison-api/api/prisoners/A0010DB",
+            "prison-api-A0010DB-prisoner.json"
+        )
+
+        val event = prepEvent("prisoner-status-changed-db", wireMockServer.port())
+        channelManager.getChannel(queueName).publishAndWait(event)
+
+        verify(telemetryService).trackEvent(
+            "MatchResultSuccess", mapOf(
+                "reason" to "Matched CRN A000010 to NOMS number A0010DB and custody ${custodyId("A000010")} to 00001A",
+                "dryRun" to "false",
+                "nomsNumber" to "A0010DB",
+                "bookingNo" to "00001A",
+                "matchedBy" to "ALL_SUPPLIED",
+                "potentialMatches" to """[{"crn":"A000010"}]""",
+                "existingNomsNumber" to "A0010DB",
+                "matchedNomsNumber" to "A0010DB",
+                "nomsNumberChanged" to "false",
+                "matchedBookingNumber" to "00001A",
+                "bookingNumberChanged" to "true",
+                "custody" to "${custodyId("A000010")}",
+                "sentenceDateInDelius" to "2022-11-11",
+                "sentenceDateInNomis" to "2022-11-11",
+                "totalCustodialEvents" to "1",
+                "matchingCustodialEvents" to "1"
+            )
+        )
+    }
+
+    @Test
+    @Order(2)
+    fun `prisoner received updates identifiers db alias match`() {
+        withMatchResponse("probation-search-single-result-db-compare.json")
+        withJsonResponse(
+            "/prison-api/api/prisoners/A0010DB",
+            "prison-api-A0010DB-prisoner-alias-match.json"
+        )
+
+        val event = prepEvent("prisoner-status-changed-db", wireMockServer.port())
+        channelManager.getChannel(queueName).publishAndWait(event)
+
+        verify(telemetryService).trackEvent(
+            "MatchResultSuccess", mapOf(
+                "reason" to "Matched CRN A000010 to NOMS number A0010DB and custody ${custodyId("A000010")} to 00001A",
+                "dryRun" to "false",
+                "nomsNumber" to "A0010DB",
+                "bookingNo" to "00001A",
+                "matchedBy" to "ALL_SUPPLIED_ALIAS",
+                "potentialMatches" to """[{"crn":"A000010"}]""",
+                "existingNomsNumber" to "A0010DB",
+                "matchedNomsNumber" to "A0010DB",
+                "nomsNumberChanged" to "false",
+                "existingBookingNumber" to "00001A",
+                "matchedBookingNumber" to "00001A",
+                "bookingNumberChanged" to "false",
+                "custody" to "${custodyId("A000010")}",
+                "sentenceDateInDelius" to "2022-11-11",
+                "sentenceDateInNomis" to "2022-11-11",
+                "totalCustodialEvents" to "1",
+                "matchingCustodialEvents" to "1"
+            )
+        )
+    }
+
+    @Test
+    @Order(3)
+    fun `prisoner received updated identifiers noms number match (HMPPS_KEY)`() {
+        withMatchResponse("probation-search-single-result-db-compare.json")
+        withJsonResponse(
+            "/prison-api/api/bookings/offenderNo/A0001DB",
+            "prison-api-A0001DB-booking.json"
+        )
+        withJsonResponse(
+            "/prison-api/api/prisoners/A0010DB",
+            "prison-api-A0010DB-prisoner-match-noms.json"
+        )
+
+        val event = prepEvent("prisoner-status-changed-db", wireMockServer.port())
+        channelManager.getChannel(queueName).publishAndWait(event)
+
+        val eventCaptor = argumentCaptor<Map<String, String?>>()
+        verify(telemetryService).trackEvent(
+            org.mockito.kotlin.eq("MatchResultSuccess"),
+            eventCaptor.capture(),
+            anyMap()
+        )
+        assertThat(eventCaptor.firstValue["matchedBy"], equalTo("HMPPS_KEY"))
+    }
+
+    @Test
+    @Order(4)
+    fun `prisoner received updated identifiers cro number match (EXTERNAL_KEY)`() {
+        withMatchResponse("probation-search-single-result-db-compare.json")
+        withJsonResponse(
+            "/prison-api/api/bookings/offenderNo/A0100DB",
+            "prison-api-A0100DB-booking.json"
+        )
+        withJsonResponse(
+            "/prison-api/api/prisoners/A0100DB",
+            "prison-api-A0100DB-prisoner-match-cro.json"
+        )
+
+        val event = prepEvent("prisoner-status-changed-db-cro", wireMockServer.port())
+        channelManager.getChannel(queueName).publishAndWait(event)
+
+        val eventCaptor = argumentCaptor<Map<String, String?>>()
+        verify(telemetryService).trackEvent(
+            org.mockito.kotlin.eq("MatchResultSuccess"),
+            eventCaptor.capture(),
+            anyMap()
+        )
+        assertThat(eventCaptor.firstValue["matchedBy"], equalTo("EXTERNAL_KEY"))
+    }
+
+    @Test
+    @Order(5)
+    fun `prisoner received updated identifiers pnc (short format) number match (EXTERNAL_KEY)`() {
+        withMatchResponse("probation-search-single-result-db-compare.json")
+        withJsonResponse(
+            "/prison-api/api/bookings/offenderNo/A0103DB",
+            "prison-api-A0103DB-booking.json"
+        )
+        withJsonResponse(
+            "/prison-api/api/prisoners/A0103DB",
+            "prison-api-A0103DB-prisoner-match-pnc-short.json"
+        )
+
+        val event = prepEvent("prisoner-status-changed-db-pnc-short", wireMockServer.port())
+        channelManager.getChannel(queueName).publishAndWait(event)
+
+        val eventCaptor = argumentCaptor<Map<String, String?>>()
+        verify(telemetryService).trackEvent(
+            org.mockito.kotlin.eq("MatchResultSuccess"),
+            eventCaptor.capture(),
+            anyMap()
+        )
+        assertThat(eventCaptor.firstValue["matchedBy"], equalTo("EXTERNAL_KEY"))
+    }
+
+    @Test
+    @Order(6)
+    fun `prisoner received updated identifiers pnc (long format) number match (EXTERNAL_KEY)`() {
+        withMatchResponse("probation-search-single-result-db-compare.json")
+        withJsonResponse(
+            "/prison-api/api/bookings/offenderNo/A0104DB",
+            "prison-api-A0104DB-booking.json"
+        )
+        withJsonResponse(
+            "/prison-api/api/prisoners/A0104DB",
+            "prison-api-A0104DB-prisoner-match-pnc-long.json"
+        )
+
+        val event = prepEvent("prisoner-status-changed-db-pnc-long", wireMockServer.port())
+        channelManager.getChannel(queueName).publishAndWait(event)
+
+        val eventCaptor = argumentCaptor<Map<String, String?>>()
+        verify(telemetryService).trackEvent(
+            org.mockito.kotlin.eq("MatchResultSuccess"),
+            eventCaptor.capture(),
+            anyMap()
+        )
+        assertThat(eventCaptor.firstValue["matchedBy"], equalTo("EXTERNAL_KEY"))
+    }
+
+    @Test
+    @Order(7)
+    fun `prisoner received updated identifiers name match (NAME)`() {
+        withMatchResponse("probation-search-single-result-db-compare.json")
+        withJsonResponse(
+            "/prison-api/api/bookings/offenderNo/A0105DB",
+            "prison-api-A0105DB-booking.json"
+        )
+        withJsonResponse(
+            "/prison-api/api/prisoners/A0105DB",
+            "prison-api-A0105DB-prisoner-match-name.json"
+        )
+
+        val event = prepEvent("prisoner-status-changed-db-name", wireMockServer.port())
+        channelManager.getChannel(queueName).publishAndWait(event)
+
+        val eventCaptor = argumentCaptor<Map<String, String?>>()
+        verify(telemetryService).trackEvent(
+            org.mockito.kotlin.eq("MatchResultSuccess"),
+            eventCaptor.capture(),
+            anyMap()
+        )
+        assertThat(eventCaptor.firstValue["matchedBy"], equalTo("NAME"))
+    }
+
+    @Test
+    @Order(8)
+    fun `prisoner received updated identifiers db partial name match`() {
+        withMatchResponse("probation-search-single-result-db-compare.json")
+        withJsonResponse(
+            "/prison-api/api/bookings/offenderNo/A0101DB",
+            "prison-api-A0101DB-booking.json"
+        )
+        withJsonResponse(
+            "/prison-api/api/prisoners/A0101DB",
+            "prison-api-A0101DB-prisoner-partial-name.json"
+        )
+
+        val event = prepEvent("prisoner-status-changed-db-partial-name", wireMockServer.port())
+        channelManager.getChannel(queueName).publishAndWait(event)
+
+        val eventCaptor = argumentCaptor<Map<String, String?>>()
+        verify(telemetryService).trackEvent(
+            org.mockito.kotlin.eq("MatchResultSuccess"),
+            eventCaptor.capture(),
+            anyMap()
+        )
+        assertThat(eventCaptor.firstValue["matchedBy"], equalTo("PARTIAL_NAME"))
+    }
+
+    @Test
+    @Order(9)
+    fun `prisoner received updated identifiers db partial name match lenient dob`() {
+        withMatchResponse("probation-search-single-result-db-compare.json")
+        withJsonResponse(
+            "/prison-api/api/bookings/offenderNo/A0102DB",
+            "prison-api-A0102DB-booking.json"
+        )
+        withJsonResponse(
+            "/prison-api/api/prisoners/A0102DB",
+            "prison-api-A0102DB-prisoner-partial-name-lenient-dob.json"
+        )
+
+        val event = prepEvent("prisoner-status-changed-db-lenient-dob", wireMockServer.port())
+        channelManager.getChannel(queueName).publishAndWait(event)
+
+        val eventCaptor = argumentCaptor<Map<String, String?>>()
+        verify(telemetryService).trackEvent(
+            org.mockito.kotlin.eq("MatchResultSuccess"),
+            eventCaptor.capture(),
+            anyMap()
+        )
+        assertThat(eventCaptor.firstValue["matchedBy"], equalTo("PARTIAL_NAME_DOB_LENIENT"))
+    }
+
+    @Test
+    @Order(10)
+    fun `prisoner received updated identifiers db no match (NOTHING)`() {
+        withMatchResponse("probation-search-single-result-db-compare.json")
+        withJsonResponse(
+            "/prison-api/api/bookings/offenderNo/A0106DB",
+            "prison-api-A0106DB-booking.json"
+        )
+        withJsonResponse(
+            "/prison-api/api/prisoners/A0106DB",
+            "prison-api-A0106DB-prisoner-no-match.json"
+        )
+
+        val event = prepEvent("prisoner-status-changed-db-no-match", wireMockServer.port())
+        channelManager.getChannel(queueName).publishAndWait(event)
+
+        val eventCaptor = argumentCaptor<Map<String, String?>>()
+        verify(telemetryService).trackEvent(
+            org.mockito.kotlin.eq("MatchResultNoMatch"),
+            eventCaptor.capture(),
+            anyMap()
+        )
+        assertThat(eventCaptor.firstValue["matchedBy"], equalTo("NOTHING"))
+    }
+
+    @Test
+    @Order(11)
+    fun `prisoner received updated identifiers compare with api response`() {
+
+        whenever(featureFlags.enabled("prison-identifiers-use-db-search")).thenReturn(false)
+        whenever(featureFlags.enabled("prison-identifiers-compare-with-db-search")).thenReturn(true)
+
+        withMatchResponse("probation-search-single-result-db-difference.json")
+        withJsonResponse(
+            "/prison-api/api/bookings/offenderNo/A0102DB",
+            "prison-api-A0102DB-booking.json"
+        )
+        withJsonResponse(
+            "/prison-api/api/prisoners/A0102DB",
+            "prison-api-A0102DB-prisoner-partial-name-lenient-dob.json"
+        )
+
+        val event = prepEvent("prisoner-status-changed-db-lenient-dob", wireMockServer.port())
+        channelManager.getChannel(queueName).publishAndWait(event)
+
+        val eventCaptorComparisonFailure = argumentCaptor<Map<String, String?>>()
+
+        verify(telemetryService).trackEvent(
+            org.mockito.kotlin.eq("MatchDifferenceFound"),
+            eventCaptorComparisonFailure.capture(),
+            anyMap()
+        )
+
+        assertThat(
+            eventCaptorComparisonFailure.firstValue, equalTo(
+                mapOf(
+                    "nomsNumber" to "A0102DB",
+                    "apiMatches" to "A000020",
+                    "dbMatches" to "A000010"
+                )
+            )
+        )
+    }
+
+    private fun withJsonResponse(url: String, filename: String) {
+        val response = aResponse().withStatus(200).withBodyFile(filename).withHeader(CONTENT_TYPE, APPLICATION_JSON)
+        wireMockServer.addStubMapping(get(url).willReturn(response).build())
+    }
+
+    private fun withMatchResponse(filename: String) {
+        val response = aResponse().withStatus(200).withBodyFile(filename).withHeader(CONTENT_TYPE, APPLICATION_JSON)
+        wireMockServer.addStubMapping(post("/probation-search/match").willReturn(response).build())
+    }
+
+    private fun custodyId(crn: String): Long = personRepository.findSentencedByCrn(crn).first().custody!!.id
+}

--- a/projects/prison-identifier-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/ProbationMatchingIntegrationTest.kt
+++ b/projects/prison-identifier-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/ProbationMatchingIntegrationTest.kt
@@ -4,9 +4,11 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.*
 import com.github.tomakehurst.wiremock.common.ContentTypes.APPLICATION_JSON
 import com.github.tomakehurst.wiremock.common.ContentTypes.CONTENT_TYPE
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.verify
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
@@ -18,6 +20,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
 import uk.gov.justice.digital.hmpps.entity.AdditionalIdentifierRepository
 import uk.gov.justice.digital.hmpps.entity.CustodyRepository
 import uk.gov.justice.digital.hmpps.entity.PersonRepository
+import uk.gov.justice.digital.hmpps.flags.FeatureFlags
 import uk.gov.justice.digital.hmpps.messaging.HmppsChannelManager
 import uk.gov.justice.digital.hmpps.telemetry.TelemetryService
 
@@ -45,6 +48,15 @@ internal class ProbationMatchingIntegrationTest {
 
     @MockitoBean
     lateinit var telemetryService: TelemetryService
+
+    @MockitoSpyBean
+    lateinit var featureFlags: FeatureFlags
+
+    @BeforeEach
+    fun setUp() {
+        whenever(featureFlags.enabled("prison-identifiers-use-db-search")).thenReturn(false)
+        whenever(featureFlags.enabled("prison-identifiers-compare-with-db-search")).thenReturn(false)
+    }
 
     @Test
     fun `inactive booking is ignored`() {

--- a/projects/prison-identifier-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/entity/Person.kt
+++ b/projects/prison-identifier-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/entity/Person.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.entity
 import jakarta.persistence.*
 import org.hibernate.annotations.Fetch
 import org.hibernate.annotations.FetchMode
+import org.hibernate.annotations.Immutable
 import org.hibernate.annotations.SQLRestriction
 import org.hibernate.type.NumericBooleanConverter
 import org.springframework.data.annotation.CreatedBy
@@ -46,10 +47,27 @@ class Person(
     @Column(name = "surname")
     val surname: String,
 
+    @Column(name = "previous_surname")
+    val previousSurname: String? = null,
+
+    @ManyToOne
+    @JoinColumn(name = "title_id")
+    val title: ReferenceData? = null,
+
+    @Column(name = "current_disposal", columnDefinition = "number")
+    @Convert(converter = NumericBooleanConverter::class)
+    val currentDisposal: Boolean,
+
     @Column(columnDefinition = "char(7)")
     var nomsNumber: String? = null,
 
-    @Column
+    @Column(name = "immigration_number")
+    val immigrationNumber: String? = null,
+
+    @Column(name = "ni_number", columnDefinition = "char(9)")
+    val niNumber: String? = null,
+
+    @Column(name = "most_recent_prisoner_number")
     var mostRecentPrisonerNumber: String? = null,
 
     @Column
@@ -99,6 +117,31 @@ class Person(
     fun custodiesWithSentenceDateCloseTo(sentenceDate: LocalDate) =
         custodies().filter { sentenceDate.withinDays(it.disposal.startDate) }
 }
+
+@Immutable
+@Entity
+@Table(name = "alias")
+@SQLRestriction("soft_deleted = 0")
+class Alias(
+    @Id
+    @Column(name = "alias_id")
+    val id: Long,
+    @Column(name = "offender_id")
+    val offenderId: Long,
+    @Column(name = "first_name", length = 35)
+    val forename: String,
+    @Column(name = "second_name", length = 35)
+    val secondName: String? = null,
+    @Column(name = "third_name", length = 35)
+    val thirdName: String? = null,
+    @Column(name = "surname", length = 35)
+    val surname: String,
+    @Column(name = "date_of_birth_date")
+    val dateOfBirth: LocalDate,
+    @Column(name = "soft_deleted", columnDefinition = "number")
+    @Convert(converter = NumericBooleanConverter::class)
+    val softDeleted: Boolean = false
+)
 
 interface PersonRepository : JpaRepository<Person, Long> {
     @Query(

--- a/projects/prison-identifier-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/entity/ProbationSearchRepository.kt
+++ b/projects/prison-identifier-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/entity/ProbationSearchRepository.kt
@@ -203,16 +203,6 @@ interface ProbationSearchRepository : JpaRepository<Person, Long> {
     ): List<Person>
 }
 
-/*
-ProbationMatchRequest(
-firstName=TERRY,
-surname=BEIER-HUEL,
- dateOfBirth=1973-04-29,
- nomsNumber=A1036EA,
- activeSentence=true,
- pncNumber=1973/636766X,
-  croNumber=null)
- */
 fun ProbationSearchRepository.fullSearch(request: ProbationMatchRequest): List<Person> = personFullMatchAllSupplied(
     pncNumber = request.pncNumber?.takeIf { it.isNotEmpty() }?.let { SearchHelpers.formatPncNumber(it) },
     nomsNumber = request.nomsNumber.takeIf { it.isNotEmpty() },

--- a/projects/prison-identifier-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/entity/ProbationSearchRepository.kt
+++ b/projects/prison-identifier-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/entity/ProbationSearchRepository.kt
@@ -1,0 +1,266 @@
+package uk.gov.justice.digital.hmpps.entity
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import uk.gov.justice.digital.hmpps.client.ProbationMatchRequest
+import uk.gov.justice.digital.hmpps.utils.SearchHelpers
+import uk.gov.justice.digital.hmpps.utils.SearchHelpers.allLenientDateVariations
+import java.time.LocalDate
+
+interface ProbationSearchRepository : JpaRepository<Person, Long> {
+    @Query(
+        """
+            select distinct p from Person p
+            where
+                (:croNumber is null or (:croNumber is not null and lower(trim(p.croNumber)) = lower(:croNumber)))
+                and
+                (
+                :pncNumber is null or (
+                    lower(trim(p.pncNumber)) = lower(trim(:pncNumber)) or
+                    lower(trim(substr(p.pncNumber,3))) = lower(trim(substr(:pncNumber,3))) or
+                    lower(trim(substr(p.pncNumber,3))) = lower(trim(:pncNumber)) or
+                    lower(trim(p.pncNumber)) = lower(trim(substr(:pncNumber,3)))
+                    )
+                )
+                and
+                (:nomsNumber is null or (:nomsNumber is not null and lower(trim(p.nomsNumber)) = lower(:nomsNumber)))
+                and
+                (:activeSentence != true or (:activeSentence = true and p.currentDisposal = true ))
+                and
+                (:forename is null or (:forename is not null and lower(trim(p.forename)) = lower(:forename)))
+                and 
+                (:surname is null or (:surname is not null and lower(trim(p.surname)) = lower(:surname)))
+                and 
+                (:dateOfBirth is null or (:dateOfBirth is not null and p.dateOfBirth = :dateOfBirth))
+                
+        """
+    )
+    fun personFullMatchAllSupplied(
+        pncNumber: String?,
+        croNumber: String?,
+        nomsNumber: String?,
+        activeSentence: Boolean = false,
+        forename: String?,
+        surname: String?,
+        dateOfBirth: LocalDate? = null,
+    ): List<Person>
+
+    @Query(
+        """
+            select distinct p from Person p join Alias a on p.id = a.offenderId
+            where
+                (:croNumber is null or (:croNumber is not null and lower(trim(p.croNumber)) = lower(:croNumber)))
+                and
+                (
+                :pncNumber is null or (
+                    lower(trim(p.pncNumber)) = lower(trim(:pncNumber)) or
+                    lower(trim(substr(p.pncNumber,3))) = lower(trim(substr(:pncNumber,3))) or
+                    lower(trim(substr(p.pncNumber,3))) = lower(trim(:pncNumber)) or
+                    lower(trim(p.pncNumber)) = lower(trim(substr(:pncNumber,3)))
+                ))
+                and
+                (:nomsNumber is null or (:nomsNumber is not null and lower(trim(p.nomsNumber)) = lower(:nomsNumber)))
+                and
+                (:activeSentence != true or (:activeSentence = true and p.currentDisposal = true ))
+                and
+                (:forename is null or (:forename is not null and lower(trim(a.forename)) = lower(:forename)))
+                and 
+                (:surname is null or (:surname is not null and lower(trim(a.surname)) = lower(:surname)))
+                and 
+                (:dateOfBirth is null or (:dateOfBirth is not null and a.dateOfBirth = :dateOfBirth))
+                
+        """
+    )
+    fun personFullMatchAliasAllSupplied(
+        pncNumber: String?,
+        croNumber: String?,
+        nomsNumber: String?,
+        activeSentence: Boolean = false,
+        forename: String?,
+        surname: String?,
+        dateOfBirth: LocalDate? = null,
+    ): List<Person>
+
+    @Query(
+        """
+            select distinct p 
+            from Person p 
+            where :nomsNumber is not null and lower(trim(p.nomsNumber)) = lower(trim(:nomsNumber))
+        """
+    )
+    fun findPersonByNomsNumber(nomsNumber: String?): List<Person>
+
+    @Query(
+        """
+            select distinct p 
+            from Person p left join Alias a on a.offenderId = p.id
+            where :croNumber is not null and lower(trim(p.croNumber)) = lower(trim(:croNumber))
+            and (:surname is null 
+                or lower(trim(p.surname)) = lower(trim(:surname)) 
+                or lower(trim(a.surname)) = lower(trim(:surname)))
+            and (:dateOfBirth is null 
+                or p.dateOfBirth = :dateOfBirth
+                or a.dateOfBirth = :dateOfBirth)   
+        """
+    )
+    fun findPersonByCroNumber(croNumber: String?, surname: String?, dateOfBirth: LocalDate?): List<Person>
+
+    @Query(
+        """
+            select distinct p 
+            from Person p left join Alias a on a.offenderId = p.id
+            where :pncNumber is not null and 
+            (    
+                lower(trim(p.pncNumber)) = lower(trim(:pncNumber)) or
+                lower(trim(substr(p.pncNumber,3))) = lower(trim(substr(:pncNumber,3))) or
+                lower(trim(substr(p.pncNumber,3))) = lower(trim(:pncNumber)) or
+                lower(trim(p.pncNumber)) = lower(trim(substr(:pncNumber,3)))
+            )
+            and (:surname is null 
+                or lower(trim(p.surname)) = lower(trim(:surname)) 
+                or lower(trim(a.surname)) = lower(trim(:surname)))
+            and (:dateOfBirth is null 
+                or p.dateOfBirth = :dateOfBirth
+                or a.dateOfBirth = :dateOfBirth)   
+        """
+    )
+    fun findPersonByPncNumber(pncNumber: String?, surname: String?, dateOfBirth: LocalDate?): List<Person>
+
+    @Query(
+        """
+            select distinct p 
+            from Person p left join Alias a on a.offenderId = p.id
+            where 
+            (:activeSentence != true or (:activeSentence = true and p.currentDisposal = true ))
+            and
+            (
+                (
+                    (:forename is null or (:forename is not null and lower(trim(a.forename)) = lower(:forename)))
+                    and 
+                    (:surname is null or (:surname is not null and lower(trim(a.surname)) = lower(:surname)))
+                    and 
+                    (:dateOfBirth is null or (:dateOfBirth is not null and a.dateOfBirth = :dateOfBirth))
+                )
+                or
+                (
+                    (:forename is null or (:forename is not null and lower(trim(p.forename)) = lower(:forename)))
+                    and 
+                    (:surname is null or (:surname is not null and lower(trim(p.surname)) = lower(:surname)))
+                    and 
+                    (:dateOfBirth is null or (:dateOfBirth is not null and p.dateOfBirth = :dateOfBirth))
+                )
+            )
+        """
+    )
+    fun findPersonByName(
+        forename: String?,
+        surname: String?,
+        dateOfBirth: LocalDate?,
+        activeSentence: Boolean = false
+    ): List<Person>
+
+    @Query(
+        """
+            select distinct p 
+            from Person p
+            where
+            (:activeSentence != true or (:activeSentence = true and p.currentDisposal = true ))
+            and
+            (
+                (:surname is null or (:surname is not null and lower(trim(p.surname)) = lower(:surname)))
+                and 
+                (:dateOfBirth is null or (:dateOfBirth is not null and p.dateOfBirth = :dateOfBirth))
+            )
+        """
+    )
+    fun findPersonByPartialName(
+        surname: String?,
+        dateOfBirth: LocalDate?,
+        activeSentence: Boolean = false
+    ): List<Person>
+
+    @Query(
+        """
+            select distinct p 
+            from Person p left join Alias a on a.offenderId = p.id
+            where
+            (:activeSentence != true or (:activeSentence = true and p.currentDisposal = true ))
+            and
+            (
+                (:forename is null or (:forename is not null and (lower(trim(p.forename)) = lower(:forename) or lower(trim(a.forename)) = lower(:forename))))
+                and
+                (:surname is null or (:surname is not null and lower(trim(p.surname)) = lower(:surname)))
+                and 
+                (p.dateOfBirth in (:dateOfBirths))
+            )
+        """
+    )
+    fun findPersonByPartialNameLenientDob(
+        forename: String?,
+        surname: String?,
+        dateOfBirths: List<LocalDate>,
+        activeSentence: Boolean = false
+    ): List<Person>
+}
+
+/*
+ProbationMatchRequest(
+firstName=TERRY,
+surname=BEIER-HUEL,
+ dateOfBirth=1973-04-29,
+ nomsNumber=A1036EA,
+ activeSentence=true,
+ pncNumber=1973/636766X,
+  croNumber=null)
+ */
+fun ProbationSearchRepository.fullSearch(request: ProbationMatchRequest): List<Person> = personFullMatchAllSupplied(
+    pncNumber = request.pncNumber?.takeIf { it.isNotEmpty() }?.let { SearchHelpers.formatPncNumber(it) },
+    nomsNumber = request.nomsNumber.takeIf { it.isNotEmpty() },
+    croNumber = request.croNumber?.takeIf { it.isNotEmpty() },
+    activeSentence = request.activeSentence,
+    forename = request.firstName.takeIf { it.isNotEmpty() },
+    surname = request.surname.takeIf { it.isNotEmpty() },
+    dateOfBirth = request.dateOfBirth
+)
+
+fun ProbationSearchRepository.fullSearchAlias(request: ProbationMatchRequest): List<Person> =
+    personFullMatchAliasAllSupplied(
+        pncNumber = request.pncNumber?.takeIf { it.isNotEmpty() }?.let { SearchHelpers.formatPncNumber(it) },
+        nomsNumber = request.nomsNumber.takeIf { it.isNotEmpty() },
+        croNumber = request.croNumber?.takeIf { it.isNotEmpty() },
+        activeSentence = request.activeSentence,
+        forename = request.firstName.takeIf { it.isNotEmpty() },
+        surname = request.surname.takeIf { it.isNotEmpty() },
+        dateOfBirth = request.dateOfBirth
+    )
+
+fun ProbationSearchRepository.searchByNoms(request: ProbationMatchRequest): List<Person> =
+    findPersonByNomsNumber(request.nomsNumber.takeIf { it.isNotEmpty() })
+
+fun ProbationSearchRepository.searchByCro(request: ProbationMatchRequest): List<Person> =
+    findPersonByCroNumber(
+        request.croNumber?.takeIf { it.isNotEmpty() },
+        request.surname.takeIf { it.isNotEmpty() }, request.dateOfBirth
+    )
+
+fun ProbationSearchRepository.searchByPnc(request: ProbationMatchRequest): List<Person> =
+    findPersonByPncNumber(
+        request.pncNumber?.takeIf { it.isNotEmpty() }?.let { SearchHelpers.formatPncNumber(it) },
+        request.surname.takeIf { it.isNotEmpty() }, request.dateOfBirth
+    )
+
+fun ProbationSearchRepository.searchByName(request: ProbationMatchRequest): List<Person> =
+    findPersonByName(
+        request.firstName.takeIf { it.isNotEmpty() },
+        request.surname.takeIf { it.isNotEmpty() }, request.dateOfBirth
+    )
+
+fun ProbationSearchRepository.searchByPartialName(request: ProbationMatchRequest): List<Person> =
+    findPersonByPartialName(request.surname.takeIf { it.isNotEmpty() }, request.dateOfBirth)
+
+fun ProbationSearchRepository.searchByPartialNameLenientDob(request: ProbationMatchRequest): List<Person> {
+    return findPersonByPartialNameLenientDob(
+        request.firstName.takeIf { it.isNotEmpty() },
+        request.surname.takeIf { it.isNotEmpty() }, allLenientDateVariations(request.dateOfBirth)
+    )
+}

--- a/projects/prison-identifier-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/entity/ReferenceData.kt
+++ b/projects/prison-identifier-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/entity/ReferenceData.kt
@@ -16,6 +16,9 @@ class ReferenceData(
     @Column(name = "code_value")
     val code: String,
 
+    @Column(name = "code_description")
+    val description: String,
+
     @ManyToOne
     @JoinColumn(name = "reference_data_master_id")
     val set: ReferenceDataSet,

--- a/projects/prison-identifier-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/ProbationDatabaseMatchingService.kt
+++ b/projects/prison-identifier-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/ProbationDatabaseMatchingService.kt
@@ -54,7 +54,7 @@ class ProbationDatabaseMatchingService(
         val dbMatchResponse = match(request)
         val dbCrns = dbMatchResponse.matches.map { it.offender.otherIds.crn }.toSet()
         val apiCrns = apiMatchResponse.matches.map { it.offender.otherIds.crn }.toSet()
-        if(dbCrns != apiCrns) {
+        if (dbCrns != apiCrns) {
             //Difference found
             telemetryService.trackEvent(
                 "MatchDifferenceFound",

--- a/projects/prison-identifier-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/ProbationDatabaseMatchingService.kt
+++ b/projects/prison-identifier-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/ProbationDatabaseMatchingService.kt
@@ -1,0 +1,89 @@
+package uk.gov.justice.digital.hmpps.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.client.*
+import uk.gov.justice.digital.hmpps.entity.*
+import uk.gov.justice.digital.hmpps.telemetry.TelemetryService
+
+@Service
+class ProbationDatabaseMatchingService(
+    private val searchRepository: ProbationSearchRepository,
+    private val telemetryService: TelemetryService,
+) {
+    fun match(request: ProbationMatchRequest): ProbationMatchResponse {
+
+        performSearch(searchRepository::fullSearch, request, "ALL_SUPPLIED")?.let { response -> return response }
+        performSearch(
+            searchRepository::fullSearchAlias,
+            request,
+            "ALL_SUPPLIED_ALIAS"
+        )?.let { response -> return response }
+        performSearch(searchRepository::searchByNoms, request, "HMPPS_KEY")?.let { response -> return response }
+        performSearch(searchRepository::searchByCro, request, "EXTERNAL_KEY")?.let { response -> return response }
+        performSearch(searchRepository::searchByPnc, request, "EXTERNAL_KEY")?.let { response -> return response }
+        performSearch(searchRepository::searchByName, request, "NAME")?.let { response -> return response }
+        performSearch(
+            searchRepository::searchByPartialName,
+            request,
+            "PARTIAL_NAME"
+        )?.let { response -> return response }
+        performSearch(
+            searchRepository::searchByPartialNameLenientDob,
+            request,
+            "PARTIAL_NAME_DOB_LENIENT"
+        )?.let { response -> return response }
+        return ProbationMatchResponse(matches = emptyList(), matchedBy = "NOTHING")
+    }
+
+    fun performSearch(
+        fn: (request: ProbationMatchRequest) -> List<Person>,
+        request: ProbationMatchRequest,
+        matchedBy: String
+    ): ProbationMatchResponse? {
+        val results = fn(request)
+        if (results.isNotEmpty()) {
+            return ProbationMatchResponse(
+                matches = results.map { OffenderMatch(it.toOffenderDetail()) },
+                matchedBy = matchedBy
+            )
+        }
+        return null
+    }
+
+    fun performCompare(request: ProbationMatchRequest, apiMatchResponse: ProbationMatchResponse) {
+        val dbMatchResponse = match(request)
+        val dbCrns = dbMatchResponse.matches.map { it.offender.otherIds.crn }.toSet()
+        val apiCrns = apiMatchResponse.matches.map { it.offender.otherIds.crn }.toSet()
+        if(dbCrns != apiCrns) {
+            //Difference found
+            telemetryService.trackEvent(
+                "MatchDifferenceFound",
+                mapOf(
+                    "nomsNumber" to request.nomsNumber,
+                    "apiMatches" to apiCrns.joinToString(","),
+                    "dbMatches" to dbCrns.joinToString(",")
+                )
+            )
+        }
+    }
+}
+
+fun Person.toOffenderDetail() = OffenderDetail(
+    otherIds = IDs(
+        crn = crn,
+        croNumber = croNumber,
+        pncNumber = pncNumber,
+        nomsNumber = nomsNumber,
+        mostRecentPrisonerNumber = mostRecentPrisonerNumber,
+        immigrationNumber = immigrationNumber,
+        niNumber = niNumber
+    ),
+    previousSurname = previousSurname,
+    title = title?.description,
+    firstName = forename,
+    middleNames = listOfNotNull(secondName, forename),
+    surname = surname,
+    dateOfBirth = dateOfBirth,
+    gender = gender?.description,
+    currentDisposal = if (currentDisposal) "1" else "0",
+)

--- a/projects/prison-identifier-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/utils/SearchHelpers.kt
+++ b/projects/prison-identifier-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/utils/SearchHelpers.kt
@@ -1,0 +1,38 @@
+package uk.gov.justice.digital.hmpps.utils
+
+import java.time.DateTimeException
+import java.time.LocalDate
+
+object SearchHelpers {
+    fun allLenientDateVariations(date: LocalDate): List<LocalDate> {
+        return swapMonthDay(date) + everyOtherValidMonth(date) + aroundDateInSameMonth(date)
+    }
+
+    fun formatPncNumber(pncNumber: String): String {
+        return pncNumber.split("/").takeIf { it.size == 2 }?.let {
+            try {
+                it[0] + "/" + "%07d".format(it[1].substring(0, it[1].length - 1).toInt()) + it[1].last().toString()
+            } catch (e: Exception) {
+                pncNumber
+            }
+        } ?: pncNumber
+    }
+
+    private fun aroundDateInSameMonth(date: LocalDate) =
+        listOf(date.minusDays(1), date.minusDays(-1), date).filter { it.month == date.month }
+
+    private fun everyOtherValidMonth(date: LocalDate): List<LocalDate> =
+        (1..12).filterNot { date.monthValue == it }.mapNotNull { setMonthDay(date, it) }
+
+    private fun swapMonthDay(date: LocalDate): List<LocalDate> = try {
+        listOf(LocalDate.of(date.year, date.dayOfMonth, date.monthValue))
+    } catch (e: DateTimeException) {
+        listOf()
+    }
+
+    private fun setMonthDay(date: LocalDate, monthValue: Int): LocalDate? = try {
+        LocalDate.of(date.year, monthValue, date.dayOfMonth)
+    } catch (e: DateTimeException) {
+        null
+    }
+}

--- a/projects/prison-identifier-and-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/utils/SearchHelperTest.kt
+++ b/projects/prison-identifier-and-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/utils/SearchHelperTest.kt
@@ -1,0 +1,46 @@
+package uk.gov.justice.digital.hmpps.utils.uk.gov.justice.digital.hmpps.utils
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.utils.SearchHelpers
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+class SearchHelperTest {
+
+    @Test
+    fun `lenient date of births are generated`() {
+        val dateOfBirths = SearchHelpers.allLenientDateVariations(toDate("1961-05-17"))
+        val expected = listOf(
+            toDate("1961-01-17"),
+            toDate("1961-02-17"),
+            toDate("1961-03-17"),
+            toDate("1961-04-17"),
+            toDate("1961-06-17"),
+            toDate("1961-07-17"),
+            toDate("1961-08-17"),
+            toDate("1961-09-17"),
+            toDate("1961-10-17"),
+            toDate("1961-11-17"),
+            toDate("1961-12-17"),
+            toDate("1961-05-16"),
+            toDate("1961-05-18"),
+            toDate("1961-05-17")
+        )
+        assertThat(dateOfBirths, equalTo(expected))
+    }
+
+    @Test
+    fun `converts a pnc to compatible with NDelius`() {
+        assertThat(SearchHelpers.formatPncNumber("63/281261B"), equalTo("63/0281261B"))
+        assertThat(SearchHelpers.formatPncNumber("63/1B"), equalTo("63/0000001B"))
+        assertThat(SearchHelpers.formatPncNumber("63/1B/1B"), equalTo("63/1B/1B"))
+        assertThat(SearchHelpers.formatPncNumber("63281261B"), equalTo("63281261B"))
+        assertThat(SearchHelpers.formatPncNumber("63/0000001B"), equalTo("63/0000001B"))
+    }
+
+    private fun toDate(dob: String): LocalDate {
+        return LocalDate.parse(dob, DateTimeFormatter.ISO_DATE)
+    }
+}


### PR DESCRIPTION
This PR provides 2 feature flags
**prison-identifiers-use-db-search**
When set to true, this will replace the call to the probation offender API match with a set of DB queries that return the same model.
**prison-identifiers-compare-with-db-search**
When set to true and _prison-identifiers-use-db-search_ is set to false, this will continue to use the probation offender API match to match the offender, but will also perform the equivalent DB match for comparison. If there are differences in the match result, a _MatchDifferenceFound_ app insights event is raised.