### PR TITLE
PI-3770 Ignore update messages for invalid CRNs

### DIFF
--- a/projects/esupervision-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/Person.kt
+++ b/projects/esupervision-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/Person.kt
@@ -6,7 +6,7 @@ import org.hibernate.annotations.SQLRestriction
 import org.hibernate.type.NumericBooleanConverter
 import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
-import uk.gov.justice.digital.hmpps.exception.IgnorableMessageException
+import uk.gov.justice.digital.hmpps.exception.IgnorableMessageException.Companion.orIgnore
 import java.time.LocalDate
 
 @Entity
@@ -79,14 +79,12 @@ class PersonManager(
 interface PersonManagerRepository : JpaRepository<PersonManager, Long> {
     @EntityGraph(attributePaths = ["provider", "team", "staff"])
     fun findByPersonCrn(crn: String): PersonManager?
-
     fun findByPersonCrnIn(crns: List<String>): List<PersonManager>
+    fun getByCrn(crn: String) = findByPersonCrn(crn).orIgnore { "CRN not found" }
 }
-
-fun PersonManagerRepository.getByCrn(crn: String) =
-    findByPersonCrn(crn) ?: throw IgnorableMessageException("CRN not found")
 
 interface PersonRepository : JpaRepository<Person, Long> {
     fun findByCrn(crn: String): Person?
+    fun existsByCrn(crn: String): Boolean
 }
 

--- a/projects/esupervision-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/CheckInService.kt
+++ b/projects/esupervision-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/CheckInService.kt
@@ -5,6 +5,7 @@ import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.audit.service.AuditableService
 import uk.gov.justice.digital.hmpps.audit.service.AuditedInteractionService
 import uk.gov.justice.digital.hmpps.detail.DomainEventDetailService
+import uk.gov.justice.digital.hmpps.exception.IgnorableMessageException
 import uk.gov.justice.digital.hmpps.integrations.delius.*
 import uk.gov.justice.digital.hmpps.integrations.delius.ContactType.Companion.E_SUPERVISION_CHECK_IN
 import uk.gov.justice.digital.hmpps.integrations.delius.audit.BusinessInteractionCode.ADD_CONTACT
@@ -23,6 +24,7 @@ class CheckInService(
     private val eventRepository: EventRepository,
     private val contactTypeRepository: ContactTypeRepository,
     private val contactRepository: ContactRepository,
+    private val personRepository: PersonRepository,
 ) : AuditableService(auditedInteractionService) {
     fun handle(de: HmppsDomainEvent) = audit(ADD_CONTACT) { audit ->
         val detail = de.detailUrl?.let { deDetailService.getDetail<CheckInDetail>(de) }
@@ -37,6 +39,8 @@ class CheckInService(
     }
 
     fun update(de: HmppsDomainEvent) = audit(UPDATE_CONTACT) { audit ->
+        if (!personRepository.existsByCrn(requireNotNull(de.personReference.findCrn())))
+            throw IgnorableMessageException("CRN not found")
         val detail = de.detailUrl?.let { deDetailService.getDetail<CheckInDetail>(de) }
         val uuid = requireNotNull(detail?.checkinUuid)
         val contact = contactRepository.getByExternalReference(Contact.externalReferencePrefix(de.eventType) + uuid)


### PR DESCRIPTION
To clear test messages from DLQ.  Resolves [ESUPERVISION-AND-DELIUS-6](https://ministryofjustice.sentry.io/issues/7119209799).