### PR TITLE
Remove deprecated appointment response field

### DIFF
--- a/projects/community-payback-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/appointments/GetAppointmentIntegrationTest.kt
+++ b/projects/community-payback-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/appointments/GetAppointmentIntegrationTest.kt
@@ -62,7 +62,6 @@ class GetAppointmentIntegrationTest @Autowired constructor(
         assertThat(response.behaviour).isEqualTo(Behaviour.EXCELLENT)
         assertThat(response.pickUpData!!.location!!.description).isEqualTo(UPWGenerator.DEFAULT_UPW_APPOINTMENT.pickUpLocation!!.description)
         assertThat(response.pickUpData!!.location!!.code).isEqualTo(UPWGenerator.DEFAULT_UPW_APPOINTMENT.pickUpLocation!!.code)
-        assertThat(response.pickUpData!!.locationCode).isEqualTo(Code(UPWGenerator.DEFAULT_UPW_APPOINTMENT.pickUpLocation!!.code))
         assertThat(response.workQuality).isEqualTo(WorkQuality.EXCELLENT)
     }
 
@@ -126,6 +125,5 @@ class GetAppointmentIntegrationTest @Autowired constructor(
                 .andReturn().response.contentAsJson<AppointmentResponse>()
 
         assertThat(response.pickUpData?.location).isNull()
-        assertThat(response.pickUpData?.locationCode).isNull()
     }
 }

--- a/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/model/AppointmentResponse.kt
+++ b/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/model/AppointmentResponse.kt
@@ -82,9 +82,6 @@ data class AppointmentResponseSupervisor(
 
 data class AppointmentResponsePickupData(
     val location: PickUpLocation?,
-    @Deprecated("this value is available from 'location'")
-    @param:Schema(deprecated = true)
-    val locationCode: Code?,
     val time: LocalTime?
 )
 

--- a/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/CommunityPaybackAppointmentsService.kt
+++ b/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/CommunityPaybackAppointmentsService.kt
@@ -75,7 +75,6 @@ class CommunityPaybackAppointmentsService(
             ),
             pickUpData = AppointmentResponsePickupData(
                 location = appointment.pickUpLocation?.toPickUpLocation(),
-                locationCode = appointment.pickUpLocation?.code?.let { Code(it) },
                 time = appointment.pickUpTime
             ),
             date = appointment.date,


### PR DESCRIPTION
This commit removes the deprecated community-payback-and-delius field `AppointmentResponsePickupData.locationCode`. The client no longer uses this field and instead resolves it from `AppointmentResponsePickupData.location.code`.