### PR TITLE
FM-354 AP & Delius - Add support for personal contacts in probation case entities.

### DIFF
--- a/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/DataLoader.kt
+++ b/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/DataLoader.kt
@@ -27,6 +27,9 @@ class DataLoader(
         save(ReferenceDataGenerator.MC05)
         saveAll(ReferenceDataGenerator.REGISTER_TYPES.values)
         save(ReferenceDataGenerator.NSI_INITIAL_ALLOCATION)
+        save(AddressGenerator.DEFAULT_ADDRESS_ENTITY)
+        save(ReferenceDataGenerator.DOCTOR_RELATIONSHIP)
+        save(PersonalContactGenerator.CASE_COMPLEX_DOCTOR)
 
         saveAll(AddressGenerator.ALL_ADDRESSES)
         save(ProbationCaseGenerator.BOROUGH)

--- a/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/entity/Entities.kt
+++ b/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/entity/Entities.kt
@@ -74,9 +74,6 @@ class Nsi(@Id @Column(name = "nsi_id") val id: Long, @Column(name = "event_id") 
 @Table(name = "personal_circumstance")
 class PersonalCircumstance(@Id @Column(name = "personal_circumstance_id") val id: Long, val startDate: LocalDate)
 
-@Entity
-class PersonalContact(@Id val personalContactId: Long, val relationshipTypeId: Long, val relationship: String)
-
 @Entity(name = "ReferralEntity")
 @Table(name = "referral")
 class Referral(@Id val referralId: Long, val referralTypeId: Long, val referralDate: LocalDate, val eventId: Long)

--- a/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/AddressGenerator.kt
+++ b/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/AddressGenerator.kt
@@ -3,10 +3,35 @@ package uk.gov.justice.digital.hmpps.data.generator
 import uk.gov.justice.digital.hmpps.data.generator.IdGenerator.id
 import uk.gov.justice.digital.hmpps.integrations.delius.approvedpremises.entity.Address
 import uk.gov.justice.digital.hmpps.integrations.delius.person.address.PersonAddress
+import uk.gov.justice.digital.hmpps.integrations.delius.person.contact.AddressEntity
 import uk.gov.justice.digital.hmpps.integrations.delius.referencedata.ReferenceData
 import java.time.LocalDate
 
 object AddressGenerator {
+    val DEFAULT_ADDRESS_ENTITY =
+        generateAddressEntity("", "1", "Promise Street", "", "Make Believe", "", "MB01 1PS", "01234567890")
+
+    fun generateAddressEntity(
+        buildingName: String? = null,
+        addressNumber: String? = null,
+        streetName: String? = null,
+        district: String? = null,
+        town: String? = null,
+        county: String? = null,
+        postcode: String? = null,
+        telephoneNumber: String? = null,
+        id: Long = IdGenerator.getAndIncrement()
+    ) = AddressEntity(
+        id,
+        buildingName,
+        addressNumber,
+        streetName,
+        district,
+        town,
+        county,
+        postcode,
+        telephoneNumber
+    )
 
     var PERSON_ADDRESS = generatePersonAddress(
         addressNumber = "12",

--- a/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/PersonalContactGenerator.kt
+++ b/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/PersonalContactGenerator.kt
@@ -1,0 +1,23 @@
+package uk.gov.justice.digital.hmpps.data.generator
+
+import uk.gov.justice.digital.hmpps.integrations.delius.person.ProbationCase
+import uk.gov.justice.digital.hmpps.integrations.delius.person.contact.PersonalContactEntity
+import java.time.LocalDate
+
+object PersonalContactGenerator {
+
+    val CASE_COMPLEX_DOCTOR = generate(ProbationCaseGenerator.CASE_COMPLEX)
+
+    fun generate(case: ProbationCase) = PersonalContactEntity(
+        IdGenerator.getAndIncrement(),
+        case,
+        "Captains mate",
+        ReferenceDataGenerator.DOCTOR_RELATIONSHIP,
+        "Shiver",
+        "Me",
+        "Timbers",
+        "0779999887",
+        AddressGenerator.DEFAULT_ADDRESS_ENTITY,
+        LocalDate.now()
+    )
+}

--- a/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/ProbationCaseGenerator.kt
+++ b/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/ProbationCaseGenerator.kt
@@ -4,6 +4,7 @@ import uk.gov.justice.digital.hmpps.data.generator.ProbationCaseGenerator.COM_PR
 import uk.gov.justice.digital.hmpps.data.generator.ProbationCaseGenerator.COM_TEAM
 import uk.gov.justice.digital.hmpps.data.generator.ProbationCaseGenerator.COM_UNALLOCATED
 import uk.gov.justice.digital.hmpps.integrations.delius.person.*
+import uk.gov.justice.digital.hmpps.integrations.delius.person.contact.PersonalContactEntity
 import uk.gov.justice.digital.hmpps.integrations.delius.referencedata.ReferenceData
 import uk.gov.justice.digital.hmpps.integrations.delius.team.Team
 import java.time.LocalDate
@@ -151,7 +152,8 @@ object ProbationCaseGenerator {
         currentExclusion: Boolean = false,
         currentRestriction: Boolean = false,
         softDeleted: Boolean = false,
-        id: Long = IdGenerator.getAndIncrement()
+        id: Long = IdGenerator.getAndIncrement(),
+        contacts: List<PersonalContactEntity> = emptyList()
     ) = ProbationCase(
         crn,
         nomsId,
@@ -171,7 +173,8 @@ object ProbationCaseGenerator {
         currentRestriction,
         listOf(),
         softDeleted,
-        id
+        id,
+        contacts
     )
 
     fun generateBorough(code: String, description: String) = Borough(IdGenerator.getAndIncrement(), code, description)

--- a/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/ReferenceDataGenerator.kt
+++ b/projects/approved-premises-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/ReferenceDataGenerator.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.data.generator.DatasetGenerator.HOSTEL_CODE
 import uk.gov.justice.digital.hmpps.data.generator.DatasetGenerator.NATIONALITY
 import uk.gov.justice.digital.hmpps.data.generator.DatasetGenerator.REGISTER_CATEGORY
 import uk.gov.justice.digital.hmpps.data.generator.DatasetGenerator.REGISTER_LEVEL
+import uk.gov.justice.digital.hmpps.data.generator.DatasetGenerator.RELATIONSHIP
 import uk.gov.justice.digital.hmpps.data.generator.DatasetGenerator.RELIGION
 import uk.gov.justice.digital.hmpps.integrations.delius.approvedpremises.referral.entity.MoveOnCategory
 import uk.gov.justice.digital.hmpps.integrations.delius.approvedpremises.referral.entity.ReferralSource
@@ -100,6 +101,7 @@ object ReferenceDataGenerator {
     val NON_MAPPA_CATEGORY = generate("RC07", REGISTER_CATEGORY.id, "Other category")
 
     val NSI_INITIAL_ALLOCATION = generate("IN1", ALL_DATASETS[DatasetCode.NM_ALLOCATION_REASON]!!.id)
+    val DOCTOR_RELATIONSHIP = generate("DOC", RELATIONSHIP.id, "Doctor")
 
     fun generate(
         code: String,
@@ -172,5 +174,6 @@ object DatasetGenerator {
     val RELIGION = ALL_DATASETS[DatasetCode.RELIGION]!!
     val REGISTER_CATEGORY = ALL_DATASETS[DatasetCode.REGISTER_CATEGORY]!!
     val REGISTER_LEVEL = ALL_DATASETS[DatasetCode.REGISTER_LEVEL]!!
+    val RELATIONSHIP = ALL_DATASETS[DatasetCode.RELATIONSHIP]!!
     fun all() = ALL_DATASETS.values
 }

--- a/projects/approved-premises-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/ProbationCaseIntegrationTest.kt
+++ b/projects/approved-premises-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/ProbationCaseIntegrationTest.kt
@@ -15,6 +15,7 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDO
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
+import uk.gov.justice.digital.hmpps.data.generator.PersonalContactGenerator
 import uk.gov.justice.digital.hmpps.data.generator.ProbationCaseGenerator
 import uk.gov.justice.digital.hmpps.data.generator.ProbationCaseGenerator.COM_TEAM
 import uk.gov.justice.digital.hmpps.model.*
@@ -83,6 +84,7 @@ class ProbationCaseIntegrationTest(
     @Test
     fun `case details are correctly returned`() {
         val case = ProbationCaseGenerator.CASE_COMPLEX
+        PersonalContactGenerator.generate(case = case)
         val detail = mockMvc.get("/probation-cases/${case.crn}/details")
         { withToken() }
             .andExpect { status { isOk() } }
@@ -141,5 +143,23 @@ class ProbationCaseIntegrationTest(
         assertThat(sentence.startDate, equalTo(LocalDate.parse("2024-12-12")))
         assertThat(sentence.endDate, equalTo(LocalDate.parse("2025-10-20")))
         assertThat(sentence.eventNumber, equalTo("1"))
+        assertThat(detail.personalContacts, hasSize(1))
+        detail.personalContacts!!.first().let { contact ->
+            assertThat(contact.name.forename, equalTo("Shiver"))
+            assertThat(contact.name.middleNames.first(), equalTo("Me"))
+            assertThat(contact.name.surname, equalTo("Timbers"))
+            assertThat(contact.telephoneNumber, equalTo("01234567890"))
+            assertThat(contact.mobileNumber, equalTo("0779999887"))
+            assertThat(contact.address!!.buildingName, equalTo(null))
+            assertThat(contact.address!!.addressNumber, equalTo("1"))
+            assertThat(contact.address!!.streetName, equalTo("Promise Street"))
+            assertThat(contact.address!!.district, equalTo(null))
+            assertThat(contact.address!!.town, equalTo("Make Believe"))
+            assertThat(contact.address!!.county, equalTo(null))
+            assertThat(contact.address!!.postcode, equalTo("MB01 1PS"))
+            assertThat(contact.relationship, equalTo("Captains mate"))
+            assertThat(contact.relationshipType.code, equalTo("DOC"))
+            assertThat(contact.relationshipType.description, equalTo("Doctor"))
+        }
     }
 }

--- a/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/person/ProbationCase.kt
+++ b/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/person/ProbationCase.kt
@@ -6,6 +6,7 @@ import org.hibernate.annotations.SQLRestriction
 import org.hibernate.type.NumericBooleanConverter
 import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
+import uk.gov.justice.digital.hmpps.integrations.delius.person.contact.PersonalContactEntity
 import uk.gov.justice.digital.hmpps.integrations.delius.referencedata.ReferenceData
 import java.time.LocalDate
 
@@ -78,7 +79,10 @@ class ProbationCase(
 
     @Id
     @Column(name = "offender_id")
-    val id: Long
+    val id: Long,
+
+    @OneToMany(mappedBy = "case")
+    val personalContacts: List<PersonalContactEntity>,
 ) {
     fun currentManager() = communityManagers.first()
 }

--- a/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/person/contact/AddressEntity.kt
+++ b/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/person/contact/AddressEntity.kt
@@ -1,0 +1,28 @@
+package uk.gov.justice.digital.hmpps.integrations.delius.person.contact
+
+import jakarta.persistence.*
+import org.hibernate.annotations.Immutable
+import org.hibernate.annotations.SQLRestriction
+import org.hibernate.type.NumericBooleanConverter
+
+@Immutable
+@Entity
+@Table(name = "address")
+@SQLRestriction("soft_deleted = 0")
+class AddressEntity(
+    @Id
+    @Column(name = "address_id")
+    val id: Long,
+    val buildingName: String?,
+    val addressNumber: String?,
+    val streetName: String?,
+    val district: String?,
+    @Column(name = "town_city")
+    val town: String?,
+    val county: String?,
+    val postcode: String?,
+    val telephoneNumber: String?,
+    @Column(updatable = false, columnDefinition = "number")
+    @Convert(converter = NumericBooleanConverter::class)
+    val softDeleted: Boolean = false
+)

--- a/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/person/contact/CasePersonalContactEntity.kt
+++ b/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/person/contact/CasePersonalContactEntity.kt
@@ -1,0 +1,62 @@
+package uk.gov.justice.digital.hmpps.integrations.delius.person.contact
+
+import jakarta.persistence.Column
+import jakarta.persistence.Convert
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import org.hibernate.annotations.Immutable
+import org.hibernate.annotations.SQLRestriction
+import org.hibernate.type.NumericBooleanConverter
+import uk.gov.justice.digital.hmpps.integrations.delius.person.ProbationCase
+import uk.gov.justice.digital.hmpps.integrations.delius.referencedata.ReferenceData
+import java.time.LocalDate
+
+@Entity
+@Immutable
+@Table(name = "personal_contact")
+@SQLRestriction("soft_deleted = 0 and (end_date is null or end_date > current_date)")
+class PersonalContactEntity(
+    @Id
+    @Column(name = "personal_contact_id")
+    val id: Long = 0,
+
+    @ManyToOne
+    @JoinColumn(name = "offender_id")
+    val case: ProbationCase,
+
+    @Column(name = "relationship")
+    val relationship: String,
+
+    @ManyToOne
+    @JoinColumn(name = "relationship_type_id")
+    val relationshipType: ReferenceData,
+
+    @Column(name = "first_name")
+    val forename: String,
+
+    @Column(name = "other_names")
+    val middleName: String?,
+
+    @Column(name = "surname")
+    val surname: String,
+
+    @Column(name = "mobile_number")
+    val mobileNumber: String?,
+
+    @ManyToOne
+    @JoinColumn(name = "address_id")
+    val address: AddressEntity?,
+
+    @Column(name = "start_date")
+    val startDate: LocalDate? = null,
+
+    @Column(name = "end_date")
+    val endDate: LocalDate? = null,
+
+    @Column(updatable = false, columnDefinition = "number")
+    @Convert(converter = NumericBooleanConverter::class)
+    val softDeleted: Boolean = false
+)

--- a/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/referencedata/ReferenceData.kt
+++ b/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/referencedata/ReferenceData.kt
@@ -62,6 +62,7 @@ enum class DatasetCode(val value: String) {
     SOURCE_TYPE("SOURCE TYPE"),
     STAFF_GRADE("OFFICER GRADE"),
     YES_NO("YES NO DONT KNOW"),
+    RELATIONSHIP("RELATIONSHIP"),
     REGISTER_TYPE_FLAG("REGISTER TYPE FLAG");
 
     companion object {

--- a/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/model/CaseDetail.kt
+++ b/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/model/CaseDetail.kt
@@ -25,7 +25,32 @@ data class CaseDetail(
     val mappaDetail: MappaDetail?,
     val careLeaver: Boolean,
     val veteran: Boolean,
-    val sentences: List<Sentence>
+    val sentences: List<Sentence>,
+    val personalContacts: List<PersonalContact>? = listOf(),
+)
+
+data class PersonalContact(
+    val relationship: String,
+    val relationshipType: RelationshipType,
+    val name: Name,
+    val telephoneNumber: String?,
+    val mobileNumber: String?,
+    val address: Address?
+)
+
+data class RelationshipType(
+    val code: String,
+    val description: String
+)
+
+data class Address(
+    val buildingName: String?,
+    val addressNumber: String?,
+    val streetName: String?,
+    val district: String?,
+    val town: String?,
+    val county: String?,
+    val postcode: String?
 )
 
 data class Name(val forename: String, val surname: String, val middleNames: List<String>)

--- a/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/CaseService.kt
+++ b/projects/approved-premises-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/CaseService.kt
@@ -2,10 +2,12 @@ package uk.gov.justice.digital.hmpps.service
 
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.exception.NotFoundException
+import uk.gov.justice.digital.hmpps.integrations.delius.contact.ContactRepository
 import uk.gov.justice.digital.hmpps.integrations.delius.entity.DisposalRepository
 import uk.gov.justice.digital.hmpps.integrations.delius.person.CommunityManager
 import uk.gov.justice.digital.hmpps.integrations.delius.person.ProbationCase
 import uk.gov.justice.digital.hmpps.integrations.delius.person.ProbationCaseRepository
+import uk.gov.justice.digital.hmpps.integrations.delius.person.contact.PersonalContactEntity
 import uk.gov.justice.digital.hmpps.integrations.delius.person.offence.entity.CaseOffence
 import uk.gov.justice.digital.hmpps.integrations.delius.person.offence.entity.MainOffenceRepository
 import uk.gov.justice.digital.hmpps.integrations.delius.person.registration.entity.*
@@ -21,6 +23,7 @@ class CaseService(
     private val offenceRepository: MainOffenceRepository,
     private val personalCircumstanceRepository: PersonalCircumstanceRepository,
     private val disposalRepository: DisposalRepository,
+    private val contactRepository: ContactRepository,
 ) {
     fun getCaseSummaries(ids: List<String>): CaseSummaries =
         CaseSummaries(probationCaseRepository.findByCrnInOrNomsIdIn(ids).map { it.summary() })
@@ -39,7 +42,13 @@ class CaseService(
                 eventNumber = disposal.event.number
             )
         }
-        return person.summary().withDetail(offences, registrations, circumstances.map { it.type.code }, sentences)
+        return person.summary().withDetail(
+            offences,
+            registrations,
+            circumstances.map { it.type.code },
+            sentences,
+            person.personalContacts
+        )
     }
 }
 
@@ -60,9 +69,31 @@ fun CaseSummary.withDetail(
     offences: List<CaseOffence>,
     registrations: List<Registration>,
     circumstances: List<String>,
-    sentences: List<Sentence>
+    sentences: List<Sentence>,
+    contacts: List<PersonalContactEntity>
 ): CaseDetail {
     val regMap = registrations.groupBy { it.type.code == RegisterType.Code.MAPPA.value }
+    val personalContacts = contacts.map {
+        PersonalContact(
+            relationship = it.relationship,
+            relationshipType = RelationshipType(it.relationshipType.code, it.relationshipType.description),
+            name = Name(it.forename, it.surname, listOf(it.middleName as String)),
+            mobileNumber = it.mobileNumber,
+            telephoneNumber = it.address?.telephoneNumber,
+            address = it.address?.let { address ->
+                Address(
+                    buildingName = address.buildingName,
+                    addressNumber = address.addressNumber,
+                    streetName = address.streetName,
+                    district = address.district,
+                    town = address.town,
+                    county = address.county,
+                    postcode = address.postcode
+                )
+            }
+        )
+    }
+
     return CaseDetail(
         this,
         offences.map { it.asOffence() },
@@ -70,7 +101,8 @@ fun CaseSummary.withDetail(
         regMap.mappa(),
         circumstances.isCareLeaver(),
         circumstances.isVeteran(),
-        sentences
+        sentences,
+        personalContacts
     )
 }
 


### PR DESCRIPTION
**Summary**

This Pull Request introduces changes to enhance the handling of personal contact information for probation cases in the application. It adds entities and structures to support data persistence and retrieval of personal contact details.

The implementation is based on similar personal contact logic in the 'unpaid-work-and-delius' project: 
https://github.com/ministryofjustice/hmpps-probation-integration-services/blob/ea14f7928cd3963ae17a676feb80b2ee2a0fbc1d/projects/unpaid-work-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/controller/casedetails/entity/CasePersonalContactEntity.kt#L18

**Main Changes:**

Modification of `ProbationCase`:

- Added a new field, `personalContacts`, to store related personal contact entities.

Addition of New Entities:

- `AddressEntity`: Represents address information.
- `PersonalContactEntity`: Represents personal contact details linked to a probation case.

Enhancement of `CaseDetail`:

- Introduced a new `personalContacts` field to include detailed contact information in the case details.
- Defined supporting classes for structured handling of contact, address, and relationship details.

Changes to `CaseService`:

- Updated methods to handle retrieval and mapping of personal contact data into case summaries and details.
- These changes aim to extend functionality by including personal contact management while preserving existing structures
