### PR TITLE
PI-3083 Revert data type change + do not index text chunks

### DIFF
--- a/projects/person-search-index-from-delius/container/pipelines/contact/index/index-template-semantic.yml
+++ b/projects/person-search-index-from-delius/container/pipelines/contact/index/index-template-semantic.yml
@@ -1233,12 +1233,12 @@ template:
         format: hour_minute_second
       textChunks:
         type: keyword
+        index: false
       textEmbedding:
         type: nested
         properties:
           knn:
             type: knn_vector
-            data_type: byte
             dimension: 1024
             space_type: cosinesimil
             method:


### PR DESCRIPTION
Turns out OpenSearch expects you to pre-quantize the vectors before ingestion, which I didn't realise. It can do it internally too, but then it stores both the full precision vector and the reduced precision one - so actually results in more disk usage.

See https://docs.opensearch.org/docs/latest/vector-search/optimizing-storage/knn-vector-quantization/