### PR TITLE
PI-3476 Enable concurrent segment search

### DIFF
--- a/projects/person-search-index-from-delius/container/pipelines/contact-semantic/index/index-template-semantic.yml
+++ b/projects/person-search-index-from-delius/container/pipelines/contact-semantic/index/index-template-semantic.yml
@@ -5,6 +5,7 @@ template:
   settings:
     default_pipeline: contact-semantic-search-pipeline
     index.search.default_pipeline: contact-semantic-search-search-pipeline
+    index.search.concurrent_segment_search.mode: auto
     index.knn: true
     index.knn.derived_source.enabled: true
     index.number_of_shards: 12


### PR DESCRIPTION
This should improve search latency since OpenSearch 3.1, according to: https://opensearch.org/blog/reducing-hybrid-query-latency-in-opensearch-3-1-with-efficient-score-collection/

OSS OpenSearch defaults to "auto".