### PR TITLE
PI-3161 Switch to S3 cache for Gradle

### DIFF
--- a/.github/actions/analyse/action.yml
+++ b/.github/actions/analyse/action.yml
@@ -5,8 +5,11 @@ inputs:
   sonar-token:
     description: Sonar token
     required: true
-  gradle-encryption-key:
-    description: Gradle encryption key
+  gradle-cache-role:
+    description: Role required for accessing Gradle cache
+    required: true
+  gradle-cache-encryption-key:
+    description: Gradle cache encryption key. Required for configuration caching.
     required: true
 
 runs:
@@ -46,8 +49,8 @@ runs:
 
     - uses: ./.github/actions/setup-gradle
       with:
-        cache-encryption-key: ${{ inputs.gradle-encryption-key }}
-        cache-read-only: true
+        cache-role: ${{ inputs.gradle-cache-role }}
+        cache-encryption-key: ${{ inputs.gradle-cache-encryption-key }}
 
     - name: Sonar analysis
       if: github.actor != 'dependabot[bot]'

--- a/.github/actions/cloud-platform-deploy/action.yml
+++ b/.github/actions/cloud-platform-deploy/action.yml
@@ -29,8 +29,11 @@ inputs:
   ip-allowlists:
     description: The HMPPS IP allow list groups to apply, in base64-encoded YAML format
     required: true
-  gradle-encryption-key:
-    description: Gradle encryption key
+  gradle-cache-role:
+    description: Role required for accessing Gradle cache
+    required: true
+  gradle-cache-encryption-key:
+    description: Gradle cache encryption key. Required for configuration caching.
     required: true
 
 runs:
@@ -49,7 +52,8 @@ runs:
       with:
         project: ${{ inputs.project }}
         version: ${{ inputs.version }}
-        gradle-encryption-key: ${{ inputs.gradle-encryption-key }}
+        gradle-cache-role: ${{ inputs.gradle-cache-role }}
+        gradle-cache-encryption-key: ${{ inputs.gradle-cache-encryption-key }}
 
     - name: Authenticate
       uses: ./.github/actions/cloud-platform-auth

--- a/.github/actions/get-build-info/action.yml
+++ b/.github/actions/get-build-info/action.yml
@@ -8,8 +8,11 @@ inputs:
   version:
     description: The version of the service to deploy
     required: true
-  gradle-encryption-key:
-    description: Gradle encryption key
+  gradle-cache-role:
+    description: Role required for accessing Gradle cache
+    required: true
+  gradle-cache-encryption-key:
+    description: Gradle cache encryption key. Required for configuration caching.
     required: true
 
 runs:
@@ -26,8 +29,8 @@ runs:
     - uses: ./.github/actions/setup-gradle
       if: ${{ steps.gradle_file.outputs.files_exists == 'true' }}
       with:
-        cache-encryption-key: ${{ inputs.gradle-encryption-key }}
-        cache-read-only: true
+        cache-role: ${{ inputs.gradle-cache-role }}
+        cache-encryption-key: ${{ inputs.gradle-cache-encryption-key }}
 
     - name: Get build info
       if: ${{ steps.gradle_file.outputs.files_exists == 'true' }}

--- a/.github/actions/gradle-build/action.yml
+++ b/.github/actions/gradle-build/action.yml
@@ -10,8 +10,11 @@ inputs:
   force:
     description: Force build, regardless of whether there are changes
     default: 'false'
-  gradle-encryption-key:
-    description: Gradle encryption key
+  gradle-cache-role:
+    description: Role required for accessing Gradle cache
+    required: true
+  gradle-cache-encryption-key:
+    description: Gradle cache encryption key. Required for configuration caching.
     required: true
 
 outputs:
@@ -37,7 +40,8 @@ runs:
 
     - uses: ./.github/actions/setup-gradle
       with:
-        cache-encryption-key: ${{ inputs.gradle-encryption-key }}
+        cache-role: ${{ inputs.gradle-cache-role }}
+        cache-encryption-key: ${{ inputs.gradle-cache-encryption-key }}
 
     - name: Build
       shell: bash

--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -2,18 +2,12 @@ name: Setup Gradle
 description: Setup Java and Gradle actions
 
 inputs:
-  cache-read-only:
-    description: |
-      When 'true', existing entries will be read from the cache but no entries will be written.
-      By default this value is 'false' for workflows on the GitHub default branch and 'true' for workflows on other branches.
-    required: false
-    default: ${{ github.event.repository != null && github.ref_name != github.event.repository.default_branch }}
+  cache-role:
+    description: Role to assume to access S3 cache bucket
+    required: true
   cache-encryption-key:
-    description: |
-      A base64 encoded AES key used to encrypt the configuration-cache data. The key is exported as 'GRADLE_ENCRYPTION_KEY' for later steps.
-      A suitable key can be generated with `openssl rand -base64 16`.
-      Configuration-cache data will not be saved/restored without an encryption key being provided.
-    required: false
+    description: Gradle cache encryption key. Required for configuration caching. See https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#saving-configuration-cache-data
+    required: true
 
 runs:
   using: "composite"
