### PR TITLE
PI - 3473 - Log failed CPR requests to telemetry

### DIFF
--- a/projects/common-platform-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/client/CorePersonClient.kt
+++ b/projects/common-platform-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/client/CorePersonClient.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.integrations.client
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.service.annotation.GetExchange
@@ -12,7 +13,7 @@ interface CorePersonClient {
     fun findByDefendantId(@PathVariable defendantId: String): CorePersonRecord
 
     @PutExchange(value = "/person/probation/{defendantId}")
-    fun createPersonRecord(@PathVariable defendantId: String, @RequestBody person: CreateCorePersonRequest)
+    fun createPersonRecord(@PathVariable defendantId: String, @RequestBody person: CreateCorePersonRequest): ResponseEntity<Void>
 }
 
 data class CorePersonRecord(

--- a/projects/common-platform-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/FIFOHandler.kt
+++ b/projects/common-platform-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/FIFOHandler.kt
@@ -189,15 +189,24 @@ class FIFOHandler(
             )
         )
 
-        corePerson.createPersonRecord(insertRemandDTO.defendant.id, cprRequest)
+        val cprResponse = corePerson.createPersonRecord(insertRemandDTO.defendant.id, cprRequest)
 
-        telemetryService.trackEvent(
-            "CPRRecordCreated", mapOf(
-                "hearingId" to insertRemandDTO.hearingId,
-                "defendantId" to insertRemandDTO.defendant.id,
-                "CRN" to insertRemandResult.insertPersonResult.person.crn
+        if (cprResponse.statusCode.is2xxSuccessful) {
+            telemetryService.trackEvent(
+                "CPRRecordCreated", mapOf(
+                    "hearingId" to insertRemandDTO.hearingId,
+                    "defendantId" to insertRemandDTO.defendant.id,
+                    "CRN" to insertRemandResult.insertPersonResult.person.crn
+                )
             )
-        )
+        } else {
+            telemetryService.trackEvent(
+                "CPRCreateEndpointFailed", mapOf(
+                    "defendantId" to insertRemandDTO.defendant.id,
+                    "CRN" to insertRemandResult.insertPersonResult.person.crn
+                )
+            )
+        }
 
         notifier.caseCreated(insertRemandResult.insertPersonResult.person)
         insertRemandResult.insertPersonResult.address?.let { notifier.addressCreated(it) }

--- a/projects/common-platform-and-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/messaging/FIFOHandlerTest.kt
+++ b/projects/common-platform-and-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/messaging/FIFOHandlerTest.kt
@@ -12,6 +12,7 @@ import org.mockito.kotlin.*
 import org.opensearch.client.opensearch.OpenSearchClient
 import org.opensearch.client.opensearch.core.IndexRequest
 import org.opensearch.client.util.ObjectBuilder
+import org.springframework.http.ResponseEntity
 import uk.gov.justice.digital.hmpps.converter.NotificationConverter
 import uk.gov.justice.digital.hmpps.data.generator.*
 import uk.gov.justice.digital.hmpps.dto.InsertEventResult
@@ -68,6 +69,7 @@ internal class FIFOHandlerTest {
 
         corePersonHasNoCrn()
         featureFlagIsEnabled(true)
+        whenever(corePersonClient.createPersonRecord(any(), any())).thenReturn(ResponseEntity.status(500).build())
 
         val notification = Notification(message = MessageGenerator.COMMON_PLATFORM_EVENT)
         handler.handle(notification)
@@ -153,6 +155,7 @@ internal class FIFOHandlerTest {
 
         corePersonHasNoCrn()
         featureFlagIsEnabled(true)
+        whenever(corePersonClient.createPersonRecord(any(), any())).thenReturn(ResponseEntity.status(500).build())
 
         val notification = Notification(message = MessageGenerator.COMMON_PLATFORM_EVENT)
         handler.handle(notification)


### PR DESCRIPTION
Should also fix instances where domain events weren't being sent after the CPR call failed