### PR TITLE
PI-4030 Update appointment search

### DIFF
--- a/libs/dev-tools/src/main/kotlin/uk/gov/justice/digital/hmpps/test/MockMvcExtensions.kt
+++ b/libs/dev-tools/src/main/kotlin/uk/gov/justice/digital/hmpps/test/MockMvcExtensions.kt
@@ -1,11 +1,13 @@
 package uk.gov.justice.digital.hmpps.test
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import org.hamcrest.Matchers.equalTo
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.test.json.JsonCompareMode
 import org.springframework.test.web.servlet.MockHttpServletRequestDsl
+import org.springframework.test.web.servlet.MockMvcResultMatchersDsl
 import org.springframework.test.web.servlet.ResultActions
 import org.springframework.test.web.servlet.ResultActionsDsl
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder
@@ -65,4 +67,6 @@ object MockMvcExtensions {
             )
         }
     }
+
+    fun <T : Any> MockMvcResultMatchersDsl.jsonPath(expression: String, value: T) = jsonPath(expression, equalTo(value))
 }

--- a/projects/accredited-programmes-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/DataLoader.kt
+++ b/projects/accredited-programmes-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/DataLoader.kt
@@ -65,6 +65,7 @@ class DataLoader(dataManager: DataManager) : BaseDataLoader(dataManager) {
         save(TestData.TWO_THIRDS_CONTACT_TYPE)
         save(TestData.OTHER_CONTACT_TYPE)
         save(TestData.APPOINTMENT_CONTACT_TYPE)
+        save(TestData.IAPS_APPOINTMENT_CONTACT_TYPE)
         save(TestData.THREE_WAY_MEETING_TYPE)
         save(TestData.REFER_TO_MANAGER_CONTACT_TYPE)
         save(TestData.ENFORCEMENT_REVIEW_CONTACT_TYPE)
@@ -106,6 +107,7 @@ class DataLoader(dataManager: DataManager) : BaseDataLoader(dataManager) {
         save(TestData.TWO_THIRDS_CONTACT)
         save(TestData.OTHER_CONTACT)
         save(TestData.TERMINATION_CONTACT)
+        save(TestData.LEGACY_APPOINTMENT)
         saveAll(TestData.APPOINTMENTS)
     }
 }

