### PR TITLE
PI-3729 Log and ignore missing offence codes

### DIFF
--- a/projects/common-platform-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/dto/InsertRemandDTO.kt
+++ b/projects/common-platform-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/dto/InsertRemandDTO.kt
@@ -1,15 +1,14 @@
 package uk.gov.justice.digital.hmpps.dto
 
 import uk.gov.justice.digital.hmpps.messaging.Defendant
-import uk.gov.justice.digital.hmpps.messaging.HearingOffence
 import java.time.ZonedDateTime
 
 data class InsertRemandDTO(
     val defendant: Defendant,
+    val mainOffence: OffenceAndPlea,
+    val additionalOffences: List<OffenceAndPlea>,
     val courtCode: String,
-    val hearingOffence: HearingOffence,
     val sittingDay: ZonedDateTime,
     val caseUrn: String,
-    val hearingId: String,
-    val additionalOffences: List<HearingOffence>
+    val hearingId: String
 )

--- a/projects/common-platform-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/dto/OffenceAndPlea.kt
+++ b/projects/common-platform-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/dto/OffenceAndPlea.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.dto
+
+import uk.gov.justice.digital.hmpps.messaging.Plea
+
+data class OffenceAndPlea(
+    val offenceCode: String,
+    val homeOfficeOffenceCode: String,
+    val plea: Plea?
+)

--- a/projects/common-platform-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/entity/Event.kt
+++ b/projects/common-platform-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/entity/Event.kt
@@ -73,13 +73,13 @@ class Event(
     val inBreach: Boolean = false,
 
     @Column(name = "active_flag", columnDefinition = "NUMBER", nullable = false)
-    val active: Boolean,
+    val active: Boolean = true,
 
     @Column
     val breachEnd: LocalDate? = null,
 
     @Column
-    val ftcCount: Long,
+    val ftcCount: Long = 0,
 
     @Column(columnDefinition = "NUMBER", nullable = false)
     val pendingTransfer: Boolean = false,

--- a/projects/common-platform-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/CommonPlatformHearing.kt
+++ b/projects/common-platform-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/CommonPlatformHearing.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.messaging
 
 import com.asyncapi.kotlinasyncapi.annotation.channel.Message
+import uk.gov.justice.digital.hmpps.dto.OffenceAndPlea
 import java.time.LocalDate
 import java.time.ZonedDateTime
 
@@ -60,7 +61,13 @@ data class HearingOffence(
     val judicialResults: List<JudicialResult>? = emptyList(),
     val plea: Plea? = null,
     val verdict: Verdict? = null
-)
+) {
+    fun withHomeOfficeCode(homeOfficeCode: String) = OffenceAndPlea(
+        offenceCode = offenceCode!!,
+        homeOfficeOffenceCode = homeOfficeCode,
+        plea = plea
+    )
+}
 
 data class JudicialResult(
     val isConvictedResult: Boolean?,

--- a/projects/common-platform-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/RemandService.kt
+++ b/projects/common-platform-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/RemandService.kt
@@ -18,13 +18,13 @@ class RemandService(
         )
 
         val insertEventResult = eventService.insertEvent(
-            hearingOffence = insertRemandDTO.hearingOffence,
             person = insertPersonResult.person,
+            mainOffence = insertRemandDTO.mainOffence,
+            additionalOffences = insertRemandDTO.additionalOffences,
             courtCode = insertRemandDTO.courtCode,
             sittingDay = insertRemandDTO.sittingDay,
             caseUrn = insertRemandDTO.caseUrn,
             hearingId = insertRemandDTO.hearingId,
-            additionalOffences = insertRemandDTO.additionalOffences,
         )
 
         return InsertRemandResult(insertPersonResult, insertEventResult)

--- a/projects/common-platform-and-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/messaging/EventServiceTest.kt
+++ b/projects/common-platform-and-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/messaging/EventServiceTest.kt
@@ -142,8 +142,15 @@ internal class EventServiceTest {
             )
         ).thenReturn(ReferenceDataGenerator.ORDER_MANAGER_INITIAL_ALLOCATION)
 
-        val result =
-            eventService.insertEvent(hearingOffence, person, court.ouCode, sittingDay, caseUrn, hearing.id, listOf())
+        val result = eventService.insertEvent(
+            person = person,
+            mainOffence = hearingOffence.withHomeOfficeCode("00100"),
+            additionalOffences = listOf(),
+            courtCode = court.ouCode,
+            sittingDay = sittingDay,
+            caseUrn = caseUrn,
+            hearingId = hearing.id
+        )
 
         verify(eventRepository).save(any<Event>())
         verify(mainOffenceRepository).save(any<MainOffence>())

--- a/projects/common-platform-and-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/messaging/FIFOHandlerTest.kt
+++ b/projects/common-platform-and-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/messaging/FIFOHandlerTest.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.data.generator.*
 import uk.gov.justice.digital.hmpps.dto.InsertEventResult
 import uk.gov.justice.digital.hmpps.dto.InsertPersonResult
 import uk.gov.justice.digital.hmpps.dto.InsertRemandResult
+import uk.gov.justice.digital.hmpps.dto.OffenceAndPlea
 import uk.gov.justice.digital.hmpps.flags.FeatureFlags
 import uk.gov.justice.digital.hmpps.integrations.client.CorePersonClient
 import uk.gov.justice.digital.hmpps.integrations.client.CorePersonRecord