@@ -22,10 +16,30 @@ runs:
       with:
         java-version: 21
         distribution: temurin
+
+    - name: Assume role for access to cache bucket
+      uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v2
+      with:
+        aws-region: eu-west-2
+        role-to-assume: ${{ inputs.cache-role }}
+        role-skip-session-tagging: true
+        role-duration-seconds: 1200
+
+    - name: Set cache encryption key as environment variable
+      shell: bash
+      run: echo "GRADLE_ENCRYPTION_KEY=$key" >> $GITHUB_ENV
+      env:
+        key: ${{ inputs.cache-encryption-key }}
+
     - uses: gradle/actions/setup-gradle@v4
       with:
-        cache-encryption-key: ${{ inputs.cache-encryption-key }}
-        cache-read-only: ${{ inputs.cache-read-only }}
+        add-job-summary: 'on-failure'
+        cache-encryption-key: ${{ env.GRADLE_ENCRYPTION_KEY }}
+        cache-read-only: ${{ github.ref_name != 'main' }}
+        gradle-home-cache-excludes: |
+          caches
+          notifications
+
     - name: Manually cache buildSrc output # workaround for https://github.com/gradle/actions/issues/21
       uses: actions/cache@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,9 +10,10 @@ on:
         type: boolean
         default: false
     secrets:
+      GRADLE_CACHE_S3_ROLE_TO_ASSUME:
+        required: true
       GRADLE_ENCRYPTION_KEY:
         required: true
-        description: Used for encrypting the Gradle cache. See https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#saving-configuration-cache-data
     outputs:
       version:
         value: ${{ jobs.build-gradle.outputs.version || jobs.build-docker.outputs.version }}
@@ -29,6 +30,11 @@ on:
 
 env:
   push: ${{ !(github.event_name == 'push' && github.ref_name != 'main') && inputs.push }}
+
+permissions:
+  contents: read
+  id-token: write
+  packages: write
 
 jobs:
   build-gradle:
@@ -104,7 +110,8 @@ jobs:
           project: ${{ matrix.project }}
           push: ${{ env.push }}
           force: ${{ inputs.force-deploy }}
-          gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          gradle-cache-role: ${{ secrets.GRADLE_CACHE_S3_ROLE_TO_ASSUME }}
+          gradle-cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
   build-docker:
     name: Docker build

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,11 +6,17 @@ on:
     branches-ignore:
       - main
 
+permissions:
+  contents: read
+  id-token: write
+  packages: write
+
 jobs:
   build:
     name: Build
     uses: ./.github/workflows/build.yml
     secrets:
+      GRADLE_CACHE_S3_ROLE_TO_ASSUME: ${{ secrets.GRADLE_CACHE_S3_ROLE_TO_ASSUME }}
       GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
   post-build:
@@ -31,7 +37,8 @@ jobs:
       - uses: ./.github/actions/analyse
         with:
           sonar-token: ${{ secrets.SONAR_TOKEN }}
-          gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          gradle-cache-role: ${{ secrets.GRADLE_CACHE_S3_ROLE_TO_ASSUME }}
+          gradle-cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
   lint:
     name: Lint

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -73,6 +73,11 @@ on:
           - preprod
           - prod
 
+permissions:
+  contents: read
+  id-token: write
+  packages: write
+
 jobs:
   build:
     name: Build
@@ -98,7 +103,8 @@ jobs:
           project: ${{ inputs.project }}
           push: true
           force: true
-          gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          gradle-cache-role: ${{ secrets.GRADLE_CACHE_S3_ROLE_TO_ASSUME }}
+          gradle-cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Build Docker project
         id: docker

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,6 +93,11 @@ on:
         type: string
         required: true
 
+permissions:
+  contents: read
+  id-token: write
+  packages: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -137,7 +142,8 @@ jobs:
           namespace: ${{ secrets.KUBE_NAMESPACE }}
           token: ${{ secrets.KUBE_TOKEN }}
           ip-allowlists: ${{ vars.HMPPS_IP_ALLOWLIST_GROUPS_YAML }}