--- a/projects/accredited-programmes-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/TestData.kt
+++ b/projects/accredited-programmes-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/TestData.kt
@@ -86,24 +86,28 @@ object TestData {
     val TERMINATION_COMMUNITY_SENTENCE =
         DisposalGenerator.generate(TERMINATION_COMMUNITY_EVENT, COMMUNITY_ORDER_TYPE, 6, MONTHS)
 
-    val TWO_THIRDS_CONTACT_TYPE = ContactType(id(), ContactType.SUPERVISION_TWO_THIRDS_POINT, false)
-    val OTHER_CONTACT_TYPE = ContactType(id(), "OTHER", false)
+    val TWO_THIRDS_CONTACT_TYPE = ContactType(id(), ContactType.SUPERVISION_TWO_THIRDS_POINT, "Two-thirds point", false)
+    val OTHER_CONTACT_TYPE = ContactType(id(), "OTHER", "Something else", false)
     val TWO_THIRDS_CONTACT =
         CUSTODIAL_EVENT.contact(TWO_THIRDS_CONTACT_TYPE, LocalDate.of(2067, 1, 1), STAFF, TEAM, PROVIDER)
     val OTHER_CONTACT = CUSTODIAL_EVENT.contact(OTHER_CONTACT_TYPE, LocalDate.of(2000, 1, 1), STAFF, TEAM, PROVIDER)
 
-    val COMPONENT_TERMINATED_CONTACT_TYPE = ContactType(id(), ContactType.COMPONENT_TERMINATED, false)
-    val COMPONENT_TRANSFER_REJECTED_CONTACT_TYPE = ContactType(id(), ContactType.COMPONENT_TRANSFER_REJECTED, false)
-    val PRE_GROUP_ONE_TO_ONE_MEETING_CONTACT_TYPE = ContactType(id(), ContactType.PRE_GROUP_ONE_TO_ONE_MEETING, false)
-    val ORDER_COMPONENT_COMMENCED_CONTACT_TYPE = ContactType(id(), ContactType.ORDER_COMPONENT_COMMENCED, false)
+    val COMPONENT_TERMINATED_CONTACT_TYPE =
+        ContactType(id(), ContactType.COMPONENT_TERMINATED, "Component terminated", false)
+    val COMPONENT_TRANSFER_REJECTED_CONTACT_TYPE =
+        ContactType(id(), ContactType.COMPONENT_TRANSFER_REJECTED, "Component transfer rejected", false)
+    val PRE_GROUP_ONE_TO_ONE_MEETING_CONTACT_TYPE =
+        ContactType(id(), ContactType.PRE_GROUP_ONE_TO_ONE_MEETING, "Pre-group one-to-one meeting", false)
+    val ORDER_COMPONENT_COMMENCED_CONTACT_TYPE =
+        ContactType(id(), ContactType.ORDER_COMPONENT_COMMENCED, "Order component commenced", false)
 
     val ATTENDED_COMPLIED = ContactOutcome(id(), "ATTC", "Attended and Complied")
     val FAILED_TO_COMPLY =
         ContactOutcome(id(), "FTC", "Failed to comply", attended = false, complied = false, enforceable = true)
     val ACCEPTABLE_ABSENCE = ContactOutcome(id(), "AA", "Acceptable absence", attended = false, complied = true)
-    val REFER_TO_MANAGER_CONTACT_TYPE = ContactType(id(), "ROM", false)
+    val REFER_TO_MANAGER_CONTACT_TYPE = ContactType(id(), "ROM", "Refer to manager", false)
     val REFER_TO_MANAGER_ACTION = EnforcementAction(id(), "ROM", "Refer to manager", 7, REFER_TO_MANAGER_CONTACT_TYPE)
-    val ENFORCEMENT_REVIEW_CONTACT_TYPE = ContactType(id(), "ARWS", false)
+    val ENFORCEMENT_REVIEW_CONTACT_TYPE = ContactType(id(), "ARWS", "Review enforcement", false)
 
     val PSS_END_DATE_KEY_DATE_TYPE =
         ReferenceData(id(), KeyDate.POST_SENTENCE_SUPERVISION_END_DATE, "Post-sentence supervision end date", DATASET)
@@ -176,15 +180,18 @@ object TestData {
     val REGISTER_CATEGORY = ReferenceData(id(), "I3", "IOM - Fixed", DATASET)
     val REGISTRATION = RegistrationGenerator.generate(PERSON, REGISTER_TYPE, REGISTER_CATEGORY)
 
-    val APPOINTMENT_CONTACT_TYPE = ContactType(id(), ContactType.APPOINTMENT, true)
-    val STATUS_CONTACT_TYPES = StatusInfo.Status.entries.map { ContactType(id(), it.contactTypeCode, false) }
-    val THREE_WAY_MEETING_TYPE = ContactType(id(), ContactType.THREE_WAY_MEETING, false)
+    val APPOINTMENT_CONTACT_TYPE = ContactType(id(), ContactType.APPOINTMENT, "Accredited programme appointment", true)
+    val IAPS_APPOINTMENT_CONTACT_TYPE = ContactType(id(), ContactType.IAPS_APPOINTMENT, "IAPS appointment", true)
+    val STATUS_CONTACT_TYPES = StatusInfo.Status.entries.map { ContactType(id(), it.contactTypeCode, it.name, false) }
+    val THREE_WAY_MEETING_TYPE = ContactType(id(), ContactType.THREE_WAY_MEETING, "3-way meeting", false)
 
     val APPOINTMENTS = REQUIREMENTS.take(2).mapIndexed { idx, r ->
         r.contact(APPOINTMENT_CONTACT_TYPE, LocalDate.of(2030, 1, 1 + idx), STAFF, TEAM, PROVIDER)
     } + LICENCE_CONDITIONS.take(2).mapIndexed { idx, lc ->
         lc.contact(APPOINTMENT_CONTACT_TYPE, LocalDate.of(2030, 1, 1 + idx), STAFF, TEAM, PROVIDER)
     }
+    val LEGACY_APPOINTMENT =
+        REQUIREMENTS[0].contact(IAPS_APPOINTMENT_CONTACT_TYPE, LocalDate.of(2030, 1, 3), STAFF, TEAM, PROVIDER)
 
     val DOMAIN_EVENT_DATASET = Dataset(id(), "DOMAIN EVENT TYPE")
     val DOMAIN_EVENT_TYPES = listOf(

--- a/projects/accredited-programmes-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/ContactGenerator.kt
+++ b/projects/accredited-programmes-and-delius/src/dev/kotlin/uk/gov/justice/digital/hmpps/data/generator/ContactGenerator.kt
@@ -58,7 +58,7 @@ object ContactGenerator {
         team = team,
         provider = provider,
         notes = "Some appointment notes",
-        externalReference = "${Contact.REFERENCE_PREFIX}:${UUID.randomUUID()}",
+        externalReference = "${Contact.REFERENCE_PREFIX}${UUID.randomUUID()}",
         sensitive = false,
     )
 
@@ -82,7 +82,7 @@ object ContactGenerator {
         team = team,
         provider = provider,
         notes = "Some appointment notes",
-        externalReference = "${Contact.REFERENCE_PREFIX}:${UUID.randomUUID()}",
+        externalReference = "${Contact.REFERENCE_PREFIX}${UUID.randomUUID()}",
         sensitive = false,
     )
 }

--- a/projects/accredited-programmes-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/AppointmentControllerIntegrationTest.kt
+++ b/projects/accredited-programmes-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/AppointmentControllerIntegrationTest.kt
@@ -2,15 +2,15 @@ package uk.gov.justice.digital.hmpps
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.test.json.JsonCompareMode
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.delete
 import org.springframework.test.web.servlet.post
@@ -101,104 +101,86 @@ internal class AppointmentControllerIntegrationTest @Autowired constructor(
 
     @Test
     fun `get appointments success`() {
+        val requirementIds = REQUIREMENTS.map { it.id }
+        val licenceConditionIds = LICENCE_CONDITIONS.map { it.id }
+        val fromDate = LocalDate.of(2030, 1, 1)
+        val toDate = LocalDate.of(2030, 12, 31)
+
+        val response = mockMvc.post("/appointments/search") {
+            withToken()
+            json = GetAppointmentsRequest(
+                requirementIds = requirementIds,
+                licenceConditionIds = licenceConditionIds,
+                fromDate = fromDate,
+                toDate = toDate,
+            )
+        }.andExpect { status { isOk() } }.andReturn().response.contentAsJson<GetAppointmentsResponse>()
+
+        val appointments = response.content.getValue("A000001")
+        assertThat(appointments).isNotEmpty
+        assertThat(appointments).allSatisfy { appointment ->
+            assertThat(appointment.date).isBetween(fromDate, toDate)
+            assertThat(listOfNotNull(appointment.requirementId, appointment.licenceConditionId)).hasSize(1)
+        }
+        assertThat(appointments.mapNotNull { it.requirementId }).allMatch(requirementIds::contains)
+        assertThat(appointments.mapNotNull { it.licenceConditionId }).allMatch(licenceConditionIds::contains)
+
+        with(appointments.first()) {
+            val expected = contactRepository.findByIdOrNull(id)!!
+            assertThat(reference).isEqualTo(expected.externalReference?.takeLast(36))
+            assertThat(crn).isEqualTo(expected.person.crn)
+            assertThat(requirementId).isEqualTo(expected.requirement?.id)
+            assertThat(licenceConditionId).isEqualTo(expected.licenceCondition?.id)
+            assertThat(date).isEqualTo(expected.date)
+            assertThat(startTime).isEqualTo(expected.startTime)
+            assertThat(endTime).isEqualTo(expected.endTime)
+            assertThat(createdAt).isEqualTo(expected.createdDatetime)
+            assertThat(updatedAt).isEqualTo(expected.lastUpdatedDatetime)
+            assertThat(type.code).isEqualTo(expected.type.code)
+            assertThat(type.description).isEqualTo(expected.type.description)
+            assertThat(outcome?.code).isEqualTo(expected.outcome?.code)
+            assertThat(outcome?.description).isEqualTo(expected.outcome?.description)
+            assertThat(location?.code).isEqualTo(expected.location?.code)
+            assertThat(location?.description).isEqualTo(expected.location?.description)
+            assertThat(staff.code).isEqualTo(expected.staff.code)
+            assertThat(staff.name.forename).isEqualTo(expected.staff.forename)
+            assertThat(staff.name.surname).isEqualTo(expected.staff.surname)
+            assertThat(team.code).isEqualTo(expected.team.code)
+            assertThat(team.description).isEqualTo(expected.team.description)
+            assertThat(notes).isEqualTo(expected.notes)
+            assertThat(sensitive).isEqualTo(expected.sensitive)
+        }
+    }
+
+    @Test
+    fun `get appointments without start date`() {
         mockMvc.post("/appointments/search") {
             withToken()
             json = GetAppointmentsRequest(
-                requirementIds = TestData.REQUIREMENTS.map { it.id },
-                licenceConditionIds = TestData.LICENCE_CONDITIONS.map { it.id },
-                fromDate = LocalDate.of(2030, 1, 1),
-                toDate = LocalDate.of(2030, 12, 31),
+                requirementIds = REQUIREMENTS.map { it.id },
+                licenceConditionIds = LICENCE_CONDITIONS.map { it.id },
+                fromDate = null,
+                toDate = LocalDate.of(2030, 1, 1),
             )
         }.andExpect {
             status { isOk() }
-            content {
-                json(
-                    """
-                    {
-                      "content": {
-                        "A000001": [
-                          {
-                            "crn": "A000001",
-                            "reference": "${TestData.APPOINTMENTS[0].externalReference?.takeLast(36)}",
-                            "requirementId": ${TestData.REQUIREMENTS[0].id},
-                            "date": "${TestData.APPOINTMENTS[0].date}",
-                            "staff": {
-                              "name": {
-                                "forename": "Forename",
-                                "surname": "Surname"
-                              },
-                              "code": "STAFF01"
-                            },
-                            "team": {
-                              "code": "TEAM01",
-                              "description": "Test Team"
-                            },
-                            "notes": "Some appointment notes",
-                            "sensitive": false
-                          },
-                          {
-                            "crn": "A000001",
-                            "reference": "${TestData.APPOINTMENTS[2].externalReference?.takeLast(36)}",
-                            "licenceConditionId": ${TestData.LICENCE_CONDITIONS[0].id},
-                            "date": "${TestData.APPOINTMENTS[2].date}",
-                            "staff": {
-                              "name": {
-                                "forename": "Forename",
-                                "surname": "Surname"
-                              },
-                              "code": "STAFF01"
-                            },
-                            "team": {
-                              "code": "TEAM01",
-                              "description": "Test Team"
-                            },
-                            "notes": "Some appointment notes",
-                            "sensitive": false
-                          },
-                          {
-                            "crn": "A000001",
-                            "reference": "${TestData.APPOINTMENTS[1].externalReference?.takeLast(36)}",
-                            "requirementId": ${TestData.REQUIREMENTS[1].id},
-                            "date": "${TestData.APPOINTMENTS[1].date}",
-                            "staff": {
-                              "name": {
-                                "forename": "Forename",
-                                "surname": "Surname"
-                              },
-                              "code": "STAFF01"
-                            },
-                            "team": {
-                              "code": "TEAM01",
-                              "description": "Test Team"
-                            },
-                            "notes": "Some appointment notes",
-                            "sensitive": false
-                          },
-                          {
-                            "crn": "A000001",
-                            "reference": "${TestData.APPOINTMENTS[3].externalReference?.takeLast(36)}",
-                            "licenceConditionId": ${TestData.LICENCE_CONDITIONS[1].id},
-                            "date": "${TestData.APPOINTMENTS[3].date}",
-                            "staff": {
-                              "name": {
-                                "forename": "Forename",
-                                "surname": "Surname"
-                              },
-                              "code": "STAFF01"
-                            },
-                            "team": {
-                              "code": "TEAM01",
-                              "description": "Test Team"
-                            },
-                            "notes": "Some appointment notes",
-                            "sensitive": false
-                          }
-                        ]
-                      }
-                    }
-                    """.trimIndent(), JsonCompareMode.STRICT
-                )
-            }
+            jsonPath("content.A000001[*].date", everyItem(lessThanOrEqualTo("2030-01-01")))
+        }
+    }
+
+    @Test
+    fun `get appointments without end date`() {
+        mockMvc.post("/appointments/search") {
+            withToken()
+            json = GetAppointmentsRequest(
+                requirementIds = REQUIREMENTS.map { it.id },
+                licenceConditionIds = LICENCE_CONDITIONS.map { it.id },
+                fromDate = LocalDate.of(2030, 1, 2),
+                toDate = null,
+            )
+        }.andExpect {
+            status { isOk() }
+            jsonPath("content.A000001[*].date", everyItem(greaterThanOrEqualTo("2030-01-02")))
         }
     }
 

--- a/projects/accredited-programmes-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/entity/contact/ContactType.kt
+++ b/projects/accredited-programmes-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/entity/contact/ContactType.kt
@@ -11,14 +11,15 @@ class ContactType(
     @Id
     @Column(name = "contact_type_id")
     val id: Long,
-
     val code: String,
+    val description: String,
 
     @Column(name = "national_standards_contact")
     @Convert(converter = YesNoConverter::class)
     val nationalStandards: Boolean,
 ) {
     companion object {
+        const val IAPS_APPOINTMENT = "CAPX"
         const val APPOINTMENT = "CAPY"
         const val THREE_WAY_MEETING = "CAPZ"
         const val PRE_GROUP_ONE_TO_ONE_MEETING = "CAPW"

--- a/projects/accredited-programmes-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/model/AppointmentResponse.kt
+++ b/projects/accredited-programmes-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/model/AppointmentResponse.kt
@@ -4,13 +4,17 @@ import java.time.LocalDate
 import java.time.ZonedDateTime
 
 data class AppointmentResponse(
-    val crn: String,
+    val id: Long,
     val reference: String?,
+    val crn: String,
     val requirementId: Long?,
     val licenceConditionId: Long?,
     val date: LocalDate,
     val startTime: ZonedDateTime?,
     val endTime: ZonedDateTime?,
+    val createdAt: ZonedDateTime,
+    val updatedAt: ZonedDateTime,
+    val type: CodedValue,
     val outcome: AppointmentOutcome?,
     val location: CodedValue?,
     val staff: ProbationPractitioner,

--- a/projects/accredited-programmes-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/model/GetAppointmentsRequest.kt
+++ b/projects/accredited-programmes-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/model/GetAppointmentsRequest.kt
@@ -8,6 +8,6 @@ data class GetAppointmentsRequest(
     val requirementIds: List<Long>,
     @Size(max = 500)
     val licenceConditionIds: List<Long>,
-    val fromDate: LocalDate,
-    val toDate: LocalDate,
+    val fromDate: LocalDate?,
+    val toDate: LocalDate?,
 )

--- a/projects/accredited-programmes-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/repository/ContactRepository.kt
+++ b/projects/accredited-programmes-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/repository/ContactRepository.kt
@@ -12,16 +12,17 @@ interface ContactRepository : JpaRepository<Contact, Long> {
     @Query(
         """
         select c from Contact c
-        where c.type.code = '${ContactType.APPOINTMENT}'
+        where c.type.code in ('${ContactType.APPOINTMENT}', '${ContactType.IAPS_APPOINTMENT}')
         and (c.requirement.id in :requirementIds or c.licenceCondition.id in :licenceConditionIds)
-        and c.date >= :fromDate and c.date <= :toDate
+        and (:fromDate is null or c.date >= :fromDate)
+        and (:toDate is null or c.date <= :toDate)
         """
     )
     fun findAllByComponentIdInDateRange(
         requirementIds: List<Long>,
         licenceConditionIds: List<Long>,
-        fromDate: LocalDate,
-        toDate: LocalDate
+        fromDate: LocalDate?,
+        toDate: LocalDate?,
     ): List<Contact>
 
     fun findByExternalReference(externalReference: String): Contact?

--- a/projects/accredited-programmes-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/AccreditedProgrammesAppointmentService.kt
+++ b/projects/accredited-programmes-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/AccreditedProgrammesAppointmentService.kt
@@ -34,7 +34,7 @@ class AccreditedProgrammesAppointmentService(
     private val telemetryService: TelemetryService,
 ) {
     fun getAppointments(request: GetAppointmentsRequest) = with(request) {
-        require(toDate >= fromDate) { "toDate cannot be before fromDate" }
+        require(toDate == null || fromDate == null || toDate >= fromDate) { "toDate cannot be before fromDate" }
         require(requirementIds.isNotEmpty() || licenceConditionIds.isNotEmpty()) {
             "at least one requirementId or licenceConditionId must be provided"
         }
@@ -111,13 +111,17 @@ class AccreditedProgrammesAppointmentService(
             .onEach { telemetryService.trackEvent("AppointmentDeleted", it.telemetry()) }
 
     private fun Contact.asAppointment() = AppointmentResponse(
+        id = id,
+        reference = externalReference?.removePrefix(Contact.REFERENCE_PREFIX),
         crn = person.crn,
-        reference = externalReference?.takeLast(36),
         requirementId = requirement?.id,
         licenceConditionId = licenceCondition?.id,
         date = date,
         startTime = startTime,
         endTime = endTime,
+        createdAt = createdDatetime,
+        updatedAt = lastUpdatedDatetime,
+        type = CodedValue(type.code, type.description),
         outcome = outcome?.let { AppointmentOutcome(it.code, it.description, it.attended, it.complied) },
         location = location?.let { CodedValue(it.code, it.description) },
         staff = staff.toProbationPractitioner { null },

--- a/projects/community-payback-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/ProvidersIntegrationTest.kt
+++ b/projects/community-payback-and-delius/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/ProvidersIntegrationTest.kt
@@ -1,13 +1,14 @@
 package uk.gov.justice.digital.hmpps
 
 import org.assertj.core.api.Assertions.assertThat
+import org.hamcrest.Matchers.hasItem
+import org.hamcrest.Matchers.not
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import uk.gov.justice.digital.hmpps.advice.ErrorResponse
 import uk.gov.justice.digital.hmpps.data.generator.StaffGenerator
 import uk.gov.justice.digital.hmpps.data.generator.TeamGenerator
@@ -17,6 +18,7 @@ import uk.gov.justice.digital.hmpps.model.ProvidersResponse
 import uk.gov.justice.digital.hmpps.model.SupervisorsResponse
 import uk.gov.justice.digital.hmpps.model.TeamsResponse
 import uk.gov.justice.digital.hmpps.test.MockMvcExtensions.contentAsJson
+import uk.gov.justice.digital.hmpps.test.MockMvcExtensions.jsonPath
 import uk.gov.justice.digital.hmpps.test.MockMvcExtensions.withToken
 import java.time.LocalDate
 
@@ -93,6 +95,26 @@ class ProvidersIntegrationTest @Autowired constructor(
     }
 
     @Test
+    fun `can set maximum for overdueDays`() {
+        mockMvc
+            .get("/providers/N01/teams/N01UPW/projects?overdueDays=8") { withToken() }
+            .andExpect {
+                content {
+                    jsonPath("content.size()", 2)
+                    jsonPath("content[*].oldestOverdueInDays", hasItem(7))
+                }
+            }
+        mockMvc
+            .get("/providers/N01/teams/N01UPW/projects?overdueDays=6") { withToken() }
+            .andExpect {
+                content {
+                    jsonPath("content.size()", 2)
+                    jsonPath("content[*].oldestOverdueInDays", not(hasItem(7)))
+                }
+            }
+    }
+
+    @Test
     fun `can sort projects by name`() {
         mockMvc
             .get("/providers/N01/teams/N01UPW/projects?typeCode=I&sort=name,asc") { withToken() }
@@ -150,27 +172,28 @@ class ProvidersIntegrationTest @Autowired constructor(
                 }
             }
         mockMvc
-            .getSessions("N01", "N01UPW", mapOf("pageSize" to 1))
+            .getSessions("N01", "N01UPW", mapOf("size" to 1))
             .andExpect {
                 content {
                     jsonPath("content.size()", 1)
-                    jsonPath("sessions.size()", 1)
+                    jsonPath("sessions.size()", 2)
                     jsonPath("page.number", 0)
                     jsonPath("page.size", 1)
                     jsonPath("page.totalElements", 2)
-                    jsonPath("page.totalPages", 1)
+                    jsonPath("page.totalPages", 2)
                 }
             }
     }
 
     @Test
     fun `can sort sessions by date`() {
+        val expected = listOf(LocalDate.now().plusDays(1).toString(), LocalDate.now().toString())
         mockMvc
             .getSessions("N01", "N01UPW", mapOf("sort" to "date,desc"))
-            .andExpect { content { jsonPath("content[*].date", listOf(LocalDate.now().plusDays(1), LocalDate.now())) } }
+            .andExpect { content { jsonPath("content[*].date", expected) } }
         mockMvc
             .getSessions("N01", "N01UPW", mapOf("sort" to "date,asc"))
-            .andExpect { content { jsonPath("content[*].date", listOf(LocalDate.now(), LocalDate.now().plusDays(1))) } }
+            .andExpect { content { jsonPath("content[*].date", expected.reversed()) } }
     }
 
     @Test
@@ -187,10 +210,10 @@ class ProvidersIntegrationTest @Autowired constructor(
     fun `can sort sessions by outcome count`() {
         mockMvc
             .getSessions("N01", "N01UPW", mapOf("sort" to "outcomeCount,desc"))
-            .andExpect { content { jsonPath("content[*].date", listOf(1, 0)) } }
+            .andExpect { content { jsonPath("content[*].outcomeCount", listOf(2, 1)) } }
         mockMvc
             .getSessions("N01", "N01UPW", mapOf("sort" to "outcomeCount,asc"))
-            .andExpect { content { jsonPath("content[*].date", listOf(0, 1)) } }
+            .andExpect { content { jsonPath("content[*].outcomeCount", listOf(1, 2)) } }
     }
 
     @Test
@@ -206,22 +229,12 @@ class ProvidersIntegrationTest @Autowired constructor(
     @Test
     fun `can filter sessions by project type codes`() {
         mockMvc
-            .getSessions("N01", "N01UPW", mapOf("typeCode" to "G"))
-            .andExpect { content { jsonPath("content.size()", 2) } }
-
-        mockMvc
             .getSessions("N01", "N01UPW", mapOf("typeCode" to "I"))
-            .andExpect { content { jsonPath("content.size()", 0) } }
-    }
-
-    @Test
-    fun `can filter sessions by project type codes and overdueDays`() {
-        mockMvc
-            .getSessions("N01", "N01UPW", mapOf("overdueDays" to 8))
-            .andExpect { content { jsonPath("content.size()", 3) } }
-        mockMvc
-            .getSessions("N01", "N01UPW", mapOf("overdueDays" to 6))
             .andExpect { content { jsonPath("content.size()", 2) } }
+
+        mockMvc
+            .getSessions("N01", "N01UPW", mapOf("typeCode" to "G"))
+            .andExpect { content { jsonPath("content.size()", 0) } }
     }
 
     @Test


### PR DESCRIPTION
* Adds support for open-ended date ranges
* Includes legacy IAPS appointment types
* Returns additional fields (type, createdAt, updatedAt)

Also,
* Fixes Community Payback test due to incorrect usage of jsonPath