### PR TITLE
PI-3833 Remove alias for movement reason code

### DIFF
--- a/projects/prison-custody-status-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/prison/PrisonApiClient.kt
+++ b/projects/prison-custody-status-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/prison/PrisonApiClient.kt
@@ -87,8 +87,7 @@ data class Movement(
     val fromAgency: String?,
     val toAgency: String?,
     val movementType: String,
-    @JsonAlias("movementReasonCode")
-    val movementReason: String?,
+    val movementReasonCode: String?,
     val movementDate: LocalDate,
     val movementTime: LocalTime
 )

--- a/projects/prison-custody-status-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/Handler.kt
+++ b/projects/prison-custody-status-to-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/Handler.kt
@@ -57,7 +57,7 @@ class Handler(
                 IdentifierAdded, IdentifierUpdated, PrisonerReceived, PrisonerReleased -> {
                     val booking = prisonApiClient.bookingFromNomsId(nomsId)
                     val movement = prisonApiClient.getLatestMovement(listOf(nomsId)).firstOrNull {
-                        it.movementReason != null
+                        it.movementReasonCode != null
                     }
                     movement?.let { booking.prisonerMovement(it) }
                 }
@@ -160,7 +160,7 @@ fun Booking.prisonerMovement(movement: Movement): PrisonerMovement {
             mapOf(
                 "nomsNumber" to personReference,
                 "movementType" to movement.movementType,
-                "movementReason" to (movement.movementReason ?: ""),
+                "movementReason" to (movement.movementReasonCode ?: ""),
                 "inOutStatus" to inOutStatus!!.name,
                 "prisonId" to (agencyId ?: "")
             )
@@ -172,7 +172,7 @@ fun Booking.prisonerMovement(movement: Movement): PrisonerMovement {
             movement.fromAgency,
             movement.toAgency ?: throw IgnorableMessageException("TemporaryAbsenceNoAgency"),
             PrisonerMovement.Type.valueOf(reason),
-            requireNotNull(movement.movementReason),
+            requireNotNull(movement.movementReasonCode),
             dateTime
         )
 
@@ -181,7 +181,7 @@ fun Booking.prisonerMovement(movement: Movement): PrisonerMovement {
             movement.fromAgency ?: throw IgnorableMessageException("TemporaryAbsenceNoAgency"),
             movement.toAgency,
             PrisonerMovement.Type.valueOf(reason),
-            requireNotNull(movement.movementReason),
+            requireNotNull(movement.movementReasonCode),
             dateTime
         )
 


### PR DESCRIPTION
The response JSON contains both "movementReasonCode" and "movementReason" - so Jackson gets confused.

Resolves [PRISON-CUSTODY-STATUS-TO-DELIUS-55](https://ministryofjustice.sentry.io/issues/7247431105)