### PR TITLE
PI-3708 Update S3 options for Application Insights data export

### DIFF
--- a/.github/actions/app-insights-to-s3/action.yml
+++ b/.github/actions/app-insights-to-s3/action.yml
@@ -38,7 +38,7 @@ runs:
       run: |
         curl -fsSL -H "x-api-key: $key" --data-urlencode "query=$query" --get "$url" \
           | jq -rc '.tables[0] | (.columns | map(.name)) as $cols | .rows[] | with_entries(.key |= $cols[.])' \
-          | aws s3 cp - "s3://$bucket_name/$bucket_prefix"
+          | aws s3 cp - "s3://$bucket_name/$bucket_prefix" --acl bucket-owner-full-control --sse AES256
       env:
         url: https://api.applicationinsights.io/v1/apps/${{ inputs.app-insights-guid }}/query
         key: ${{ inputs.app-insights-key }}

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -123,6 +123,6 @@ jobs:
             | order by timestamp desc
           role-arn: ${{ secrets.ANALYTICAL_PLATFORM_EXPORT_S3_ROLE_TO_ASSUME }}
           bucket-name: ${{ secrets.ANALYTICAL_PLATFORM_EXPORT_S3_BUCKET_NAME }}
-          bucket-prefix: /landing/hmpps-probation-integration/data/database_name=azure_monitor_application_insights/table_name=appointment_reminders_and_delius/extraction_timestamp=${{ steps.get-timestamp.outputs.timestamp }}/export.jsonl
+          bucket-prefix: landing/hmpps-probation-integration/data/database_name=azure_monitor_application_insights/table_name=appointment_reminders_and_delius/extraction_timestamp=${{ steps.get-timestamp.outputs.timestamp }}/export.jsonl
           app-insights-key: ${{ secrets.APP_INSIGHTS_API_KEY }}
           app-insights-guid: ${{ secrets.APP_INSIGHTS_APPLICATION_GUID }}


### PR DESCRIPTION
The bucket requires server-side encryption to be enabled. And there was an extra leading slash in the object key.

Tested here: https://github.com/ministryofjustice/hmpps-probation-integration-services/actions/runs/20100605159/job/57670179076