### PR TITLE
PI-3829 Allow accredited programmes to reduce appointment duration

### DIFF
--- a/libs/appointments/src/main/kotlin/uk/gov/justice/digital/hmpps/appointments/model/UpdateAppointment.kt
+++ b/libs/appointments/src/main/kotlin/uk/gov/justice/digital/hmpps/appointments/model/UpdateAppointment.kt
@@ -18,6 +18,7 @@ class UpdateAppointment {
         val startTime: LocalTime,
         val endTime: LocalTime?,
         val allowConflicts: Boolean = false,
+        val allowDurationReduction: Boolean = false,
     ) {
         val endsInFuture: Boolean =
             date.atTime(endTime ?: startTime).atZone(EuropeLondon) > ZonedDateTime.now(EuropeLondon)
@@ -36,11 +37,21 @@ class UpdateAppointment {
             allowConflicts = recreate.allowConflicts
         )
 
-        infix fun isSameDateAndTimeAs(other: Schedule) =
+        internal infix fun isSameDateAndTimeAs(other: Schedule) =
             date == other.date && startTime == other.startTime && endTime == other.endTime
 
         internal infix fun isSameDateAndTimeAs(other: AppointmentContact) =
             this isSameDateAndTimeAs Schedule(other)
+
+        internal infix fun isDurationReductionOf(other: Schedule) =
+            date == other.date && startTime == other.startTime &&
+                endTime != null && other.endTime != null && endTime < other.endTime
+
+        internal infix fun isDurationReductionOf(other: AppointmentContact) =
+            this isDurationReductionOf Schedule(other)
+
+        internal infix fun isAllowedDurationReductionOf(existing: AppointmentContact) =
+            allowDurationReduction && this isDurationReductionOf existing
     }
 
     data class Recreate(

--- a/libs/appointments/src/main/kotlin/uk/gov/justice/digital/hmpps/appointments/service/AppointmentService.kt
+++ b/libs/appointments/src/main/kotlin/uk/gov/justice/digital/hmpps/appointments/service/AppointmentService.kt
@@ -156,13 +156,13 @@ class AppointmentService internal constructor(
 
     private fun <T> UpdatePipeline<T>.validateUpdates(updates: UpdateBuilder<T>) = onEach { (request, existing) ->
         val outcome = updates.applyOutcome?.invoke(Outcome(existing), request)?.outcomeCode
-        val amendDateTime = updates.amendDateTime?.invoke(Schedule(existing), request)?.apply {
+        updates.amendDateTime?.invoke(Schedule(existing), request)?.apply {
             require(endTime == null || startTime < endTime) {
                 "Start time must be before end time"
             }
-        }
-        require(amendDateTime == null || amendDateTime.endsInFuture || outcome != null) {
-            "Outcome must be provided when amending an appointment in the past"
+            require(endsInFuture || outcome != null || this isAllowedDurationReductionOf existing) {
+                "Outcome must be provided when amending an appointment in the past"
+            }
         }
     }
 
@@ -177,7 +177,7 @@ class AppointmentService internal constructor(
     private fun AppointmentContact.amendDateTime(request: Schedule): AppointmentContact {
         if (request isSameDateAndTimeAs this) return this
 
-        require(outcome == null) {
+        require(outcome == null || request isAllowedDurationReductionOf this) {
             "Appointment with outcome cannot be rescheduled"
         }
 

--- a/libs/appointments/src/test/kotlin/uk/gov/justice/digital/hmpps/appointments/service/AppointmentServiceTest.kt
+++ b/libs/appointments/src/test/kotlin/uk/gov/justice/digital/hmpps/appointments/service/AppointmentServiceTest.kt
@@ -32,7 +32,9 @@ import uk.gov.justice.digital.hmpps.appointments.test.TestData.FTC_OUTCOME
 import uk.gov.justice.digital.hmpps.audit.entity.AuditedInteraction
 import uk.gov.justice.digital.hmpps.audit.service.AuditedInteractionService
 import uk.gov.justice.digital.hmpps.data.generator.IdGenerator.id
+import uk.gov.justice.digital.hmpps.datetime.EuropeLondon
 import java.time.LocalDate
+import java.time.LocalTime
 import java.time.LocalTime.NOON
 import java.time.ZonedDateTime
 
@@ -711,6 +713,93 @@ class AppointmentServiceTest {
 
         assertThat(existing.externalReference).isEqualTo("REF01")
         assertThat(existing.outcome).isEqualTo(TestData.OUTCOME)
+    }
+
+    @Test
+    fun `amend appointment with outcome succeeds when reducing duration is allowed`() {
+        val date = LocalDate.now().plusDays(1)
+        val existing = TestData.appointment(
+            date = date,
+            startTime = date.atTime(9, 0).atZone(EuropeLondon),
+            endTime = date.atTime(14, 0).atZone(EuropeLondon),
+            outcome = TestData.OUTCOME
+        )
+        whenever(appointmentRepository.findByExternalReferenceIn(listOf(existing.externalReference!!)))
+            .thenReturn(listOf(existing))
+
+        appointmentService.update(existing) {
+            reference = { existing.externalReference }
+            amendDateTime = { copy(endTime = LocalTime.of(13, 0), allowDurationReduction = true) }
+        }
+
+        assertThat(existing.startTime.toLocalTime()).isEqualTo(LocalTime.of(9, 0))
+        assertThat(existing.endTime?.toLocalTime()).isEqualTo(LocalTime.of(13, 0))
+        assertThat(existing.outcome).isEqualTo(TestData.OUTCOME)
+    }
+
+    @Test
+    fun `amend past appointment succeeds when reducing duration is allowed`() {
+        val date = LocalDate.now().minusDays(1)
+        val existing = TestData.appointment(
+            date = date,
+            startTime = date.atTime(9, 0).atZone(EuropeLondon),
+            endTime = date.atTime(14, 0).atZone(EuropeLondon)
+        )
+        whenever(appointmentRepository.findByExternalReferenceIn(listOf(existing.externalReference!!)))
+            .thenReturn(listOf(existing))
+
+        appointmentService.update(existing) {
+            reference = { existing.externalReference }
+            amendDateTime = { copy(endTime = LocalTime.of(13, 0), allowDurationReduction = true) }
+        }
+
+        assertThat(existing.endTime?.toLocalTime()).isEqualTo(LocalTime.of(13, 0))
+        assertThat(existing.outcome).isEqualTo(null)
+    }
+
+    @Test
+    fun `attempt to extend appointment with outcome when reducing duration is allowed`() {
+        val date = LocalDate.now().plusDays(1)
+        val existing = TestData.appointment(
+            date = date,
+            startTime = date.atTime(9, 0).atZone(EuropeLondon),
+            endTime = date.atTime(14, 0).atZone(EuropeLondon),
+            outcome = TestData.OUTCOME
+        )
+
+        whenever(appointmentRepository.findByExternalReferenceIn(listOf(existing.externalReference!!)))
+            .thenReturn(listOf(existing))
+
+        assertThatThrownBy {
+            appointmentService.update(existing) {
+                reference = { existing.externalReference }
+                amendDateTime = { copy(endTime = LocalTime.of(15, 0), allowDurationReduction = true) }
+            }
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("Appointment with outcome cannot be rescheduled")
+    }
+
+    @Test
+    fun `attempt to extend past appointment when reducing duration is allowed`() {
+        val date = LocalDate.now().minusDays(1)
+        val existing = TestData.appointment(
+            date = date,
+            startTime = date.atTime(9, 0).atZone(EuropeLondon),
+            endTime = date.atTime(10, 0).atZone(EuropeLondon)
+        )
+
+        whenever(appointmentRepository.findByExternalReferenceIn(listOf(existing.externalReference!!)))
+            .thenReturn(listOf(existing))
+
+        assertThatThrownBy {
+            appointmentService.update(existing) {
+                reference = { existing.externalReference }
+                amendDateTime = { copy(endTime = LocalTime.of(11, 0), allowDurationReduction = true) }
+            }
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("Outcome must be provided when amending an appointment in the past")
     }
 
     private fun mockCreateReferenceData() {

--- a/projects/accredited-programmes-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/AccreditedProgrammesAppointmentService.kt
+++ b/projects/accredited-programmes-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/AccreditedProgrammesAppointmentService.kt
@@ -98,7 +98,9 @@ class AccreditedProgrammesAppointmentService(
     fun update(request: UpdateAppointmentsRequest) {
         appointmentService.bulkUpdate(request.appointments) {
             reference = { "${Contact.REFERENCE_PREFIX}${it.reference}" }
-            amendDateTime = { Schedule(it.date, it.startTime, it.endTime, allowConflicts = true) }
+            amendDateTime = {
+                Schedule(it.date, it.startTime, it.endTime, allowConflicts = true, allowDurationReduction = true)
+            }
             reassign = { Assignee(it.staff.code, it.team.code, it.location?.code) }
             applyOutcome = { Outcome(it.outcome?.code) }
             appendNotes = { it.notes }


### PR DESCRIPTION
Previously, amending the time was only valid for future appointments or those without an outcome. Now, accredited programmes can bypass those checks as long as they are only reducing the appointment length by moving the end time closer to the start time.