### PR TITLE
PI-3964 Bump Spring Boot to 4.0.4

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
     kotlin("jvm") version "2.3.20"
     kotlin("plugin.noarg") version "2.3.20" apply false
     kotlin("plugin.spring") version "2.3.20" apply false
-    id("org.springframework.boot") version "4.0.3" apply false
+    id("org.springframework.boot") version "4.0.4" apply false
     id("io.spring.dependency-management") version "1.1.7" apply false
     id("com.gorylenko.gradle-git-properties") version "2.5.7" apply false
     id("com.google.cloud.tools.jib") apply false


### PR DESCRIPTION
This includes Jackson 3.1.0 which resolves GHSA-72hv-8253-57qq