### PR TITLE
PI-2938 Extend visibility timeout while running

### DIFF
--- a/libs/messaging/src/test/kotlin/uk/gov/justice/digital/hmpps/listener/AwsNotificationListenerTest.kt
+++ b/libs/messaging/src/test/kotlin/uk/gov/justice/digital/hmpps/listener/AwsNotificationListenerTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.listener
 
 import io.awspring.cloud.sqs.listener.AsyncAdapterBlockingExecutionFailedException
 import io.awspring.cloud.sqs.listener.ListenerExecutionFailedException
+import io.awspring.cloud.sqs.listener.Visibility
 import io.sentry.Sentry
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
@@ -10,14 +11,16 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
-import org.mockito.Mockito.mockStatic
+import org.mockito.Mockito.*
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.messaging.support.GenericMessage
+import org.springframework.scheduling.concurrent.SimpleAsyncTaskScheduler
 import uk.gov.justice.digital.hmpps.message.Notification
 import uk.gov.justice.digital.hmpps.messaging.NotificationHandler
+import uk.gov.justice.digital.hmpps.telemetry.TelemetryService
 import uk.gov.justice.digital.hmpps.test.MockMvcExtensions.objectMapper
 import java.util.concurrent.CompletionException
 
@@ -26,11 +29,15 @@ class AwsNotificationListenerTest {
     @Mock
     lateinit var handler: NotificationHandler<Any>
 
+    @Mock
+    lateinit var telemetryService: TelemetryService
+
     lateinit var listener: AwsNotificationListener
 
     @BeforeEach
     fun setUp() {
-        listener = AwsNotificationListener(handler, objectMapper, "my-queue")
+        listener =
+            AwsNotificationListener(handler, objectMapper, telemetryService, SimpleAsyncTaskScheduler(), "my-queue", 1)
     }
 
     @Test
@@ -79,4 +86,17 @@ class AwsNotificationListenerTest {
             it.verify { Sentry.captureException(meaningfulException) }
         }
     }
+
+    @Test
+    fun `visibility timeout is extended while running`() {
+        val notification = objectMapper.writeValueAsString(Notification("message"))
+        val visibility = mock(Visibility::class.java)
+        whenever(handler.handle(any<String>())).thenAnswer { Thread.sleep(1500) }
+
+        listener.receive(notification, visibility)
+
+        verify(visibility, times(2)).changeTo(30)
+        verify(handler).handle(notification)
+    }
+
 }

--- a/templates/sqs.tf
+++ b/templates/sqs.tf
@@ -8,7 +8,7 @@ resource "aws_sns_topic_subscription" "SERVICE_NAME-queue-subscription" {
 }
 
 module "SERVICE_NAME-queue" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=6.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=5.1.2"
 
   # Queue configuration
   sqs_name = "SERVICE_NAME-queue"
@@ -25,7 +25,6 @@ module "SERVICE_NAME-queue" {
   is_production          = var.is_production
   namespace              = var.namespace
   team_name              = var.team_name
-  use_team_name          = true
 }
 
 resource "aws_sqs_queue_policy" "SERVICE_NAME-queue-policy" {
@@ -34,7 +33,7 @@ resource "aws_sqs_queue_policy" "SERVICE_NAME-queue-policy" {
 }
 
 module "SERVICE_NAME-dlq" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=6.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sqs?ref=5.1.2"
 
   # Queue configuration
   sqs_name                  = "SERVICE_NAME-dlq"
@@ -48,7 +47,6 @@ module "SERVICE_NAME-dlq" {
   is_production          = var.is_production
   namespace              = var.namespace
   team_name              = var.team_name
-  use_team_name          = true
 }
 
 resource "aws_sqs_queue_policy" "SERVICE_NAME-dlq-policy" {


### PR DESCRIPTION
Periodically extends the timeout for the message while the handler is running, so that the message is not received multiple times.