### PR TITLE
CPB-825 Add community payback update appointment endpoint

### DIFF
--- a/projects/community-payback-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/appointments/UpdateAppointmentIntegrationTest.kt
+++ b/projects/community-payback-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/appointments/UpdateAppointmentIntegrationTest.kt
@@ -45,7 +45,7 @@ class UpdateAppointmentIntegrationTest @Autowired constructor(
     @Test
     fun `404 if appointment id is invalid`() {
         mockMvc
-            .put("/projects/$PROJECT/appointments/9999/outcome") {
+            .put("/projects/$PROJECT/appointments/9999") {
                 withToken()
                 json = TestData.updateAppointment(9999)
             }
@@ -60,7 +60,7 @@ class UpdateAppointmentIntegrationTest @Autowired constructor(
         val original = unpaidWorkAppointmentRepository.getAppointment(UPWGenerator.UPW_APPOINTMENT_TO_UPDATE[0].id)
 
         mockMvc
-            .put("/projects/$PROJECT/appointments/${original.id}/outcome") {
+            .put("/projects/$PROJECT/appointments/${original.id}") {
                 withToken()
                 json = TestData.updateAppointment(original.id).copy(
                     version = UUID(original.rowVersion + 1, original.contact.rowVersion + 1)
@@ -79,7 +79,7 @@ class UpdateAppointmentIntegrationTest @Autowired constructor(
     fun `can update appointment outcome`() {
         val original = unpaidWorkAppointmentRepository.getAppointment(UPWGenerator.UPW_APPOINTMENT_TO_UPDATE[1].id)
 
-        mockMvc.put("/projects/$PROJECT/appointments/${original.id}/outcome") {
+        mockMvc.put("/projects/$PROJECT/appointments/${original.id}") {
             withToken()
             json = TestData.updateAppointment(original.id)
         }.andExpect { status { isOk() } }
@@ -109,7 +109,7 @@ class UpdateAppointmentIntegrationTest @Autowired constructor(
             it.event?.id == originalContact.event!!.id && it.contactType.code == REVIEW_ENFORCEMENT_STATUS.value
         })
 
-        mockMvc.put("/projects/$PROJECT/appointments/${original.id}/outcome") {
+        mockMvc.put("/projects/$PROJECT/appointments/${original.id}") {
             withToken()
             json = TestData.updateAppointment(original.id).copy(outcome = Code("F"))
         }.andExpect { status { is2xxSuccessful() } }
@@ -127,7 +127,7 @@ class UpdateAppointmentIntegrationTest @Autowired constructor(
     fun `enforcement created when complied is false`() {
         val original = unpaidWorkAppointmentRepository.getAppointment(UPWGenerator.UPW_APPOINTMENT_TO_UPDATE[2].id)
 
-        mockMvc.put("/projects/$PROJECT/appointments/${original.id}/outcome") {
+        mockMvc.put("/projects/$PROJECT/appointments/${original.id}") {
             withToken()
             json = TestData.updateAppointment(original.id).copy(outcome = Code("F"))
         }.andExpect { status { is2xxSuccessful() } }
@@ -140,7 +140,7 @@ class UpdateAppointmentIntegrationTest @Autowired constructor(
     fun `contact alert created when alertActive is true`() {
         val original = unpaidWorkAppointmentRepository.getAppointment(UPWGenerator.UPW_APPOINTMENT_TO_UPDATE[3].id)
 
-        mockMvc.put("/projects/$PROJECT/appointments/${original.id}/outcome") {
+        mockMvc.put("/projects/$PROJECT/appointments/${original.id}") {
             withToken()
             json = TestData.updateAppointment(original.id).copy(alertActive = true)
         }.andExpect { status { is2xxSuccessful() } }
@@ -152,7 +152,7 @@ class UpdateAppointmentIntegrationTest @Autowired constructor(
     fun `contact alert deleted when alertActive is false`() {
         val original = unpaidWorkAppointmentRepository.getAppointment(UPWGenerator.UPW_APPOINTMENT_TO_UPDATE[4].id)
 
-        mockMvc.put("/projects/$PROJECT/appointments/${original.id}/outcome") {
+        mockMvc.put("/projects/$PROJECT/appointments/${original.id}") {
             withToken()
             json = TestData.updateAppointment(original.id).copy(alertActive = true)
         }.andExpect { status { is2xxSuccessful() } }
@@ -161,7 +161,7 @@ class UpdateAppointmentIntegrationTest @Autowired constructor(
 
         val second = unpaidWorkAppointmentRepository.getAppointment(original.id)
 
-        mockMvc.put("/projects/$PROJECT/appointments/${second.id}/outcome") {
+        mockMvc.put("/projects/$PROJECT/appointments/${second.id}") {
             withToken()
             json = TestData.updateAppointment(original.id).copy(
                 version = UUID(second.rowVersion, second.contact.rowVersion),

--- a/projects/community-payback-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/test/TestData.kt
+++ b/projects/community-payback-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/test/TestData.kt
@@ -95,7 +95,7 @@ object TestData {
         notes = "testing"
     )
 
-    fun updateAppointment(id: Long) = AppointmentOutcomeRequest(
+    fun updateAppointment(id: Long) = UpdateAppointmentRequest(
         version = UUID(1, 1),
         date = LocalDate.now(),
         startTime = LocalTime.of(LocalTime.now().minusHours(1).hour, 0),

--- a/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/controller/ProjectsController.kt
+++ b/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/controller/ProjectsController.kt
@@ -1,10 +1,14 @@
 package uk.gov.justice.digital.hmpps.controller
 
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
 import jakarta.validation.Valid
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
-import uk.gov.justice.digital.hmpps.model.AppointmentOutcomeRequest
+import uk.gov.justice.digital.hmpps.model.UpdateAppointmentRequest
 import uk.gov.justice.digital.hmpps.model.CreateAppointmentsRequest
 import uk.gov.justice.digital.hmpps.service.CommunityPaybackAppointmentsService
 import uk.gov.justice.digital.hmpps.service.ProjectService
@@ -35,12 +39,23 @@ class ProjectsController(
         @RequestParam username: String
     ) = communityPaybackAppointmentsService.getSession(projectCode, date, username)
 
+    @PutMapping(value = ["/{projectCode}/appointments/{appointmentId}"])
+    fun updateAppointment(
+        @PathVariable projectCode: String,
+        @PathVariable appointmentId: Long,
+        @RequestBody appointmentOutcome: UpdateAppointmentRequest
+    ) = communityPaybackAppointmentsService.updateAppointment(projectCode, appointmentId, appointmentOutcome)
+
+    @Operation(
+        deprecated = true,
+        description = "Deprecated, should instead use PUT /projects/{projectCode}/appointments/{appointmentId}",
+    )
     @PutMapping(value = ["/{projectCode}/appointments/{appointmentId}/outcome"])
     fun updateAppointmentOutcome(
         @PathVariable projectCode: String,
         @PathVariable appointmentId: Long,
-        @RequestBody appointmentOutcome: AppointmentOutcomeRequest
-    ) = communityPaybackAppointmentsService.updateAppointmentOutcome(projectCode, appointmentId, appointmentOutcome)
+        @RequestBody appointmentOutcome: UpdateAppointmentRequest
+    ) = communityPaybackAppointmentsService.updateAppointment(projectCode, appointmentId, appointmentOutcome)
 
     @PostMapping(value = ["/{projectCode}/appointments"])
     fun createAppointments(

--- a/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/model/UpdateAppointmentRequest.kt
+++ b/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/model/UpdateAppointmentRequest.kt
@@ -4,7 +4,7 @@ import java.time.LocalDate
 import java.time.LocalTime
 import java.util.*
 
-data class AppointmentOutcomeRequest(
+data class UpdateAppointmentRequest(
     val version: UUID,
     val outcome: Code?,
     val supervisor: Code,

--- a/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/CommunityPaybackAppointmentsService.kt
+++ b/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/CommunityPaybackAppointmentsService.kt
@@ -287,10 +287,10 @@ class CommunityPaybackAppointmentsService(
     }
 
     @Transactional
-    fun updateAppointmentOutcome(
+    fun updateAppointment(
         projectCode: String,
         appointmentId: Long,
-        request: AppointmentOutcomeRequest
+        request: UpdateAppointmentRequest
     ) {
         val unpaidWorkAppointment = unpaidWorkAppointmentRepository.getAppointment(appointmentId)
         unpaidWorkAppointment.validateVersion(request.version.mostSignificantBits)


### PR DESCRIPTION
This replaces the now deprecated ‘update appointment outcome’ endpoint.