### PR TITLE
Return 409 conflict for database constraint failures

### DIFF
--- a/libs/oauth-server/build.gradle.kts
+++ b/libs/oauth-server/build.gradle.kts
@@ -1,11 +1,13 @@
 dependencies {
     implementation(project(":libs:commons"))
+    compileOnly("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
     implementation(libs.springdoc)
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.boot:spring-boot-starter-data-jpa")
     testImplementation(libs.bundles.mockito)
 }
 

--- a/libs/oauth-server/src/main/kotlin/uk/gov/justice/digital/hmpps/advice/ControllerAdvice.kt
+++ b/libs/oauth-server/src/main/kotlin/uk/gov/justice/digital/hmpps/advice/ControllerAdvice.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.advice
 
 import jakarta.validation.ConstraintViolationException
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.http.HttpStatus.*
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.AccessDeniedException
@@ -14,17 +16,17 @@ import uk.gov.justice.digital.hmpps.exception.NotFoundException
 @RestControllerAdvice(basePackages = ["uk.gov.justice.digital.hmpps"])
 class ControllerAdvice {
     @ExceptionHandler(NotFoundException::class)
-    fun handleNotFound(e: NotFoundException) = ResponseEntity
+    fun handle(e: NotFoundException) = ResponseEntity
         .status(NOT_FOUND)
         .body(ErrorResponse(status = NOT_FOUND.value(), message = e.message))
 
     @ExceptionHandler(ConflictException::class)
-    fun handleConflict(e: ConflictException) = ResponseEntity
+    fun handle(e: ConflictException) = ResponseEntity
         .status(CONFLICT)
         .body(ErrorResponse(status = CONFLICT.value(), message = e.message))
 
     @ExceptionHandler(MethodArgumentNotValidException::class)
-    fun handleMethodArgumentNotValid(e: MethodArgumentNotValidException) = ResponseEntity
+    fun handle(e: MethodArgumentNotValidException) = ResponseEntity
         .badRequest()
         .body(
             ErrorResponse(
@@ -35,22 +37,31 @@ class ControllerAdvice {
         )
 
     @ExceptionHandler(InvalidRequestException::class)
-    fun handleInvalidRequest(e: InvalidRequestException) = ResponseEntity
+    fun handle(e: InvalidRequestException) = ResponseEntity
         .status(BAD_REQUEST)
         .body(ErrorResponse(status = BAD_REQUEST.value(), message = e.message))
 
     @ExceptionHandler(ConstraintViolationException::class)
-    fun handleInvalidRequest(e: ConstraintViolationException) = ResponseEntity
+    fun handle(e: ConstraintViolationException) = ResponseEntity
         .status(BAD_REQUEST)
         .body(ErrorResponse(status = BAD_REQUEST.value(), message = e.message))
 
     @ExceptionHandler(AccessDeniedException::class)
-    fun handleAccessDenied(e: AccessDeniedException) = ResponseEntity
+    fun handle(e: AccessDeniedException) = ResponseEntity
         .status(FORBIDDEN)
         .body(ErrorResponse(status = FORBIDDEN.value(), message = e.message))
 
     @ExceptionHandler(IllegalArgumentException::class)
-    fun handleIllegalArgument(e: IllegalArgumentException) = ResponseEntity
+    fun handle(e: IllegalArgumentException) = ResponseEntity
         .status(BAD_REQUEST)
         .body(ErrorResponse(status = BAD_REQUEST.value(), message = e.message))
+}
+
+@RestControllerAdvice(basePackages = ["uk.gov.justice.digital.hmpps"])
+@ConditionalOnClass(name = ["org.springframework.dao.DataIntegrityViolationException"])
+class JpaControllerAdvice {
+    @ExceptionHandler(DataIntegrityViolationException::class)
+    fun handle(e: DataIntegrityViolationException) = ResponseEntity
+        .status(CONFLICT)
+        .body(ErrorResponse(status = CONFLICT.value(), message = e.message))
 }

--- a/libs/oauth-server/src/test/kotlin/uk/gov/justice/digital/hmpps/advice/ControllerAdviceTest.kt
+++ b/libs/oauth-server/src/test/kotlin/uk/gov/justice/digital/hmpps/advice/ControllerAdviceTest.kt
@@ -6,9 +6,8 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.whenever
 import org.springframework.core.MethodParameter
-import org.springframework.http.HttpStatus.BAD_REQUEST
-import org.springframework.http.HttpStatus.CONFLICT
-import org.springframework.http.HttpStatus.NOT_FOUND
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.http.HttpStatus.*
 import org.springframework.validation.BindingResult
 import org.springframework.validation.FieldError
 import org.springframework.web.bind.MethodArgumentNotValidException
@@ -19,7 +18,7 @@ import kotlin.reflect.jvm.javaMethod
 class ControllerAdviceTest {
     @Test
     fun `handles not found`() {
-        val response = ControllerAdvice().handleNotFound(NotFoundException("Some Entity", "identifier", 123))
+        val response = ControllerAdvice().handle(NotFoundException("Some Entity", "identifier", 123))
 
         assertThat(response.statusCode, equalTo(NOT_FOUND))
         assertThat(response.body?.message, equalTo("Some Entity with identifier of 123 not found"))
@@ -27,7 +26,15 @@ class ControllerAdviceTest {
 
     @Test
     fun `handles conflict`() {
-        val response = ControllerAdvice().handleConflict(ConflictException("something conflicted"))
+        val response = ControllerAdvice().handle(ConflictException("something conflicted"))
+
+        assertThat(response.statusCode, equalTo(CONFLICT))
+        assertThat(response.body?.message, equalTo("something conflicted"))
+    }
+
+    @Test
+    fun `handles database integrity violation`() {
+        val response = JpaControllerAdvice().handle(DataIntegrityViolationException("something conflicted"))
 
         assertThat(response.statusCode, equalTo(CONFLICT))
         assertThat(response.body?.message, equalTo("something conflicted"))
@@ -37,7 +44,7 @@ class ControllerAdviceTest {
     fun `handles invalid method argument`() {
         val bindingResult = mock(BindingResult::class.java)
         whenever(bindingResult.fieldErrors).thenReturn(listOf(FieldError("object", "field", "message")))
-        val response = ControllerAdvice().handleMethodArgumentNotValid(
+        val response = ControllerAdvice().handle(
             MethodArgumentNotValidException(MethodParameter(::testMethod.javaMethod!!, 0), bindingResult)
         )
 


### PR DESCRIPTION
This was something I noticed while testing the accredited programmes integration - creating multiple appointments with the same reference results in a 500, due to the unique index on contact.external_reference. A 409 conflict seems like the correct response in this scenario.