### PR TITLE
PI-3337: remove left join, as this is not needed.  Also, as r_contact…

### DIFF
--- a/projects/manage-supervision-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/overview/entity/Contact.kt
+++ b/projects/manage-supervision-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/overview/entity/Contact.kt
@@ -339,7 +339,6 @@ interface ContactRepository : JpaRepository<Contact, Long> {
             select c.*
             from contact c
             join r_contact_type ct on c.contact_type_id = ct.contact_type_id
-            left join r_contact_type_outcome cot on cot.contact_outcome_type_id = c.contact_outcome_type_id
             where c.offender_id = :personId and ct.attendance_contact = 'Y'
             and (to_char(c.contact_date, 'YYYY-MM-DD') > :dateNow
             or (to_char(c.contact_date, 'YYYY-MM-DD') = :dateNow and to_char(c.contact_start_time, 'HH24:MI') > :timeNow))


### PR DESCRIPTION
…_type_outcome.CONTACT_TYPE_ID is not in the left join, this is causing duplicate data returning for those contacts with an outcome recorded.