### PR TITLE
PI-3719 Increase App Insights data export period to 10 days

### DIFF
--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -109,7 +109,7 @@ jobs:
         with:
           query: |
             customEvents
-            | where timestamp between (startofday(ago(7d)) .. startofday(now()))
+            | where timestamp between (startofday(ago(10d)) .. startofday(now()))
             | where cloud_RoleName in ("appointment-reminders-and-delius")
             | where name == "UnpaidWorkAppointmentReminderSent"
             | project


### PR DESCRIPTION
to cover any delayed runs - data is deduplicated on the analytical platform