### PR TITLE
PI-3997 Increase retries when patching ingress

### DIFF
--- a/.github/workflows/readonly.yml
+++ b/.github/workflows/readonly.yml
@@ -127,7 +127,7 @@ jobs:
       - name: ${{ inputs.action == 'enable' && 'Block' || 'Unblock' }} ingresses
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
-          max_attempts: 3 # Patching ingresses intermittently fails on MOJ Cloud Platform, so we retry this step
+          max_attempts: 10 # Patching ingresses intermittently fails on MOJ Cloud Platform, so we retry this step
           timeout_minutes: 15
           command: |
             ingress=$(kubectl get ingress -o jsonpath='{.items[*].metadata.name}' -l 'app=${{ matrix.project }}')
@@ -156,7 +156,7 @@ jobs:
         if: inputs.action == 'enable' && matrix.project != 'hmpps-auth-and-delius' && matrix.project != 'probation-search-and-delius' # Note: hmpps-auth is excluded here to continue allowing 'POST /authenticate' requests, which are read-only
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
-          max_attempts: 3 # Patching ingresses intermittently fails on MOJ Cloud Platform, so we retry this step
+          max_attempts: 10 # Patching ingresses intermittently fails on MOJ Cloud Platform, so we retry this step
           timeout_minutes: 15
           command: |
             ingress=$(kubectl get ingress -o jsonpath='{.items[*].metadata.name}' -l 'app=${{ matrix.project }}')
@@ -178,7 +178,7 @@ jobs:
         if: inputs.action == 'disable' && matrix.project != 'hmpps-auth-and-delius' && matrix.project != 'probation-search-and-delius'
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
-          max_attempts: 3 # Patching ingresses intermittently fails on MOJ Cloud Platform, so we retry this step
+          max_attempts: 10 # Patching ingresses intermittently fails on MOJ Cloud Platform, so we retry this step
           timeout_minutes: 15
           command: |
             ingress=$(kubectl get ingress -o jsonpath='{.items[*].metadata.name}' -l 'app=${{ matrix.project }}')
@@ -260,6 +260,7 @@ jobs:
           - topic-pi-community-payback-upw
           - hmpps_accredited_programmes_manage_and_deliver_devs
           - topic-pi-manage-people-on-probation
+          - topic-pi-manage-my-community-sentence
     steps:
       - name: Send message to Slack
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1


### PR DESCRIPTION
The new ingress controller appears to hit the 10-second timeout more often than before when patching ingresses for multiple projects at once.

Also, adds notification for topic-pi-manage-my-community-sentence channel, as per https://mojdt.slack.com/archives/C0AFGL8AE0Y/p1774952621055669?thread_ts=1774952260.631539&cid=C0AFGL8AE0Y