### PR TITLE
Stop caching Docker branch builds

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -55,7 +55,7 @@ runs:
       with:
         labels: GIT_BRANCH=${{ github.ref_name }}
         cache-from: type=gha,scope=${{ inputs.project }}
-        cache-to: ${{ inputs.push && format('type=gha,mode=max,scope={0}', inputs.project) || '' }}
+        cache-to: ${{ inputs.push == 'true' && format('type=gha,mode=max,scope={0}', inputs.project) || '' }}
         context: "{{defaultContext}}:projects/${{ inputs.project }}/container"
         pull: true
         load: true
@@ -103,7 +103,7 @@ runs:
       with:
         labels: GIT_BRANCH=${{ github.ref_name }}
         cache-from: type=gha,scope=${{ inputs.project }}
-        cache-to: ${{ inputs.push && format('type=gha,mode=max,scope={0}', inputs.project) || '' }}
+        cache-to: ${{ inputs.push == 'true' && format('type=gha,mode=max,scope={0}', inputs.project) || '' }}
         context: "{{defaultContext}}:projects/${{ inputs.project }}/container"
         push: ${{ inputs.push }}
         provenance: false


### PR DESCRIPTION
to prevent GitHub Actions caches filling up