### PR TITLE
PI-3159 Fix AsyncAPI serializer

### DIFF
--- a/libs/messaging/src/main/kotlin/uk/gov/justice/digital/hmpps/documentation/AsyncApiReferencingSerializer.kt
+++ b/libs/messaging/src/main/kotlin/uk/gov/justice/digital/hmpps/documentation/AsyncApiReferencingSerializer.kt
@@ -23,14 +23,14 @@ class AsyncApiReferencingSerializer(val objectMapper: ObjectMapper) : AsyncApiSe
     }
 
     private fun ReferencableMessagesList.replaceWithReference(message: Message) {
-        val name = message.name
-        if (message.name != null) {
-            // If the name is populated, replace with remote schema reference
+        val (name, title) = Pair(message.name, message.title)
+        if (name != null && title == null) {
+            // If the name is populated, replace it with a remote schema reference
             reference { ref("https://raw.githubusercontent.com/ministryofjustice/hmpps-domain-events/main/spec/schemas/$name.yml") }
             removeIf { it is Message && it.name == name }
-        } else if (message.title != null) {
+        } else if (title != null) {
             // Otherwise update the name to match the title
-            message.name = message.title
+            message.name = title
         }
     }
 }


### PR DESCRIPTION
The serializer runs each time the endpoint is invoked. So on the first run, named messages were replaced with references, but on a second run, messages that should not have a reference (due to not having a `name` attribute) were given an incorrect reference.