### PR TITLE
Fix configuration cache misses due to AWS credentials

### DIFF
--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -26,6 +26,17 @@ runs:
         role-skip-session-tagging: true
         role-duration-seconds: 1200
 
+    - name: Save credentials to AWS profile
+      if: inputs.cache-role != ''
+      shell: bash # language=bash
+      run: |
+        export AWS_PROFILE=cache-profile
+        aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID" --profile "$PROFILE_NAME"
+        aws configure set aws_secret_access_key "$AWS_SECRET_ACCESS_KEY" --profile "$PROFILE_NAME"
+        aws configure set aws_session_token "$AWS_SESSION_TOKEN" --profile "$PROFILE_NAME"
+        aws configure set region "eu-west-2" --profile "$PROFILE_NAME"
+        echo "AWS_PROFILE=$AWS_PROFILE" >> $GITHUB_ENV
+
     - name: Set cache encryption key as environment variable
       shell: bash
       run: echo "GRADLE_ENCRYPTION_KEY=$key" >> $GITHUB_ENV
@@ -35,11 +46,9 @@ runs:
     - uses: gradle/actions/setup-gradle@v5
       with:
         add-job-summary: 'on-failure'
-        #cache-encryption-key: ${{ env.GRADLE_ENCRYPTION_KEY }} # TODO configuration cache doesn't work with s3-build-cache yet, as of Oct 2025. See https://github.com/burrunan/gradle-s3-build-cache/issues/21
-        cache-read-only: ${{ github.ref_name != 'main' }}
+        cache-encryption-key: ${{ env.GRADLE_ENCRYPTION_KEY }}
         gradle-home-cache-excludes: |
-          caches
-          notifications
+          caches/build-cache-1
 
     - name: Manually cache buildSrc output # workaround for https://github.com/gradle/actions/issues/21
       uses: actions/cache@v4

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -14,3 +14,7 @@ repositories {
     mavenCentral()
     gradlePluginPortal()
 }
+
+tasks {
+    jar { outputs.cacheIf { true } }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@ org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 org.gradle.configuration-cache.parallel=true
-org.gradle.configuration-cache.problems=warn
-# Remove the above line once https://github.com/n0mer/gradle-git-properties/pull/235 is released
+org.gradle.configuration-cache.inputs.unsafe.ignore.file-system-checks=~/.aws/**
+# ^ workaround for configuration cache issues (e.g. https://github.com/burrunan/gradle-s3-build-cache/issues/21)
 org.gradle.jvmargs=-Xmx4g "-XX:MaxMetaspaceSize=1g"
 systemProp.sonar.host.url=https://sonarcloud.io
 systemProp.sonar.organization=ministryofjustice

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -136,6 +136,7 @@ buildCache {
         isPush = System.getenv("CI") != null
         bucket = "hmpps-probation-integration-gradle-cache"
         region = "eu-west-2"
-        lookupDefaultAwsCredentials = true
+        lookupDefaultAwsCredentials = false
+        awsProfile = "cache-profile"
     }
 }


### PR DESCRIPTION
Before (2.5-3 minutes per build)
https://github.com/ministryofjustice/hmpps-probation-integration-services/actions/runs/19742542588
<img width="614" height="588" alt="image" src="https://github.com/user-attachments/assets/9142a5ff-4982-4b1a-bc68-b7b10313219a" />

After (30-50 seconds per build)
https://github.com/ministryofjustice/hmpps-probation-integration-services/actions/runs/19743174362
<img width="610" height="585" alt="image" src="https://github.com/user-attachments/assets/32339519-b556-41f8-990e-86dc9f613654" />
