### PR TITLE
PI-3711 Add validation for future outcomes

### DIFF
--- a/libs/appointments/src/main/kotlin/uk/gov/justice/digital/hmpps/appointments/service/AppointmentService.kt
+++ b/libs/appointments/src/main/kotlin/uk/gov/justice/digital/hmpps/appointments/service/AppointmentService.kt
@@ -280,6 +280,12 @@ class AppointmentService internal constructor(
         enforcementAction: EnforcementAction,
         enforcementReviewType: Type
     ) = apply {
+        if (Schedule(this).isFuture && outcome != null) {
+            require(outcome.attended == false && outcome.complied == true) {
+                "Only permissible absences can be recorded for a future attendance"
+            }
+        }
+
         this.outcome = outcome
         if (outcome != null) {
             attended = outcome.attended

--- a/libs/appointments/src/test/kotlin/uk/gov/justice/digital/hmpps/appointments/test/TestData.kt
+++ b/libs/appointments/src/test/kotlin/uk/gov/justice/digital/hmpps/appointments/test/TestData.kt
@@ -26,6 +26,8 @@ internal object TestData {
         AppointmentOutcome(id(), "ATTC", "Attended - complied", attended = true, complied = true, enforceable = false)
     val FTC_OUTCOME =
         AppointmentOutcome(id(), "FTC", "Failed to comply", attended = false, complied = false, enforceable = true)
+    val ACCEPTABLE_ABSENCE_OUTCOME =
+        AppointmentOutcome(id(), "AA", "Acceptable absence", attended = false, complied = true, enforceable = false)
     val PROVIDER = AppointmentEntities.Provider(id(), "P01")
     val TEAM = Team(id(), "T01", "Team 1", PROVIDER)
     val STAFF = Staff(id(), "S01")

--- a/projects/accredited-programmes-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/DataLoader.kt
+++ b/projects/accredited-programmes-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/DataLoader.kt
@@ -75,6 +75,7 @@ class DataLoader(dataManager: DataManager) : BaseDataLoader(dataManager) {
         saveAll(TestData.STATUS_CONTACT_TYPES)
         save(TestData.ATTENDED_COMPLIED)
         save(TestData.FAILED_TO_COMPLY)
+        save(TestData.ACCEPTABLE_ABSENCE)
         save(TestData.REFER_TO_MANAGER_ACTION)
         save(TestData.PSS_END_DATE_KEY_DATE_TYPE)
         save(TestData.PSS_END_DATE)

--- a/projects/accredited-programmes-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/TestData.kt
+++ b/projects/accredited-programmes-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/TestData.kt
@@ -100,6 +100,7 @@ object TestData {
     val ATTENDED_COMPLIED = ContactOutcome(id(), "ATTC", "Attended and Complied")
     val FAILED_TO_COMPLY =
         ContactOutcome(id(), "FTC", "Failed to comply", attended = false, complied = false, enforceable = true)
+    val ACCEPTABLE_ABSENCE = ContactOutcome(id(), "AA", "Acceptable absence", attended = false, complied = true)
     val REFER_TO_MANAGER_CONTACT_TYPE = ContactType(id(), "ROM", false)
     val REFER_TO_MANAGER_ACTION = EnforcementAction(id(), "ROM", "Refer to manager", 7, REFER_TO_MANAGER_CONTACT_TYPE)
     val ENFORCEMENT_REVIEW_CONTACT_TYPE = ContactType(id(), "ARWS", false)

--- a/projects/accredited-programmes-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/AppointmentControllerIntegrationTest.kt
+++ b/projects/accredited-programmes-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/AppointmentControllerIntegrationTest.kt
@@ -453,7 +453,7 @@ internal class AppointmentControllerIntegrationTest @Autowired constructor(
                         startTime = LocalTime.now(),
                         endTime = LocalTime.now().plusMinutes(30),
                         sensitive = true,
-                        outcome = RequestCode("ATTC"),
+                        outcome = RequestCode("AA"),
                         location = RequestCode("OFFICE1"),
                         team = RequestCode("TEAM01"),
                         staff = RequestCode("STAFF01"),
@@ -473,7 +473,7 @@ internal class AppointmentControllerIntegrationTest @Autowired constructor(
                 |Some appended notes
                 """.trimMargin()
             )
-            assertThat(outcome?.code).isEqualTo("ATTC")
+            assertThat(outcome?.code).isEqualTo("AA")
             assertThat(date).isEqualTo(LocalDate.now().plusDays(1))
             assertThat(sensitive).isTrue
         }

--- a/projects/community-payback-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/UPWGenerator.kt
+++ b/projects/community-payback-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/UPWGenerator.kt
@@ -142,7 +142,7 @@ object UPWGenerator {
         contactOutcome = null,
         startTime = LocalTime.of(10, 15),
         endTime = LocalTime.of(16, 30),
-        date = LocalDate.now(),
+        date = LocalDate.now().minusDays(1),
         personId = PersonGenerator.DEFAULT_PERSON.id,
         officeLocation = DEFAULT_OFFICE_LOCATION,
         staff = StaffGenerator.DEFAULT_STAFF,
@@ -212,7 +212,7 @@ object UPWGenerator {
     val UPW_APPOINTMENT_NO_ENFORCEMENT = generateUpwAppointment(
         startTime = LocalTime.of(10, 15),
         endTime = LocalTime.of(16, 30),
-        date = LocalDate.now(),
+        date = LocalDate.now().minusDays(1),
         project = UPW_PROJECT_2,
         details = UPW_DETAILS_2,
         contact = CONTACT_NO_ENFORCEMENT,
@@ -232,7 +232,7 @@ object UPWGenerator {
         generateUpwAppointment(
             startTime = LocalTime.of(12, 0),
             endTime = LocalTime.of(14, 0),
-            date = LocalDate.now().plusDays(1),
+            date = LocalDate.now().minusDays(1),
             project = UPW_PROJECT_2,
             details = UPW_DETAILS_3,
             contact = generateContact(
@@ -243,7 +243,7 @@ object UPWGenerator {
                 contactOutcome = null,
                 startTime = LocalTime.of(12, 0),
                 endTime = LocalTime.of(14, 0),
-                date = LocalDate.now().plusDays(1),
+                date = LocalDate.now().minusDays(1),
                 officeLocation = DEFAULT_OFFICE_LOCATION,
                 staff = StaffGenerator.DEFAULT_STAFF,
                 team = TeamGenerator.DEFAULT_UPW_TEAM,

--- a/projects/community-payback-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/appointments/UpdateAppointmentIntegrationTest.kt
+++ b/projects/community-payback-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/appointments/UpdateAppointmentIntegrationTest.kt
@@ -18,10 +18,7 @@ import uk.gov.justice.digital.hmpps.entity.contact.ContactType.Code.REVIEW_ENFOR
 import uk.gov.justice.digital.hmpps.entity.sentence.EventRepository
 import uk.gov.justice.digital.hmpps.entity.unpaidwork.UnpaidWorkAppointmentRepository
 import uk.gov.justice.digital.hmpps.entity.unpaidwork.getAppointment
-import uk.gov.justice.digital.hmpps.model.AppointmentOutcomeRequest
-import uk.gov.justice.digital.hmpps.model.Behaviour
 import uk.gov.justice.digital.hmpps.model.Code
-import uk.gov.justice.digital.hmpps.model.WorkQuality
 import uk.gov.justice.digital.hmpps.test.MockMvcExtensions.contentAsJson
 import uk.gov.justice.digital.hmpps.test.MockMvcExtensions.json
 import uk.gov.justice.digital.hmpps.test.MockMvcExtensions.withToken
@@ -111,23 +108,7 @@ class UpdateAppointmentIntegrationTest @Autowired constructor(
 
         mockMvc.put("/projects/$PROJECT/appointments/${original.id}/outcome") {
             withToken()
-            json = AppointmentOutcomeRequest(
-                id = original.id,
-                version = UUID(original.rowVersion, originalContact.rowVersion),
-                outcome = Code("F"),
-                supervisor = Code("N01P001"),
-                startTime = LocalTime.of(8, 0),
-                endTime = LocalTime.of(10, 0),
-                notes = "ftc count",
-                hiVisWorn = true,
-                workedIntensively = true,
-                penaltyMinutes = 65,
-                minutesCredited = 55,
-                workQuality = WorkQuality.EXCELLENT,
-                behaviour = Behaviour.UNSATISFACTORY,
-                sensitive = false,
-                alertActive = true,
-            )
+            json = TestData.updateAppointment(original.id).copy(outcome = Code("F"))
         }.andExpect { status { is2xxSuccessful() } }
 
         val event = eventRepository.findAll().first { it.id == originalContact.event!!.id }
@@ -145,23 +126,7 @@ class UpdateAppointmentIntegrationTest @Autowired constructor(
 
         mockMvc.put("/projects/$PROJECT/appointments/${original.id}/outcome") {
             withToken()
-            json = AppointmentOutcomeRequest(
-                id = original.id,
-                version = UUID(original.rowVersion, original.contact.rowVersion),
-                outcome = Code("F"),
-                supervisor = Code("N01P001"),
-                startTime = LocalTime.of(8, 0),
-                endTime = LocalTime.of(10, 0),
-                notes = "enforcement",
-                hiVisWorn = true,
-                workedIntensively = true,
-                penaltyMinutes = 65,
-                minutesCredited = 375,
-                workQuality = WorkQuality.EXCELLENT,
-                behaviour = Behaviour.UNSATISFACTORY,
-                sensitive = false,
-                alertActive = true,
-            )
+            json = TestData.updateAppointment(original.id).copy(outcome = Code("F"))
         }.andExpect { status { is2xxSuccessful() } }
 
         val enforcement = enforcementRepository.findAll().firstOrNull { it.contact.id == original.contact.id }
@@ -174,23 +139,7 @@ class UpdateAppointmentIntegrationTest @Autowired constructor(
 
         mockMvc.put("/projects/$PROJECT/appointments/${original.id}/outcome") {
             withToken()
-            json = AppointmentOutcomeRequest(
-                id = original.id,
-                version = UUID(original.rowVersion, original.contact.rowVersion),
-                outcome = Code("A"),
-                supervisor = Code("N01P001"),
-                startTime = LocalTime.of(8, 0),
-                endTime = LocalTime.of(10, 0),
-                notes = "contact alert",
-                hiVisWorn = true,
-                workedIntensively = true,
-                penaltyMinutes = 65,
-                minutesCredited = 55,
-                workQuality = WorkQuality.EXCELLENT,
-                behaviour = Behaviour.UNSATISFACTORY,
-                sensitive = false,
-                alertActive = true,
-            )
+            json = TestData.updateAppointment(original.id).copy(alertActive = true)
         }.andExpect { status { is2xxSuccessful() } }
         val alert = contactAlertRepository.findAll().firstOrNull { it.contactId == original.contact.id }
         assertThat(alert).isNotNull
@@ -202,23 +151,7 @@ class UpdateAppointmentIntegrationTest @Autowired constructor(
 
         mockMvc.put("/projects/$PROJECT/appointments/${original.id}/outcome") {
             withToken()
-            json = AppointmentOutcomeRequest(
-                id = original.id,
-                version = UUID(original.rowVersion, original.contact.rowVersion),
-                outcome = null,
-                supervisor = Code("N01P001"),
-                startTime = LocalTime.of(8, 0),
-                endTime = LocalTime.of(10, 0),
-                notes = "contact alert",
-                hiVisWorn = true,
-                workedIntensively = true,
-                penaltyMinutes = 65,
-                minutesCredited = 55,
-                workQuality = WorkQuality.EXCELLENT,
-                behaviour = Behaviour.UNSATISFACTORY,
-                sensitive = false,
-                alertActive = true,
-            )
+            json = TestData.updateAppointment(original.id).copy(alertActive = true)
         }.andExpect { status { is2xxSuccessful() } }
 
         val alertCreated = contactAlertRepository.findAll().filter { it.contactId == original.contact.id }
@@ -227,22 +160,9 @@ class UpdateAppointmentIntegrationTest @Autowired constructor(
 
         mockMvc.put("/projects/$PROJECT/appointments/${second.id}/outcome") {
             withToken()
-            json = AppointmentOutcomeRequest(
-                id = second.id,
+            json = TestData.updateAppointment(original.id).copy(
                 version = UUID(second.rowVersion, second.contact.rowVersion),
-                outcome = null,
-                supervisor = Code("N01P001"),
-                startTime = LocalTime.of(8, 0),
-                endTime = LocalTime.of(10, 0),
-                notes = "contact alert deleting",
-                hiVisWorn = true,
-                workedIntensively = true,
-                penaltyMinutes = 65,
-                minutesCredited = 55,
-                workQuality = WorkQuality.EXCELLENT,
-                behaviour = Behaviour.UNSATISFACTORY,
-                sensitive = false,
-                alertActive = false,
+                alertActive = false
             )
         }.andExpect { status { is2xxSuccessful() } }
 

--- a/projects/community-payback-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/test/TestData.kt
+++ b/projects/community-payback-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/test/TestData.kt
@@ -58,18 +58,18 @@ object TestData {
     fun updateAppointment(id: Long) = AppointmentOutcomeRequest(
         id = id,
         version = UUID(1, 1),
-        outcome = null,
-        supervisor = Code("N01P001"),
         startTime = LocalTime.of(10, 0),
         endTime = LocalTime.of(18, 0),
-        notes = "testing update",
+        minutesCredited = 415,
+        penaltyMinutes = 65,
+        outcome = Code(ReferenceDataGenerator.ATTENDED_COMPLIED_CONTACT_OUTCOME.code),
         hiVisWorn = true,
         workedIntensively = true,
-        penaltyMinutes = 65,
-        minutesCredited = 415,
         workQuality = WorkQuality.EXCELLENT,
         behaviour = Behaviour.EXCELLENT,
+        supervisor = Code("N01P001"),
         sensitive = false,
         alertActive = false,
+        notes = "testing update",
     )
 }


### PR DESCRIPTION
When applying an outcome to future appointments, only permissible absences (i.e. complied but not attended) are allowed.