### PR TITLE
Re-enable read-only mode for manage-supervision-and-delius project

### DIFF
--- a/.github/workflows/readonly.yml
+++ b/.github/workflows/readonly.yml
@@ -77,7 +77,6 @@ jobs:
             | grep -v domain-events-and-delius \
             | grep -v offender-events-and-delius \
             | grep -v opensearch-proxy \
-            | grep -v manage-supervision-and-delius \
             | jq --raw-input . | jq --slurp --compact-output .
           )
           echo "projects=$json" | tee -a "$GITHUB_OUTPUT"


### PR DESCRIPTION
This was previously disabled when the ingress was removed (See https://dsdmoj.atlassian.net/browse/PI-3028). However, the ingress has been reinstated now, so we can put the service into read-only mode as normal.