### PR TITLE
Attempt to fix Docker builds always detecting changes

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -53,19 +53,21 @@ runs:
       with:
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        context: projects/${{ inputs.project }}/container
         pull: true
         load: true
         push: false
         provenance: false
         tags: |
           ghcr.io/ministryofjustice/hmpps-probation-integration-services/${{ inputs.project }}:latest
+      working-directory: projects/${{ inputs.project }}/container
       env:
         SOURCE_DATE_EPOCH: 0
 
     - name: Check for changes
       id: check-changes
       run: |
+        echo "old: $old"
+        echo "new: $new"
         if [ "$old" = "$new" ]; then echo 'projects=[]'; else echo 'projects=["${{ inputs.project }}"]'; fi | tee -a "$GITHUB_OUTPUT"
       env:
         new: ${{ steps.build.outputs.digest }}
@@ -78,12 +80,12 @@ runs:
       with:
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        context: projects/${{ inputs.project }}/container
         push: ${{ inputs.push }}
         provenance: false
         tags: |
           ghcr.io/ministryofjustice/hmpps-probation-integration-services/${{ inputs.project }}:latest
           ghcr.io/ministryofjustice/hmpps-probation-integration-services/${{ inputs.project }}:${{ steps.version.outputs.version }}
+      working-directory: projects/${{ inputs.project }}/container
       env:
         SOURCE_DATE_EPOCH: 0
 

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -53,13 +53,13 @@ runs:
       with:
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        context: "{{defaultContext}}:projects/${{ inputs.project }}/container"
         pull: true
         load: true
         push: false
         provenance: false
         tags: |
           ghcr.io/ministryofjustice/hmpps-probation-integration-services/${{ inputs.project }}:latest
-      working-directory: projects/${{ inputs.project }}/container
       env:
         SOURCE_DATE_EPOCH: 0
 
@@ -80,12 +80,12 @@ runs:
       with:
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        context: "{{defaultContext}}:projects/${{ inputs.project }}/container"
         push: ${{ inputs.push }}
         provenance: false
         tags: |
           ghcr.io/ministryofjustice/hmpps-probation-integration-services/${{ inputs.project }}:latest
           ghcr.io/ministryofjustice/hmpps-probation-integration-services/${{ inputs.project }}:${{ steps.version.outputs.version }}
-      working-directory: projects/${{ inputs.project }}/container
       env:
         SOURCE_DATE_EPOCH: 0
 

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -51,8 +51,8 @@ runs:
       uses: docker/build-push-action@v6
       id: build
       with:
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-from: type=gha,scope=${{ inputs.project }}
+        cache-to: type=gha,mode=max,scope=${{ inputs.project }}
         context: "{{defaultContext}}:projects/${{ inputs.project }}/container"
         pull: true
         load: true
@@ -78,8 +78,8 @@ runs:
       uses: docker/build-push-action@v6
       if: (steps.check-changes.outputs.projects != '[]' && inputs.push == 'true') || inputs.force == 'true'
       with:
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-from: type=gha,scope=${{ inputs.project }}
+        cache-to: type=gha,mode=max,scope=${{ inputs.project }}
         context: "{{defaultContext}}:projects/${{ inputs.project }}/container"
         push: ${{ inputs.push }}
         provenance: false


### PR DESCRIPTION
I think the problem was that the caches weren't scoped to the individual Docker build.  So e.g. a build for the "feature-flags" project might have been using the cache from some other project.  Hence, no caching and changes incorrectly being detected for all but one project every time.