### PR TITLE
PI-3730 Improve handling of JSON parsing failures

### DIFF
--- a/projects/domain-events-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/scheduling/Scheduler.kt
+++ b/projects/domain-events-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/scheduling/Scheduler.kt
@@ -11,7 +11,7 @@ class Scheduler(private val service: DomainEventService) {
     @Scheduled(fixedDelayString = "\${poller.fixed-delay:100}")
     fun poll() {
         service.getDeltas()
-            .onEach { service.notify(it) }
+            .also(service::publishAll)
             .also(service::deleteAll)
     }
 }

--- a/projects/domain-events-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/DomainEventService.kt
+++ b/projects/domain-events-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/DomainEventService.kt
@@ -30,9 +30,12 @@ class DomainEventService(
 
     fun deleteAll(deltas: List<DomainEvent>) = domainEventRepository.deleteAllByIdInBatch(deltas.map { it.id })
 
+    fun publishAll(events: List<DomainEvent>) {
+        events.map { notificationEnhancer.enhance(it.asNotification()) }.onEach(::notify)
+    }
+
     @WithSpan("POLL domain_event", kind = SpanKind.SERVER)
-    fun notify(delta: DomainEvent) {
-        val notification = notificationEnhancer.enhance(delta.asNotification())
+    fun notify(notification: Notification<HmppsDomainEvent>) {
         notificationPublisher.publish(notification)
         telemetryService.trackEvent(
             "DomainEventPublished",

--- a/projects/domain-events-and-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/service/DomainEventServiceTest.kt
+++ b/projects/domain-events-and-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/service/DomainEventServiceTest.kt
@@ -47,8 +47,12 @@ class DomainEventServiceTest {
     @Test
     fun `multiple messages can be published`() {
         whenever(notificationEnhancer.enhance(any())).thenAnswer { it.getArgument(0) }
-        service.notify(DomainEventGenerator.generate("manual-ogrs"))
-        service.notify(DomainEventGenerator.generate("registration-added"))
+        service.publishAll(
+            listOf(
+                DomainEventGenerator.generate("manual-ogrs"),
+                DomainEventGenerator.generate("registration-added")
+            )
+        )
 
         verify(notificationPublisher, times(2)).publish(any())
     }
@@ -56,10 +60,13 @@ class DomainEventServiceTest {
     @Test
     fun `nothing is published if any entity is invalid`() {
         assertThrows<JsonProcessingException> {
-            service.notify(
-                DomainEventGenerator.generate(
-                    "{\"invalid-json\"}",
-                    "{\"invalid-json\"}"
+            service.publishAll(
+                listOf(
+                    DomainEventGenerator.generate("manual-ogrs"),
+                    DomainEventGenerator.generate(
+                        """{"invalid-json"}""",
+                        """{"invalid-json"}""",
+                    )
                 )
             )
         }


### PR DESCRIPTION
Ensure all JSON is parsed successfully before publishing, otherwise valid messages are published but not deleted - so we get stuck in a loop repeatedly publishing messages.