### PR TITLE
PI-3909 Switch to SQS listener

### DIFF
--- a/projects/common-platform-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/CourtMessageHandler.kt
+++ b/projects/common-platform-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/messaging/CourtMessageHandler.kt
@@ -1,13 +1,18 @@
 package uk.gov.justice.digital.hmpps.messaging
 
 import com.asyncapi.kotlinasyncapi.annotation.channel.Channel
+import io.awspring.cloud.sqs.annotation.SqsListener
 import io.awspring.cloud.sqs.listener.SqsHeaders
 import io.awspring.cloud.sqs.operations.SqsTemplate
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.StatusCode
+import io.opentelemetry.instrumentation.annotations.WithSpan
+import io.sentry.Sentry
+import io.sentry.spring7.tracing.SentryTransaction
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Conditional
 import org.springframework.messaging.MessageHeaders
 import org.springframework.messaging.support.MessageBuilder
-import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import tools.jackson.databind.ObjectMapper
 import uk.gov.justice.digital.hmpps.config.AwsCondition
@@ -23,14 +28,14 @@ class CourtMessageHandler(
     private val telemetryService: TelemetryService,
     private val sqsTemplate: SqsTemplate,
     private val objectMapper: ObjectMapper,
-    @Value("\${messaging.consumer.court-message-queue}") private val receiveQueue: String,
     @Value("\${messaging.consumer.queue}") private val sendQueue: String
 ) {
-    @Scheduled(fixedDelayString = "\${common-platform.queue.poller.fixed-delay:1000}")
-    fun handle() {
-        sqsTemplate.receive(receiveQueue, String::class.java).ifPresent { receivedMessage ->
-
-            val notification: Notification<CommonPlatformHearing> = converter.fromMessage(receivedMessage.payload)!!
+    @WithSpan
+    @SentryTransaction(operation = "messaging")
+    @SqsListener("\${messaging.consumer.court-message-queue}")
+    fun handle(receivedMessage: String) {
+        try {
+            val notification: Notification<CommonPlatformHearing> = converter.fromMessage(receivedMessage) ?: return
 
             telemetryService.trackEvent(
                 "CourtMessageHandlerReceived", mapOf(
@@ -62,6 +67,10 @@ class CourtMessageHandler(
                         )
                     )
                 }
+        } catch (e: Exception) {
+            Span.current().recordException(e).setStatus(StatusCode.ERROR)
+            Sentry.captureException(e)
+            throw e
         }
     }
 }

--- a/projects/common-platform-and-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/messaging/CourtMessageHandlerTest.kt
+++ b/projects/common-platform-and-delius/src/test/kotlin/uk/gov/justice/digital/hmpps/messaging/CourtMessageHandlerTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.messaging
 
-import tools.jackson.module.kotlin.jacksonTypeRef
 import io.awspring.cloud.sqs.operations.SqsTemplate
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -12,14 +11,12 @@ import org.mockito.Mockito
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.*
 import org.springframework.messaging.Message
-import org.springframework.messaging.MessageHeaders
-import org.springframework.messaging.support.MessageBuilder
+import tools.jackson.module.kotlin.jacksonTypeRef
 import uk.gov.justice.digital.hmpps.converter.NotificationConverter
 import uk.gov.justice.digital.hmpps.data.generator.MessageGenerator
 import uk.gov.justice.digital.hmpps.message.Notification
 import uk.gov.justice.digital.hmpps.telemetry.TelemetryService
 import uk.gov.justice.digital.hmpps.test.MockMvcExtensions.objectMapper
-import java.util.*
 
 @ExtendWith(MockitoExtension::class)
 internal class CourtMessageHandlerTest {
@@ -41,7 +38,6 @@ internal class CourtMessageHandlerTest {
             telemetryService,
             sqsTemplate,
             objectMapper,
-            "receive-queue",
             "send-queue"
         )
     }
@@ -49,18 +45,10 @@ internal class CourtMessageHandlerTest {
     @Test
     fun `message with multiple defendants is split into multiple messages`() {
         val notification = Notification(message = MessageGenerator.COMMON_PLATFORM_EVENT_MULTIPLE_DEFENDANTS)
-        val incomingMessage = Optional.of(
-            MessageBuilder.createMessage(
-                objectMapper.writeValueAsString(notification),
-                MessageHeaders(mapOf())
-            )
-        )
 
-        whenever(sqsTemplate.receive(any<String>(), any<Class<String>>()))
-            .thenReturn(incomingMessage)
         whenever(converter.fromMessage(any())).thenReturn(notification)
 
-        handler.handle()
+        handler.handle(objectMapper.writeValueAsString(notification))
 
         verify(sqsTemplate, Mockito.times(2)).send(any(), any<Message<String>>())
     }
@@ -68,18 +56,10 @@ internal class CourtMessageHandlerTest {
     @Test
     fun `message with multiple defendants output only contains single defendant`() {
         val notification = Notification(message = MessageGenerator.COMMON_PLATFORM_EVENT_MULTIPLE_DEFENDANTS)
-        val incomingMessage = Optional.of(
-            MessageBuilder.createMessage(
-                objectMapper.writeValueAsString(notification),
-                MessageHeaders(mapOf())
-            )
-        )
 
-        whenever(sqsTemplate.receive(any<String>(), any<Class<String>>()))
-            .thenReturn(incomingMessage)
         whenever(converter.fromMessage(any())).thenReturn(notification)
 
-        handler.handle()
+        handler.handle(objectMapper.writeValueAsString(notification))
 
         val captor = argumentCaptor<Message<String>>()
         verify(sqsTemplate, times(2)).send(eq("send-queue"), captor.capture())


### PR DESCRIPTION
DLQ was not working before because the SQSTemplate defaults to immediately acknowledging messages, so failures were not fed back to the queue.

Telemetry was not working before because there was no span wrapping the function.