### PR TITLE
Convert sourceId to integer

### DIFF
--- a/projects/person-search-index-from-delius/container/pipelines/contact/logstash-incremental.conf
+++ b/projects/person-search-index-from-delius/container/pipelines/contact/logstash-incremental.conf
@@ -22,6 +22,7 @@ filter {
     }
     mutate { add_field => { "[@metadata][semantic_index_check]" => "%{tags}" } }
     mutate { remove_field => ["tags"] }
+    mutate { convert => { "sourceId" => "integer" } }
     jdbc_streaming {
         id => "load-db-record"
         jdbc_driver_library => "/etc/logstash/ojdbc11.jar"


### PR DESCRIPTION
```
, :parameters=>{:p0=>"1934376843", :p1=>"1934376843", :p2=>"1934376843", :p3=>"1934376843"}, :exception=>#<Sequel::Datab
aseError: Java::JavaSql::SQLSyntaxErrorException: ORA-01722: invalid number
```