### PR TITLE
Ignore dev Swagger links

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -11,3 +11,4 @@ https://raw.githubusercontent.com/ministryofjustice/hmpps-probation-integration-
 https://ministryofjustice.github.io/hmpps-probation-integration-services/tech-docs/projects/
 https://operations-engineering-reports.cloud-platform.service.justice.gov.uk.*
 https://criminaljusticehub.org.uk.*
+https://.*-dev.hmpps.service.justice.gov.uk/swagger-ui/index.html


### PR DESCRIPTION
to avoid failures for services that have not been deployed to dev yet

Result: https://github.com/ministryofjustice/hmpps-probation-integration-services/actions/runs/17638583430#summary-50120053315