### PR TITLE
Add branch label to Docker images

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -81,7 +81,7 @@ runs:
       run: |
         echo "old digest: $old"
         echo "new digest: $new"
-        if [ "$old" = "$new" ]; then digest_changed_projects='[]'; else echo digest_changed_projects='["'"${project}"'"]'; fi
+        if [ "$old" = "$new" ]; then digest_changed_projects='[]'; else digest_changed_projects='["'"${project}"'"]'; fi
 
         # merge changes from deploy files and digest changes
         echo "projects=$(jq -c -n \


### PR DESCRIPTION
This ensures branch builds are not cached in the same way as branch builds, avoiding the following issue:
1. deploy from branch (builds and pushes)
2. merge to main (checks digest and detects no changes)
3. pipeline does not deploy changes