### PR TITLE
PI-3883 Fix Docker digest check

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -58,8 +58,8 @@ runs:
         cache-to: ${{ inputs.push == 'true' && format('type=gha,mode=max,scope={0}', inputs.project) || '' }}
         context: "{{defaultContext}}:projects/${{ inputs.project }}/container"
         pull: true
-        load: true
-        push: false
+        load: ${{ inputs.push != 'true' }}
+        push: ${{ inputs.push == 'true' }}
         provenance: false
         tags: |
           ghcr.io/ministryofjustice/hmpps-probation-integration-services/${{ inputs.project }}:latest


### PR DESCRIPTION
The local digest when loading into the local Docker registry no longer matches the remote digest in GHCR. I'm not sure why, but the fix is to push the latest image (if push=true), and check the remote digest before pushing the tagged version.