### PR TITLE
PI-2757 prevent starting up connection to preprod or prod with auto ddl set

### DIFF
--- a/libs/commons/src/main/kotlin/uk/gov/justice/digital/hmpps/config/NonProdConnectionValidator.kt
+++ b/libs/commons/src/main/kotlin/uk/gov/justice/digital/hmpps/config/NonProdConnectionValidator.kt
@@ -1,0 +1,23 @@
+package uk.gov.justice.digital.hmpps.config
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties
+import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer
+import org.springframework.context.annotation.Configuration
+import uk.gov.justice.digital.hmpps.logging.Logger
+import uk.gov.justice.digital.hmpps.logging.Logger.logger
+
+@ConditionalOnProperty("spring.datasource.url")
+@Configuration
+class NonProdConnectionValidator(private val dsp: DataSourceProperties) : HibernatePropertiesCustomizer {
+    override fun customize(hibernateProperties: Map<String, Any>) {
+        if (dsp.isForPreprodOrProd()) {
+            Logger.logger().warn("Application connecting to ${dsp.url}")
+            require(hibernateProperties["hibernate.hbm2ddl.auto"] == "none") {
+                "Application attempted to connect to preprod or prod with auto ddl active."
+            }
+        }
+    }
+}
+
+private fun DataSourceProperties.isForPreprodOrProd() = url.contains("PRDNDA") or url.contains("PRENDA")

--- a/projects/court-case-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/person/entity/Person.kt
+++ b/projects/court-case-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/person/entity/Person.kt
@@ -403,8 +403,8 @@ interface SentenceCounts {
 fun matchesPerson(surname: String, firstName: String?, dateOfBirth: LocalDate?) =
     Specification<Person> { person, _, cb ->
         val toMatch = listOfNotNull(
-            cb.equal(cb.lower(person[SURNAME]), surname.lowercase()),
-            firstName?.lowercase()?.let { cb.equal(cb.lower(person[FORENAME]), it) },
+            cb.equal(cb.trim(cb.lower(person[SURNAME])), surname.lowercase()),
+            firstName?.lowercase()?.let { cb.equal(cb.trim(cb.lower(person[FORENAME])), it) },
             dateOfBirth?.let { cb.equal(person.get<LocalDate>(DOB), it) }
         )
         cb.and(*toMatch.toTypedArray())


### PR DESCRIPTION
Another layer of validation is possible to check on the profile we are setting - but given we don't use profiles in any environment except for local I considered this was possibly more volatile - however, we could start setting profiles on preprod and prod and verify it only connects to those dbs in that profile - but that doesn't really prevent the issue - as someone could run pre-prod or prod profile locally. This at least validates that no ddl will be ran when connecting to preprod or prod dbs.