### PR TITLE
PI-3666 Update appointment defaults + validation

### DIFF
--- a/libs/appointments/src/main/kotlin/uk/gov/justice/digital/hmpps/appointments/model/UpdateAppointment.kt
+++ b/libs/appointments/src/main/kotlin/uk/gov/justice/digital/hmpps/appointments/model/UpdateAppointment.kt
@@ -19,7 +19,9 @@ class UpdateAppointment {
         val endTime: LocalTime?,
         val allowConflicts: Boolean = false,
     ) {
-        val isFuture: Boolean = date.atTime(endTime ?: startTime).atZone(EuropeLondon) > ZonedDateTime.now(EuropeLondon)
+        val endsInFuture: Boolean =
+            date.atTime(endTime ?: startTime).atZone(EuropeLondon) > ZonedDateTime.now(EuropeLondon)
+        val startsInFuture: Boolean = date.atTime(startTime).atZone(EuropeLondon) > ZonedDateTime.now(EuropeLondon)
 
         init {
             require(endTime == null || startTime < endTime) {

--- a/libs/appointments/src/main/kotlin/uk/gov/justice/digital/hmpps/appointments/service/AppointmentService.kt
+++ b/libs/appointments/src/main/kotlin/uk/gov/justice/digital/hmpps/appointments/service/AppointmentService.kt
@@ -143,7 +143,7 @@ class AppointmentService internal constructor(
     private fun <T> UpdatePipeline<T>.validateUpdates(updates: UpdateBuilder<T>) = onEach { (request, existing) ->
         val outcome = updates.applyOutcome?.invoke(Outcome(existing), request)?.outcomeCode
         val amendDateTime = updates.amendDateTime?.invoke(Schedule(existing), request)
-        require(amendDateTime == null || amendDateTime.isFuture || outcome != null) {
+        require(amendDateTime == null || amendDateTime.endsInFuture || outcome != null) {
             "Outcome must be provided when amending an appointment in the past"
         }
     }
@@ -280,7 +280,7 @@ class AppointmentService internal constructor(
         enforcementAction: EnforcementAction,
         enforcementReviewType: Type
     ) = apply {
-        if (Schedule(this).isFuture && outcome != null) {
+        if (Schedule(this).startsInFuture && outcome != null) {
             require(outcome.attended == false && outcome.complied == true) {
                 "Only permissible absences can be recorded for a future attendance"
             }

--- a/projects/community-payback-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/DataLoader.kt
+++ b/projects/community-payback-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/DataLoader.kt
@@ -61,6 +61,7 @@ class DataLoader(dataManager: DataManager) : BaseDataLoader(dataManager) {
         save(StaffGenerator.DEFAULT_STAFF)
         save(StaffGenerator.SECOND_STAFF)
         save(StaffGenerator.OTHER_PROVIDER_STAFF)
+        save(StaffGenerator.UNALLOCATED_STAFF)
         save(PersonGenerator.DEFAULT_PERSON_MANAGER)
     }
 

--- a/projects/community-payback-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/StaffGenerator.kt
+++ b/projects/community-payback-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/StaffGenerator.kt
@@ -27,6 +27,13 @@ object StaffGenerator {
         teams = listOf(TeamGenerator.OTHER_PROVIDER_TEAM)
     )
 
+    val UNALLOCATED_STAFF = generateStaff(
+        code = "N01000U",
+        forename = "Unallocated",
+        surname = "Staff",
+        teams = listOf(TeamGenerator.DEFAULT_UPW_TEAM)
+    )
+
     fun generateStaff(
         id: Long = IdGenerator.getAndIncrement(),
         code: String,

--- a/projects/community-payback-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/TeamGenerator.kt
+++ b/projects/community-payback-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/TeamGenerator.kt
@@ -47,6 +47,7 @@ object TeamGenerator {
         upwTeam: Boolean,
         startDate: LocalDate = LocalDate.now().minusDays(1),
         endDate: LocalDate? = null,
-        staff: List<Staff> = emptyList()
-    ) = Team(id, code, description, provider, upwTeam, startDate, endDate, staff)
+        staff: List<Staff> = emptyList(),
+        unallocatedStaff: List<Staff> = emptyList(),
+    ) = Team(id, code, description, provider, upwTeam, startDate, endDate, staff, unallocatedStaff)
 }

--- a/projects/community-payback-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/ProvidersIntegrationTest.kt
+++ b/projects/community-payback-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/ProvidersIntegrationTest.kt
@@ -7,6 +7,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
+import uk.gov.justice.digital.hmpps.data.generator.StaffGenerator
 import uk.gov.justice.digital.hmpps.model.ProvidersResponse
 import uk.gov.justice.digital.hmpps.model.SessionsResponse
 import uk.gov.justice.digital.hmpps.model.SupervisorsResponse
@@ -65,7 +66,11 @@ class ProvidersIntegrationTest @Autowired constructor(
             .andExpect { status { is2xxSuccessful() } }
             .andReturn().response.contentAsJson<SupervisorsResponse>()
 
-        assertThat(response.supervisors.size).isEqualTo(2)
+        assertThat(response.supervisors.map { it.code }).containsExactlyInAnyOrder(
+            StaffGenerator.DEFAULT_STAFF.code,
+            StaffGenerator.SECOND_STAFF.code,
+            StaffGenerator.UNALLOCATED_STAFF.code
+        )
     }
 
     @Test

--- a/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/entity/contact/ContactType.kt
+++ b/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/entity/contact/ContactType.kt
@@ -6,7 +6,9 @@ import org.hibernate.type.YesNoConverter
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import uk.gov.justice.digital.hmpps.exception.NotFoundException
+import uk.gov.justice.digital.hmpps.exception.NotFoundException.Companion.orNotFoundBy
 import uk.gov.justice.digital.hmpps.model.CodeDescription
+import uk.gov.justice.digital.hmpps.utils.Extensions.reportMissing
 import java.io.Serializable
 
 @Entity
@@ -98,10 +100,9 @@ interface ContactOutcomeRepository : JpaRepository<ContactOutcome, Long> {
     )
     fun findForTypeCode(typeCode: String): List<ContactOutcome>
 
-    fun findContactOutcomeByCode(code: String): ContactOutcome?
-
-    fun findByCodeIn(code: List<String>): List<ContactOutcome>
+    fun findByCode(code: String): ContactOutcome?
+    fun getByCode(code: String) = findByCode(code).orNotFoundBy("code", code)
+    fun findByCodeIn(code: Set<String>): List<ContactOutcome>
+    fun getByCodeIn(codes: List<String>) =
+        codes.toSet().let { codes -> findByCodeIn(codes).associateBy { it.code }.reportMissing(codes) }
 }
-
-fun ContactOutcomeRepository.getContactOutcome(code: String) =
-    findContactOutcomeByCode(code) ?: throw NotFoundException("Contact Outcome", "code", code)

--- a/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/entity/staff/OfficeLocation.kt
+++ b/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/entity/staff/OfficeLocation.kt
@@ -6,6 +6,7 @@ import jakarta.persistence.Id
 import jakarta.persistence.Table
 import org.hibernate.annotations.Immutable
 import org.springframework.data.jpa.repository.JpaRepository
+import uk.gov.justice.digital.hmpps.utils.Extensions.reportMissing
 
 @Entity
 @Table(name = "office_location")
@@ -33,5 +34,7 @@ class OfficeLocation(
 )
 
 interface OfficeLocationRepository : JpaRepository<OfficeLocation, Long> {
-    fun findAllByCodeIn(codes: List<String>): List<OfficeLocation>
+    fun findByCodeIn(codes: Collection<String>): List<OfficeLocation>
+    fun getByCodeIn(codes: List<String>) =
+        codes.toSet().let { codes -> findByCodeIn(codes).associateBy { it.code }.reportMissing(codes) }
 }

--- a/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/entity/staff/Staff.kt
+++ b/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/entity/staff/Staff.kt
@@ -5,11 +5,12 @@ import org.hibernate.annotations.Immutable
 import org.hibernate.annotations.SQLRestriction
 import org.springframework.data.jpa.repository.JpaRepository
 import uk.gov.justice.digital.hmpps.entity.ReferenceData
-import uk.gov.justice.digital.hmpps.exception.NotFoundException
+import uk.gov.justice.digital.hmpps.exception.NotFoundException.Companion.orNotFoundBy
 import uk.gov.justice.digital.hmpps.model.CodeDescription
 import uk.gov.justice.digital.hmpps.model.Name
 import uk.gov.justice.digital.hmpps.model.Supervisor
 import uk.gov.justice.digital.hmpps.model.SupervisorTeamsResponse
+import uk.gov.justice.digital.hmpps.utils.Extensions.reportMissing
 import java.time.LocalDate
 
 @Immutable
@@ -77,8 +78,8 @@ fun Staff.toSupervisorTeams() = teams.map {
 
 interface StaffRepository : JpaRepository<Staff, Long> {
     fun findByCode(code: String): Staff?
-    fun findAllByCodeIn(code: Collection<String>): List<Staff>
+    fun getByCode(code: String) = findByCode(code).orNotFoundBy("code", code)
+    fun findByCodeIn(code: Collection<String>): List<Staff>
+    fun getByCodeIn(codes: List<String>) =
+        codes.toSet().let { codes -> findByCodeIn(codes).associateBy { it.code }.reportMissing(codes) }
 }
-
-fun StaffRepository.getStaff(code: String): Staff =
-    findByCode(code) ?: throw NotFoundException("Staff", "code", code)

--- a/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/entity/staff/Team.kt
+++ b/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/entity/staff/Team.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.entity.staff
 
 import jakarta.persistence.*
 import org.hibernate.annotations.Immutable
+import org.hibernate.annotations.SQLRestriction
 import org.hibernate.type.YesNoConverter
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
@@ -43,7 +44,20 @@ class Team(
         inverseJoinColumns = [JoinColumn(name = "staff_id")]
     )
     val staff: List<Staff>,
-)
+
+    @ManyToMany
+    @JoinTable(
+        name = "staff_team",
+        joinColumns = [JoinColumn(name = "team_id")],
+        inverseJoinColumns = [JoinColumn(name = "staff_id")]
+    )
+    @SQLRestriction("officer_code like '%U' and (end_date is null or end_date > current_date)")
+    val unallocatedStaff: List<Staff>,
+) {
+    fun unallocatedStaff() = checkNotNull(unallocatedStaff.singleOrNull()) {
+        "Team $code does not have a single unallocated staff member"
+    }
+}
 
 interface TeamRepository : JpaRepository<Team, Long> {
     @Query(

--- a/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/entity/unpaidwork/CreateUnpaidWorkAppointment.kt
+++ b/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/entity/unpaidwork/CreateUnpaidWorkAppointment.kt
@@ -19,7 +19,6 @@ import uk.gov.justice.digital.hmpps.jpa.GeneratedId
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.ZonedDateTime
-import java.time.temporal.ChronoUnit
 
 @Entity
 @Table(name = "upw_appointment")
@@ -79,7 +78,7 @@ class CreateUnpaidWorkAppointment(
     var outcomeId: Long?,
 
     @Column(name = "minutes_offered")
-    val minutesOffered: Long? = ChronoUnit.MINUTES.between(startTime, endTime),
+    val minutesOffered: Long?,
 
     @Column(name = "minutes_credited")
     var minutesCredited: Long?,

--- a/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/entity/unpaidwork/UnpaidWorkAllocation.kt
+++ b/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/entity/unpaidwork/UnpaidWorkAllocation.kt
@@ -6,6 +6,7 @@ import org.hibernate.type.NumericBooleanConverter
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import uk.gov.justice.digital.hmpps.entity.ReferenceData
+import uk.gov.justice.digital.hmpps.utils.Extensions.reportMissing
 import java.time.LocalDate
 import java.time.LocalTime
 
@@ -69,5 +70,8 @@ interface UpwAllocationRepository : JpaRepository<UnpaidWorkAllocation, Long> {
         """
     )
     fun findByEventId(eventId: Long): List<UnpaidWorkAllocation>
+    fun findByIdIn(id: Set<Long>): List<UnpaidWorkAllocation>
+    fun getByIdIn(ids: List<Long>) =
+        ids.toSet().let { ids -> findByIdIn(ids).associateBy { it.id }.reportMissing(ids) }
 }
 

--- a/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/entity/unpaidwork/UnpaidWorkDetails.kt
+++ b/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/entity/unpaidwork/UnpaidWorkDetails.kt
@@ -7,6 +7,7 @@ import org.hibernate.type.NumericBooleanConverter
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import uk.gov.justice.digital.hmpps.entity.sentence.Disposal
+import uk.gov.justice.digital.hmpps.utils.Extensions.reportMissing
 
 @Entity
 @Immutable
@@ -29,21 +30,23 @@ class UnpaidWorkDetails(
 interface UpwDetailsRepository : JpaRepository<UnpaidWorkDetails, Long> {
     @Query(
         """
-        select d from UnpaidWorkDetails d
-        where d.disposal.event.id = :eventId
-        and d.softDeleted = false
-        and d.disposal.softDeleted = false
-    """
+            select d from UnpaidWorkDetails d
+            where d.disposal.event.id = :eventId
+            and d.softDeleted = false
+            and d.disposal.softDeleted = false
+        """
     )
-    fun findByEventId(eventId: Long): List<UnpaidWorkDetails>
+    fun findByEventIdIn(eventId: Long): List<UnpaidWorkDetails>
 
     @Query(
         """
-        select d from UnpaidWorkDetails d
-        where d.disposal.event.id in :eventId
-        and d.softDeleted = false
-        and d.disposal.softDeleted = false
-    """
+            select d from UnpaidWorkDetails d
+            where d.disposal.event.id in :eventId
+            and d.softDeleted = false
+            and d.disposal.softDeleted = false
+        """
     )
-    fun findAllByEventId(eventId: Collection<Long>): List<UnpaidWorkDetails>
+    fun findByEventIdIn(eventId: Collection<Long>): List<UnpaidWorkDetails>
+    fun getByEventIdIn(ids: Collection<Long>) =
+        ids.toSet().let { ids -> findByEventIdIn(ids).associateBy { it.disposal.event.id }.reportMissing(ids) }
 }

--- a/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/entity/unpaidwork/UnpaidWorkProject.kt
+++ b/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/entity/unpaidwork/UnpaidWorkProject.kt
@@ -47,7 +47,7 @@ class UpwProject(
 
     val completionDate: LocalDate?
 ) {
-    fun requireAvailabilityOnDates(dates: List<LocalDate>) {
+    fun requireAvailabilityOnDates(dates: List<LocalDate>) = apply {
         require(completionDate == null || completionDate > dates.max()) {
             "Appointment cannot be scheduled after the project completion date (${dates.max()} > $completionDate)"
         }

--- a/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/model/CreateAppointmentsRequest.kt
+++ b/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/model/CreateAppointmentsRequest.kt
@@ -1,12 +1,12 @@
 package uk.gov.justice.digital.hmpps.model
 
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid
 import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Positive
 import jakarta.validation.constraints.PositiveOrZero
 import java.time.LocalDate
 import java.time.LocalTime
-import java.time.temporal.ChronoUnit
 import java.util.*
 
 data class CreateAppointmentsRequest(
@@ -28,20 +28,22 @@ data class CreateAppointmentRequest(
     val endTime: LocalTime,
 
     // allocation
-    val supervisor: Code,
+    @Schema(description = "The appointment supervisor. Defaults to the unallocated staff member in the project team.")
+    val supervisor: Code?,
 
     // unpaid work details
     val allocationId: Long?,
     val pickUp: PickUp?,
     @field:PositiveOrZero
-    val minutesOffered: Long = ChronoUnit.MINUTES.between(startTime, endTime),
+    @Schema(description = "The minutes offered towards a person's unpaid work requirement. Defaults to the difference between the appointment startTime and endTime.")
+    val minutesOffered: Long? = null,
 
     // outcome details
     val outcome: Code?,
     @field:PositiveOrZero
-    val penaltyMinutes: Long = 0,
+    val penaltyMinutes: Long? = null,
     @field:PositiveOrZero
-    val minutesCredited: Long = 0,
+    val minutesCredited: Long? = null,
     val hiVisWorn: Boolean?,
     val workedIntensively: Boolean?,
     val workQuality: WorkQuality?,

--- a/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/model/ScheduleResponse.kt
+++ b/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/model/ScheduleResponse.kt
@@ -47,7 +47,7 @@ data class AppointmentScheduleResponse(
     val startTime: LocalTime,
     val endTime: LocalTime,
     val outcome: CodeDescription?,
-    val minutesCredited: Long?,
+    val minutesCredited: Long,
     val allocationId: Long?
 )
 
@@ -86,6 +86,6 @@ fun UnpaidWorkAppointment.toAppointmentScheduleResponse() = AppointmentScheduleR
     startTime = this.startTime,
     endTime = this.endTime,
     outcome = this.contact.outcome?.toCodeDescription(),
-    minutesCredited = this.minutesCredited,
+    minutesCredited = this.minutesCredited ?: 0,
     allocationId = this.allocation?.id
 )

--- a/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/CaseScheduleService.kt
+++ b/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/CaseScheduleService.kt
@@ -23,7 +23,7 @@ class CaseScheduleService(
     fun getSchedule(crn: String, eventNumber: String): ScheduleResponse {
         val person = personRepository.getByCrn(crn)
         val event = eventRepository.getByPersonAndEventNumber(person.id, eventNumber)
-        val upwDetailsIds = upwDetailsRepository.findByEventId(event.id).map { it.id }
+        val upwDetailsIds = upwDetailsRepository.findByEventIdIn(event.id).map { it.id }
         val requirementProgress = if (upwDetailsIds.isNotEmpty()) {
             val upwMinutesDtos = unpaidWorkAppointmentRepository.getUpwRequiredAndCompletedMinutes(upwDetailsIds)
 

--- a/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/utils/Extensions.kt
+++ b/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/utils/Extensions.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.utils
+
+object Extensions {
+    inline fun <K, reified V> Map<K, V>.reportMissing(required: Set<K>) = also {
+        val missing = required - keys
+        require(missing.isEmpty()) { "Invalid ${V::class.simpleName}: $missing" }
+    }
+}


### PR DESCRIPTION
Appointments library validation:
* Only restrict to permissible absences when the startTime is in the future

Community Payback appointment creation:
* Default to unallocated staff when no supervisor is provided
* Default minutesCredited to 0 in schedule response
* Allow null for minutesCredited and penaltyMinutes when creating an appointment