### PR TITLE
HIA-834: If invalid mappa level - return null level - no exception

### DIFF
--- a/projects/external-api-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/DataLoader.kt
+++ b/projects/external-api-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/DataLoader.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.data.generator.ReferenceDataGenerator.RD_DIS
 import uk.gov.justice.digital.hmpps.data.generator.ReferenceDataGenerator.RD_DISABILITY_TYPE
 import uk.gov.justice.digital.hmpps.data.generator.ReferenceDataGenerator.RD_NATIONALITY
 import uk.gov.justice.digital.hmpps.data.generator.ReferenceDataGenerator.RD_RELIGION
+import uk.gov.justice.digital.hmpps.data.generator.RegistrationGenerator.INVALID_MAPPA_LEVEL
 import uk.gov.justice.digital.hmpps.model.Category
 import uk.gov.justice.digital.hmpps.model.Level
 import uk.gov.justice.digital.hmpps.user.AuditUserRepository
@@ -57,12 +58,15 @@ class DataLoader(
                 persist(RD_DISABILITY_TYPE)
                 persist(RD_DISABILITY_CONDITION)
                 persist(RD_ADDRESS_STATUS)
+                persist(RegistrationGenerator.INVALID_MAPPA_LEVEL)
                 persist(DataGenerator.DEFAULT_PROVIDER)
                 persist(DataGenerator.DEFAULT_TEAM)
                 persist(DataGenerator.JOHN_SMITH)
                 persist(DataGenerator.JS_USER)
                 persist(DataGenerator.PERSON)
+                persist(DataGenerator.PERSON_2)
                 persist(DataGenerator.PERSON_MANAGER)
+                persist(DataGenerator.PERSON_MANAGER_2)
                 persist(PersonGenerator.generateAddress(PersonGenerator.DEFAULT))
                 persist(DataGenerator.OFFENCE)
                 persist(DataGenerator.COURT)
@@ -88,6 +92,16 @@ class DataLoader(
                         RegistrationGenerator.LEVELS[Level.M1.name],
                         reviewDate = LocalDate.now().plusMonths(6),
                         notes = "Mappa Detail for ${DataGenerator.PERSON.crn}"
+                    )
+                )
+                persist(
+                    RegistrationGenerator.generate(
+                        RegistrationGenerator.MAPPA_TYPE,
+                        RegistrationGenerator.CATEGORIES[Category.M2.name],
+                        INVALID_MAPPA_LEVEL,
+                        person = DataGenerator.PERSON_2,
+                        reviewDate = LocalDate.now().plusMonths(6),
+                        notes = "Invalid mappa level ${DataGenerator.PERSON_2.crn}"
                     )
                 )
                 persist(PersonGenerator.EXCLUSION)

--- a/projects/external-api-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/DataGenerator.kt
+++ b/projects/external-api-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/DataGenerator.kt
@@ -16,8 +16,18 @@ object DataGenerator {
     val JS_USER = StaffUser(JOHN_SMITH, "john-smith", IdGenerator.getAndIncrement())
 
     val PERSON = PersonGenerator.DEFAULT
+    val PERSON_2 = PersonGenerator.DEFAULT_2
     val PERSON_MANAGER = PersonManager(
         PERSON,
+        DEFAULT_PROVIDER,
+        DEFAULT_TEAM,
+        JOHN_SMITH,
+        true,
+        IdGenerator.getAndIncrement()
+    )
+
+    val PERSON_MANAGER_2 = PersonManager(
+        PERSON_2,
         DEFAULT_PROVIDER,
         DEFAULT_TEAM,
         JOHN_SMITH,

--- a/projects/external-api-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/PersonGenerator.kt
+++ b/projects/external-api-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/PersonGenerator.kt
@@ -18,7 +18,7 @@ object PersonGenerator {
         exclusionMessage = "You are excluded from viewing this case",
         restrictionMessage = "You are restricted from viewing this case"
     )
-    val DEFAULT_2 = generate("A000002", "A0002DY")
+    val DEFAULT_2 = generate("A000003", "A0003DY")
 
     fun generate(
         crn: String,

--- a/projects/external-api-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/PersonGenerator.kt
+++ b/projects/external-api-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/PersonGenerator.kt
@@ -18,6 +18,7 @@ object PersonGenerator {
         exclusionMessage = "You are excluded from viewing this case",
         restrictionMessage = "You are restricted from viewing this case"
     )
+    val DEFAULT_2 = generate("A000002", "A0002DY")
 
     fun generate(
         crn: String,

--- a/projects/external-api-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/RegistrationGenerator.kt
+++ b/projects/external-api-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/RegistrationGenerator.kt
@@ -14,6 +14,7 @@ object RegistrationGenerator {
     val MAPPA_TYPE = generateType(RegisterType.MAPPA_CODE)
     val CATEGORIES = Category.entries.map { generateReferenceData(it.name) }.associateBy { it.code }
     val LEVELS = Level.entries.map { generateReferenceData(it.name) }.associateBy { it.code }
+    val INVALID_MAPPA_LEVEL = generateReferenceData("L1", "Level 1")
 
     fun generateType(code: String, id: Long = IdGenerator.getAndIncrement()) =
         RegisterType(code, "Description for $code", id)

--- a/projects/external-api-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/SupervisionIntegrationTest.kt
+++ b/projects/external-api-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/SupervisionIntegrationTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import uk.gov.justice.digital.hmpps.data.generator.DataGenerator.PERSON
+import uk.gov.justice.digital.hmpps.data.generator.DataGenerator.PERSON_2
 import uk.gov.justice.digital.hmpps.data.generator.ReferenceDataGenerator.RD_FEMALE
 import uk.gov.justice.digital.hmpps.data.generator.ReferenceDataGenerator.RD_MALE
 import uk.gov.justice.digital.hmpps.model.PersonIdentifier
@@ -67,5 +68,14 @@ internal class SupervisionIntegrationTest : BaseIntegrationTest() {
                 RefData(PhoneTypes.MOBILE.name, PhoneTypes.MOBILE.description)
             )
         )
+    }
+
+    @Test
+    fun `returns no mappa level if invalid mappa level`() {
+        val response = mockMvc
+            .perform(get("/case/${PERSON_2.crn}/supervisions").withToken())
+            .andExpect(status().is2xxSuccessful)
+            .andReturn().response.contentAsJson<SupervisionResponse>()
+        Assertions.assertEquals(null, response.mappaDetail?.level)
     }
 }

--- a/projects/external-api-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/model/MappaDetail.kt
+++ b/projects/external-api-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/model/MappaDetail.kt
@@ -17,7 +17,6 @@ enum class Level(val number: Int) { M0(0), M1(1), M2(2), M3(3) }
 enum class Category(val number: Int) { X9(0), M1(1), M2(2), M3(3), M4(4) }
 
 fun String.toMappaLevel() = Level.entries.find { it.name == this }?.number
-    ?: throw IllegalStateException("Unexpected MAPPA level: $this")
 
 fun String.toMappaCategory() = Category.entries.find { it.name == this }?.number
     ?: throw IllegalStateException("Unexpected MAPPA category: $this")


### PR DESCRIPTION
External API throws an exception if a MAPPA record is returned with an old level. As stated in the ndelius slack channel, Andrew Logan has stated that in this case, external api should return a null level and not throw an exception
See https://mojdt.slack.com/archives/C6C1KGRME/p1752741999193479