### PR TITLE
PI-3449 Remove use of `copy_to` fields

### DIFF
--- a/projects/person-search-index-from-delius/container/pipelines/contact-semantic/index/index-template-semantic.yml
+++ b/projects/person-search-index-from-delius/container/pipelines/contact-semantic/index/index-template-semantic.yml
@@ -1226,7 +1226,6 @@ template:
       date:
         type: text
         analyzer: probation_text_analyzer
-        copy_to: notes
         fields:
           date:
             type: date
@@ -1255,42 +1254,50 @@ template:
         type: text
         analyzer: probation_text_analyzer
         boost: 4
-      outcome:
+      typeCode:
         type: text
         analyzer: probation_text_analyzer
-        store: true
+        fields:
+          keyword:
+            type: keyword
+      typeDescription:
+        type: text
+        analyzer: probation_text_analyzer
+        boost: 3
+        fields:
+          keyword:
+            type: keyword
+      typeShortDescription:
+        type: text
+        analyzer: probation_text_analyzer
+        fields:
+          keyword:
+            type: keyword
+      outcomeCode:
+        type: text
+        analyzer: probation_text_analyzer
+        fields:
+          keyword:
+            type: keyword
+      outcomeDescription:
+        type: text
+        analyzer: probation_text_analyzer
         boost: 2
         fields:
           keyword:
             type: keyword
-      type:
+      attended:
         type: text
         analyzer: probation_text_analyzer
-        store: true
         fields:
           keyword:
             type: keyword
-      typeCode:
-        type: keyword
-        copy_to: type
-      typeDescription:
-        type: keyword
-        copy_to: type
-      typeShortDescription:
-        type: keyword
-        copy_to: type
-      outcomeCode:
-        type: keyword
-        copy_to: outcome
-      outcomeDescription:
-        type: keyword
-        copy_to: outcome
-      attended:
-        type: keyword
-        copy_to: outcome
       complied:
-        type: keyword
-        copy_to: outcome
+        type: text
+        analyzer: probation_text_analyzer
+        fields:
+          keyword:
+            type: keyword
       lastUpdatedDateTime:
         type: date
       rowVersion:


### PR DESCRIPTION
As they seem to break highlighting on the semantic index