### PR TITLE
CPB-825 Remove CP Update Appointment Outcome Endpoint

### DIFF
--- a/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/controller/ProjectsController.kt
+++ b/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/controller/ProjectsController.kt
@@ -46,17 +46,6 @@ class ProjectsController(
         @RequestBody appointmentOutcome: UpdateAppointmentRequest
     ) = communityPaybackAppointmentsService.updateAppointment(projectCode, appointmentId, appointmentOutcome)
 
-    @Operation(
-        deprecated = true,
-        description = "Deprecated, should instead use PUT /projects/{projectCode}/appointments/{appointmentId}",
-    )
-    @PutMapping(value = ["/{projectCode}/appointments/{appointmentId}/outcome"])
-    fun updateAppointmentOutcome(
-        @PathVariable projectCode: String,
-        @PathVariable appointmentId: Long,
-        @RequestBody appointmentOutcome: UpdateAppointmentRequest
-    ) = communityPaybackAppointmentsService.updateAppointment(projectCode, appointmentId, appointmentOutcome)
-
     @PostMapping(value = ["/{projectCode}/appointments"])
     fun createAppointments(
         @PathVariable projectCode: String,


### PR DESCRIPTION
This has been superceeded by the appointment update endpoint (PUT), which is now in use by all clients