### PR TITLE
PI-3013 Only preload contacts for cases with over 1000 contacts

### DIFF
--- a/projects/person-search-index-from-delius/container/config/logstash.yml
+++ b/projects/person-search-index-from-delius/container/config/logstash.yml
@@ -3,3 +3,4 @@ config.reload.automatic: true
 config.support_escapes: true
 dead_letter_queue.enable: true
 pipeline.batch.size: ${PIPELINE_BATCH_SIZE:10}
+pipeline.workers: ${PIPELINE_WORKERS:1}

--- a/projects/person-search-index-from-delius/container/pipelines/contact/logstash-incremental.conf
+++ b/projects/person-search-index-from-delius/container/pipelines/contact/logstash-incremental.conf
@@ -24,15 +24,6 @@ filter {
     mutate { remove_field => ["tags"] }
     # If CRN-specific index does not exist, create and populate it
     if ("_httprequestfailure" in [@metadata][semantic_index_check]) {
-        # Create the index
-        http {
-            id => "create-semantic-index"
-            url => "${SEARCH_INDEX_HOST}/contact-semantic-search-%{[@metadata][crn_lowercase]}"
-            verb => "PUT"
-            target_body => "[@metadata][semantic_index_creation_response_body]"
-        }
-        # Ignore failures creating the index - this can happen when processing two events for the same CRN
-        mutate { remove_field => ["tags"] }
         # Get all contact ids for CRN
         jdbc_streaming {
             id => "load-all-contact-ids-for-crn"
@@ -55,51 +46,71 @@ filter {
             tag_on_default_use => []
             use_cache => false
         }
-        # Split contact ids into separate events
-        split {
-            id => "split-contact-ids"
-            field => "contact_ids"
+        # Check the number of contacts returned
+        ruby {
+          code => "
+            length = event.get('contact_ids')&.length
+            event.set('preloadAllContactsIntoSemanticIndex', length && length > 1000 && length < 20000)
+          "
         }
-        mutate { remove_field => [ "sourceId" ] }
-        mutate { add_field => { "sourceId" => "%{[contact_ids][contact_id]}" } }
-        mutate { convert => { "sourceId" => "integer" } }
-        # Continue down the pipeline for each contact id...
+        if [@metadata][preloadAllContactsIntoSemanticIndex] {
+            # Create the index
+            mutate { rename => { "tags" => "tags_before" } }
+            http {
+                id => "create-semantic-index"
+                url => "${SEARCH_INDEX_HOST}/contact-semantic-search-%{[@metadata][crn_lowercase]}"
+                verb => "PUT"
+                target_body => "[@metadata][semantic_index_creation_response_body]"
+            }
+            # Ignore failures creating the index - this can happen when processing two events for the same CRN
+            mutate { remove_field => ["tags"] }
+            mutate { rename => { "tags_before" => "tags" } }
+            # Split contact ids into separate events
+            split {
+                id => "split-contact-ids"
+                field => "contact_ids"
+            }
+            mutate { remove_field => [ "sourceId" ] }
+            mutate { add_field => { "sourceId" => "%{[contact_ids][contact_id]}" } }
+            mutate { convert => { "sourceId" => "integer" } }
+            # Continue down the pipeline for each contact id...
+        }
     }
-     jdbc_streaming {
-         id => "load-db-record"
-         jdbc_driver_library => "/etc/logstash/ojdbc11.jar"
-         jdbc_driver_class => "Java::oracle.jdbc.driver.OracleDriver"
-         jdbc_connection_string => "${JDBC_CONNECTION_STRING}"
-         jdbc_user => "${JDBC_USER}"
-         jdbc_password => "${JDBC_PASSWORD}"
-         jdbc_validate_connection => true
-         jdbc_validation_timeout => 120
-         statement => "${INCREMENTAL_STATEMENT_SQL}"
-         use_prepared_statements => true
-         prepared_statement_name => "search_indexer_contact_incremental"
-         prepared_statement_bind_values => ["%{sourceId}", "%{sourceId}", "%{sourceId}", "%{sourceId}"]
-         target => "db"
-         tag_on_default_use => []
-         use_cache => false
-     }
-     prune { whitelist_names => ["sourceId", "db", "tags", "Message", "MessageAttributes"] }
-     if [db][0][json] and [MessageAttributes][eventType][Value] == "CONTACT_CHANGED" {
-         json {
-             id => "parse-db-json"
-             source => "[db][0][json]"
-         }
-         mutate { add_field => { "[@metadata][action]" => "index" } }
-     } else if [MessageAttributes][eventType][Value] == "CONTACT_DELETED"  {
-         mutate { add_field => { "[@metadata][action]" => "delete" } }
-     } else {
-        # we have had a contact change, but no db record has been found
-        # as we are are adding a tag, the result will be logged
-        mutate { add_tag => ["NO_RESULT"] }
-     }
+    jdbc_streaming {
+        id => "load-db-record"
+        jdbc_driver_library => "/etc/logstash/ojdbc11.jar"
+        jdbc_driver_class => "Java::oracle.jdbc.driver.OracleDriver"
+        jdbc_connection_string => "${JDBC_CONNECTION_STRING}"
+        jdbc_user => "${JDBC_USER}"
+        jdbc_password => "${JDBC_PASSWORD}"
+        jdbc_validate_connection => true
+        jdbc_validation_timeout => 120
+        statement => "${INCREMENTAL_STATEMENT_SQL}"
+        use_prepared_statements => true
+        prepared_statement_name => "search_indexer_contact_incremental"
+        prepared_statement_bind_values => ["%{sourceId}", "%{sourceId}", "%{sourceId}", "%{sourceId}"]
+        target => "db"
+        tag_on_default_use => []
+        use_cache => false
+    }
+    prune { whitelist_names => ["sourceId", "db", "tags", "Message", "MessageAttributes"] }
+    if [db][0][json] and [MessageAttributes][eventType][Value] == "CONTACT_CHANGED" {
+        json {
+            id => "parse-db-json"
+            source => "[db][0][json]"
+        }
+        mutate { add_field => { "[@metadata][action]" => "index" } }
+    } else if [MessageAttributes][eventType][Value] == "CONTACT_DELETED" {
+        mutate { add_field => { "[@metadata][action]" => "delete" } }
+    } else {
+       # we have had a contact change, but no db record has been found
+       # as we are are adding a tag, the result will be logged
+       mutate { add_tag => ["NO_RESULT"] }
+    }
 
-     if ![tags] or ![tags][0] {
-         mutate { remove_field => ["db", "Message", "MessageAttributes"] }
-     }
+    if ![tags] or ![tags][0] {
+        mutate { remove_field => ["db", "Message", "MessageAttributes"] }
+    }
 }
 
 output {
@@ -120,13 +131,15 @@ output {
             action => "%{[@metadata][action]}"
             validate_after_inactivity => 0
         }
-        opensearch {
-            id => "index-into-semantic-search"
-            hosts => ["${SEARCH_INDEX_HOST}"]
-            index => "contact-semantic-search-%{[@metadata][crn_lowercase]}"
-            document_id => "%{sourceId}"
-            action => "%{[@metadata][action]}"
-            validate_after_inactivity => 0
+        if [@metadata][preloadAllContactsIntoSemanticIndex] {
+            opensearch {
+                id => "index-into-semantic-search"
+                hosts => ["${SEARCH_INDEX_HOST}"]
+                index => "contact-semantic-search-%{[@metadata][crn_lowercase]}"
+                document_id => "%{sourceId}"
+                action => "%{[@metadata][action]}"
+                validate_after_inactivity => 0
+            }
         }
     } else {
         stdout {

--- a/projects/person-search-index-from-delius/deploy/values.yaml
+++ b/projects/person-search-index-from-delius/deploy/values.yaml
@@ -29,6 +29,8 @@ generic-service:
     CONTACT_INDEX_PREFIX: contact-search
     PERSON_INDEX_PREFIX: person-search
     PIPELINES_ENABLED: person-incremental,contact-incremental
+    PIPELINE_WORKERS: 10
+    PIPELINE_BATCH_SIZE: 1
     JDK_JAVA_OPTIONS: ''
     LS_JAVA_OPTS: -Xms1536m -Xmx1536m # = 75% of pod memory limit (see above)
 


### PR DESCRIPTION
Also,
* scale up workers to increase CPU usage due to slower OpenSearch/SageMaker indexing being IO-bound - see https://www.elastic.co/docs/reference/logstash/tuning-logstash
* reduce batch size to reduce memory usage due to more events being kept in-flight while waiting for OpenSearch/SageMaker