-          gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          gradle-cache-role: ${{ secrets.GRADLE_CACHE_S3_ROLE_TO_ASSUME }}
+          gradle-cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - uses: docker/login-action@v3
         if: ${{ steps.check_files.outputs.files_exists == 'true' && steps.enabled.outputs.enabled == 'true' }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,13 +19,14 @@ jobs:
     permissions:
       contents: write
       pages: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
       - uses: ./.github/actions/setup-gradle
         with:
+          cache-role: ${{ secrets.GRADLE_CACHE_S3_ROLE_TO_ASSUME }}
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          cache-read-only: true
 
       - name: Prepare API specs
         run: ./script/prepare-api-specs.sh

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -11,6 +11,11 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+  id-token: write
+  packages: write
+
 jobs:
   build:
     name: Build
@@ -20,6 +25,7 @@ jobs:
       force-deploy: "${{ inputs.force-deploy || false }}"
     concurrency: pipeline-build-${{ github.ref_name }}
     secrets:
+      GRADLE_CACHE_S3_ROLE_TO_ASSUME: ${{ secrets.GRADLE_CACHE_S3_ROLE_TO_ASSUME }}
       GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
   post-build:
@@ -47,7 +53,8 @@ jobs:
       - uses: ./.github/actions/analyse
         with:
           sonar-token: ${{ secrets.SONAR_TOKEN }}
-          gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          gradle-cache-role: ${{ secrets.GRADLE_CACHE_S3_ROLE_TO_ASSUME }}
+          gradle-cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
   deploy-to-test:
     name: Deploy to test

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -147,8 +147,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-gradle
         with:
+          cache-role: ${{ secrets.GRADLE_CACHE_S3_ROLE_TO_ASSUME }}
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          cache-read-only: true
 
       - name: Build jars
         run: ./gradlew jar

--- a/.github/workflows/templates.yml
+++ b/.github/workflows/templates.yml
@@ -43,5 +43,3 @@ jobs:
 
       - name: Compile and test
         run: ./gradlew test-project:check
-        env:
-          GRADLE_CACHE_READONLY: true

--- a/.github/workflows/templates.yml
+++ b/.github/workflows/templates.yml
@@ -11,6 +11,10 @@ on:
     - cron: "30 5 * * MON-FRI" # Every weekday at 05:30 UTC
   workflow_dispatch:
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -28,8 +32,8 @@ jobs:
 
       - uses: ./.github/actions/setup-gradle
         with:
+          cache-role: ${{ secrets.GRADLE_CACHE_S3_ROLE_TO_ASSUME }}
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          cache-read-only: true
 
       - name: Render project template
         uses: ./.github/actions/render-project-template
@@ -39,3 +43,5 @@ jobs:
 
       - name: Compile and test
         run: ./gradlew test-project:check
+        env:
+          GRADLE_CACHE_READONLY: true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -127,11 +127,11 @@ develocity {
 
 buildCache {
     local {
-        isEnabled = !providers.environmentVariable("CI").isPresent
+        isEnabled = System.getenv("CI") == null
     }
     remote<com.github.burrunan.s3cache.AwsS3BuildCache> {
-        isEnabled = providers.environmentVariable("CI").isPresent
-        isPush = providers.environmentVariable("CI").isPresent
+        isEnabled = System.getenv("CI") != null
+        isPush = System.getenv("CI") != null
         bucket = "hmpps-probation-integration-gradle-cache"
         region = "eu-west-2"
         lookupDefaultAwsCredentials = true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -119,7 +119,7 @@ plugins {
 
 develocity {
     buildScan {
-        publishing.onlyIf { System.getenv().containsKey("CI") }
+        publishing.onlyIf { providers.environmentVariable("CI").isPresent }
         termsOfUseUrl.set("https://gradle.com/help/legal-terms-of-use")
         termsOfUseAgree.set("yes")
     }
@@ -127,11 +127,11 @@ develocity {
 
 buildCache {
     local {
-        isEnabled = !System.getenv().containsKey("CI")
+        isEnabled = !providers.environmentVariable("CI").isPresent
     }
     remote<com.github.burrunan.s3cache.AwsS3BuildCache> {
-        isEnabled = System.getenv().containsKey("CI")
-        isPush = System.getenv().containsKey("CI")
+        isEnabled = providers.environmentVariable("CI").isPresent
+        isPush = providers.environmentVariable("CI").isPresent
         bucket = "hmpps-probation-integration-gradle-cache"
         region = "eu-west-2"
         lookupDefaultAwsCredentials = true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -112,11 +112,28 @@ dependencyResolutionManagement {
     }
 }
 
-plugins { id("com.gradle.develocity") version "4.0.2" }
+plugins {
+    id("com.gradle.develocity") version "4.0.2"
+    id("com.github.burrunan.s3-build-cache") version "1.9.2"
+}
+
 develocity {
     buildScan {
-        publishing.onlyIf { !System.getenv("CI").isNullOrEmpty() }
+        publishing.onlyIf { System.getenv().containsKey("CI") }
         termsOfUseUrl.set("https://gradle.com/help/legal-terms-of-use")
         termsOfUseAgree.set("yes")
+    }
+}
+
+buildCache {
+    local {
+        isEnabled = !System.getenv().containsKey("CI")
+    }
+    remote<com.github.burrunan.s3cache.AwsS3BuildCache> {
+        isEnabled = System.getenv().containsKey("CI")
+        isPush = System.getenv().containsKey("CI")
+        bucket = "hmpps-probation-integration-gradle-cache"
+        region = "eu-west-2"
+        lookupDefaultAwsCredentials = true
     }
 }


### PR DESCRIPTION
Unfortunately, this means we lose the ability to use the configuration cache due to the AWS OIDC credentials changing each time the build runs. See gradle/gradle#20873

Hopefully they fix this in Gradle 9.x.