### PR TITLE
Switch to azure/setup-helm action

### DIFF
--- a/.github/actions/cloud-platform-deploy/action.yml
+++ b/.github/actions/cloud-platform-deploy/action.yml
@@ -80,16 +80,14 @@ runs:
         namespace: ${{ inputs.namespace }}
         token: ${{ inputs.token }}
 
+    - name: Install Helm
+      uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4
+
     - name: Deploy
       shell: bash
       run: |
         yq -i ".appVersion = \"${{ inputs.version }}\"" "projects/${{ inputs.project }}/deploy/Chart.yaml"
-
-        echo '::group::Install Helm dependencies'
-        eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-        brew install helm
         helm dependency update "projects/${{ inputs.project }}/deploy"
-        echo '::endgroup::'
 
         set +o pipefail
         for attempt in $(seq 1 $MAX_ATTEMPTS); do


### PR DESCRIPTION
This caches the Helm installation saving time compared to the Homebrew version.


New version only takes around 1s:
<img width="1130" height="113" alt="image" src="https://github.com/user-attachments/assets/7cb33bfd-ca74-4fb8-a8af-53938617ff33" />


Compared to around 30s before:
<img width="569" height="315" alt="image" src="https://github.com/user-attachments/assets/9a35b569-3844-4469-b60d-519a3d1fba13" />