@@ -127,7 +128,7 @@ internal class FIFOHandlerTest {
         verify(telemetryService).trackEvent(
             "PersonAlreadyExists",
             mapOf(
-                "defendantId" to "00000000-0000-0000-0000-000000000000",
+                "defendantIds" to "[00000000-0000-0000-0000-000000000000]",
                 "crns" to "[X123456]",
                 "hearingId" to notification.message.hearing.id,
                 "hearingDates" to "2024-01-01T12:00Z[Europe/London], 2024-03-19T12:00Z[Europe/London], 2030-12-31T12:00Z[Europe/London]",
@@ -159,16 +160,7 @@ internal class FIFOHandlerTest {
     }
 
     private fun personOnRemandIsSuccessfullyCreated() {
-        whenever(offenceService.findMainOffence(any())).thenReturn(
-            HearingOffence(
-                id = "0",
-                offenceTitle = "Offence",
-                wording = "Offence",
-                offenceCode = "AA00000",
-                offenceLegislation = "",
-                listingNumber = 0
-            )
-        )
+        whenever(offenceService.findMainOffence(any())).thenReturn(OffenceAndPlea("AA00000", "12345", null))
 
         whenever(remandService.insertPersonOnRemand(any())).thenReturn(
             InsertRemandResult(
@@ -201,7 +193,7 @@ internal class FIFOHandlerTest {
     private fun corePersonAlreadyHasCrn() {
         val person = CorePersonRecord(
             "John", "Robert", "Smith", LocalDate.now().minusYears(21),
-            Identifiers(crns = listOf("X123456"))
+            Identifiers(crns = listOf("X123456"), defendantIds = listOf("00000000-0000-0000-0000-000000000000"))
         )
         whenever(corePersonClient.findByDefendantId(any())).thenReturn(person)
     }

--- a/projects/common-platform-and-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/messaging/OffenceServiceTest.kt
+++ b/projects/common-platform-and-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/messaging/OffenceServiceTest.kt
@@ -13,6 +13,8 @@ import software.amazon.awssdk.core.ResponseInputStream
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
 import software.amazon.awssdk.services.s3.model.GetObjectResponse
+import uk.gov.justice.digital.hmpps.data.generator.JudicialResultGenerator
+import uk.gov.justice.digital.hmpps.dto.OffenceAndPlea
 import uk.gov.justice.digital.hmpps.integrations.client.ManageOffencesClient
 import uk.gov.justice.digital.hmpps.integrations.client.Offence
 import uk.gov.justice.digital.hmpps.service.OffenceService
@@ -54,43 +56,10 @@ internal class OffenceServiceTest {
     fun `Main offence is set to the offence with the lowest priority`() {
         mockS3Client()
 
-        whenever(manageOffencesClient.getOffenceByCode("TN42001")).thenReturn(
-            Offence(
-                id = 0,
-                code = "TN42001",
-                description = "Offence 1",
-                startDate = LocalDate.now(),
-                homeOfficeStatsCode = "001/00"
-            )
-        )
-        whenever(manageOffencesClient.getOffenceByCode("ZZ00120")).thenReturn(
-            Offence(
-                id = 1,
-                code = "ZZ00120",
-                description = "Offence 2",
-                startDate = LocalDate.now(),
-                homeOfficeStatsCode = "001/01"
-            )
-        )
-
         val result = offenceService.findMainOffence(
             listOf(
-                HearingOffence(
-                    id = "0",
-                    offenceTitle = "Offence 1",
-                    offenceCode = "TN42001",
-                    wording = "Offence 1",
-                    offenceLegislation = "Offence 1",
-                    listingNumber = 0
-                ),
-                HearingOffence(
-                    id = "1",
-                    offenceTitle = "Offence 2",
-                    offenceCode = "ZZ00120",
-                    wording = "Offence 2",
-                    offenceLegislation = "Offence 2",
-                    listingNumber = 0
-                )
+                OffenceAndPlea("TN42001", "00100", null),
+                OffenceAndPlea("ZZ00120", "00101", null),
             )
         )
 
@@ -109,7 +78,7 @@ internal class OffenceServiceTest {
             )
         )
 
-        offenceService.findMainOffence(
+        offenceService.getRemandOffences(
             listOf(
                 HearingOffence(
                     id = "0",
@@ -117,9 +86,10 @@ internal class OffenceServiceTest {
                     offenceCode = "AA00000",
                     wording = "Unknown",
                     offenceLegislation = "Unknown",
-                    listingNumber = 0
+                    listingNumber = 0,
+                    judicialResults = listOf(JudicialResultGenerator.DEFAULT)
                 )
-            )
+            ), mapOf()
         )
 
         verify(telemetryService).trackEvent(
@@ -144,7 +114,7 @@ internal class OffenceServiceTest {
             )
         )
 
-        offenceService.findMainOffence(
+        offenceService.getRemandOffences(
             listOf(
                 HearingOffence(
                     id = "0",
@@ -152,9 +122,10 @@ internal class OffenceServiceTest {
                     offenceCode = "AA99999",
                     wording = "Unknown",
                     offenceLegislation = "Unknown",
-                    listingNumber = 0
+                    listingNumber = 0,
+                    judicialResults = listOf(JudicialResultGenerator.DEFAULT)
                 )
-            )
+            ), mapOf()
         )
 
         verify(telemetryService).trackEvent(


### PR DESCRIPTION
The main change here is to look up the Home Office code from the Manage Offences API at the start, and to filter out any offences with a null or ignored CJA or Home Office code, so that we don't have to deal with them again later.  Previously, we were using the Home Office code from two places (Manage Offences API + Detailed Offence table) - I've made the assumption that the API is the better source for this, but it would be good if someone could confirm.

Also, we were previously only applying the offence code ignore rules to the main offence - by applying these rules to all offences at the start, we can ensure additional offences with invalid codes don't slip through.

Depends on #5902

Resolves [COMMON-PLATFORM-AND-DELIUS-W](https://ministryofjustice.sentry.io/issues/6689394978) and [COMMON-PLATFORM-AND-DELIUS-1R](https://ministryofjustice.sentry.io/issues/6859282019)