### PR TITLE
PI-4123 Use Specification to build appointment query

### DIFF
--- a/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/entity/unpaidwork/UnpaidWorkAppointment.kt
+++ b/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/entity/unpaidwork/UnpaidWorkAppointment.kt
@@ -11,6 +11,7 @@ import org.springframework.data.annotation.LastModifiedBy
 import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.domain.Specification
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
@@ -26,6 +27,8 @@ import uk.gov.justice.digital.hmpps.exception.NotFoundException
 import uk.gov.justice.digital.hmpps.model.CodeDescription
 import uk.gov.justice.digital.hmpps.model.RequirementProgress
 import uk.gov.justice.digital.hmpps.model.Session
+import uk.gov.justice.digital.hmpps.utils.Extensions.allOfNotNull
+import uk.gov.justice.digital.hmpps.utils.Extensions.optionalFilter
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -432,25 +435,9 @@ interface UnpaidWorkAppointmentRepository : JpaRepository<UnpaidWorkAppointment,
         typeCodesCount: Int = typeCodes.count(),
     ): Page<Triple<Long, Int, Int>>
 
-    @Query(
-        """
-        select a from UnpaidWorkAppointment a
-        join fetch a.contact c
-        left join fetch a.contact.outcome o
-        where (:crn is null or a.person.crn = :crn)
-          and (:eventNumber is null or a.details.disposal.event.number = :eventNumber)
-          and (:fromDate is null or a.date >= :fromDate)
-          and (:toDate is null or a.date <= :toDate)
-          and (:projectCodes is null or a.project.code in :projectCodes)
-          and (:projectTypeCodes is null or a.project.projectType.code in :projectTypeCodes)
-          and (:appointmentIds is null or a.id in :appointmentIds)
-          and (:references is null or (c.externalReference is not null and c.externalReference in :references))
-          and (:outcomeCodes is null
-            or (o is null and 'NO_OUTCOME' in :outcomeCodes)
-            or (o is not null and o.code in :outcomeCodes))
-        """
-    )
     @EntityGraph(value = "UnpaidWorkAppointment.all")
+    fun findAll(spec: Specification<UnpaidWorkAppointment>, pageable: Pageable): Page<UnpaidWorkAppointment>
+
     fun findAppointments(
         crn: String?,
         eventNumber: String?,
@@ -462,10 +449,20 @@ interface UnpaidWorkAppointmentRepository : JpaRepository<UnpaidWorkAppointment,
         appointmentIds: List<Long>?,
         references: List<String>?,
         pageable: Pageable,
-    ): Page<UnpaidWorkAppointment>
-
-    @EntityGraph(value = "UnpaidWorkAppointment.all")
-    fun findAllByIdIn(appointmentIds: List<Long>?, pageable: Pageable): Page<UnpaidWorkAppointment>
+    ): Page<UnpaidWorkAppointment> = findAll(
+        allOfNotNull(
+            optionalFilter("id", appointmentIds) { it.`in`(appointmentIds) },
+            optionalFilter("contact.externalReference", references) { it.`in`(references) },
+            optionalFilter("person.crn", crn) { it.equalTo(crn) },
+            optionalFilter("details.disposal.event.number", eventNumber) { it.equalTo(eventNumber) },
+            optionalFilter("date", fromDate) { greaterThanOrEqualTo(it, fromDate) },
+            optionalFilter("date", toDate) { lessThanOrEqualTo(it, toDate) },
+            optionalFilter("project.code", projectCodes) { it.`in`(projectCodes) },
+            optionalFilter("project.projectType.code", projectTypeCodes) { it.`in`(projectTypeCodes) },
+            optionalFilter("contact.outcome.code", outcomeCodes) { coalesce(it, "NO_OUTCOME").`in`(outcomeCodes) },
+        ),
+        pageable
+    )
 }
 
 fun UnpaidWorkAppointmentRepository.getAppointment(id: Long) =

--- a/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/entity/unpaidwork/UnpaidWorkDetails.kt
+++ b/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/entity/unpaidwork/UnpaidWorkDetails.kt
@@ -24,6 +24,9 @@ class UnpaidWorkDetails(
     @Column(name = "upw_details_id")
     val id: Long,
 
+    @Version
+    var rowVersion: Long = 0,
+
     @ManyToOne
     @JoinColumn(name = "disposal_id")
     val disposal: Disposal,

--- a/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/CommunityPaybackAppointmentsService.kt
+++ b/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/CommunityPaybackAppointmentsService.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.service
 
-import org.apache.commons.lang3.ObjectUtils.allNull
 import org.springframework.data.domain.Pageable
 import org.springframework.data.web.PagedModel
 import org.springframework.orm.ObjectOptimisticLockingFailureException
@@ -108,15 +107,10 @@ class CommunityPaybackAppointmentsService(
         references: List<String>?,
         pageable: Pageable
     ): PagedModel<AppointmentsResponse> {
-        val appointments =
-            if (appointmentIds != null &&
-                allNull(references, crn, eventNumber, fromDate, toDate, projectCodes, projectTypeCodes, outcomeCodes)
-            ) {
-                unpaidWorkAppointmentRepository.findAllByIdIn(appointmentIds, pageable)
-            } else unpaidWorkAppointmentRepository.findAppointments(
-                crn, eventNumber, fromDate, toDate, projectCodes, projectTypeCodes, outcomeCodes,
-                appointmentIds, references?.map { "$REFERENCE_PREFIX$it" }, pageable
-            )
+        val appointments = unpaidWorkAppointmentRepository.findAppointments(
+            crn, eventNumber, fromDate, toDate, projectCodes, projectTypeCodes, outcomeCodes,
+            appointmentIds, references?.map { "$REFERENCE_PREFIX$it" }, pageable
+        )
         val upwDetailsIds = appointments.map { it.details.id }.distinct()
         val crns = appointments.map { it.person.crn }.distinct()
         val minutes = unpaidWorkAppointmentRepository.getUpwRequiredAndCompletedMinutes(upwDetailsIds)

--- a/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/utils/Extensions.kt
+++ b/projects/community-payback-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/utils/Extensions.kt
@@ -1,9 +1,13 @@
 package uk.gov.justice.digital.hmpps.utils
 
+import jakarta.persistence.criteria.*
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.domain.JpaSort
+import org.springframework.data.jpa.domain.Specification
+import org.springframework.data.jpa.domain.Specification.allOf
+import uk.gov.justice.digital.hmpps.entity.unpaidwork.UnpaidWorkAppointment
 
 object Extensions {
     inline fun <K, reified V> Map<K, V>.reportMissing(required: Set<K>) = also {
@@ -18,4 +22,15 @@ object Extensions {
             JpaSort.unsafe(order.direction, property)
         }.fold(Sort.unsorted()) { acc, sort -> if (acc.isUnsorted) sort else acc.and(sort) })
     }
+
+    private fun <T> From<*, *>.getNested(name: String) = name.split(".").let { parts ->
+        parts.dropLast(1).fold(this) { path, part -> path.join<Any, Any>(part, JoinType.LEFT) }
+            .get<T>(parts.last())
+    }
+
+    fun <T> optionalFilter(nestedPath: String, value: T?, block: CriteriaBuilder.(Path<T>) -> Predicate) =
+        value?.let { Specification<UnpaidWorkAppointment> { root, _, cb -> cb.block(root.getNested(nestedPath)) } }
+
+    fun <T : Any> allOfNotNull(vararg specifications: Specification<T>?) =
+        allOf(specifications.filterNotNull())
 }


### PR DESCRIPTION
This will generate a different SQL query depending on the provided parameters, so each one can have its own finely tuned query plan.

Tested in preprod and queries that were taking >10s before are now taking milliseconds: [App Insights](https://portal.azure.com/#blade/AppInsightsExtension/BladeRedirect/BladeName/searchV1/ResourceId/%252Fsubscriptions%252Fa5ddf257-3b21-4ba9-a28c-ab30f751b383%252FresourceGroups%252Fnomisapi-preprod-rg%252Fproviders%252FMicrosoft.Insights%252Fcomponents%252Fnomisapi-preprod/BladeInputs/%7B%22tables%22%3A%5B%22requests%22%5D%2C%22timeContextWhereClause%22%3A%22%7C%20where%20timestamp%20%3E%20datetime(%5C%222026-05-14T16%3A05%3A24.650Z%5C%22)%20and%20timestamp%20%3C%20datetime(%5C%222026-05-15T16%3A05%3A24.650Z%5C%22)%22%2C%22filterWhereClause%22%3A%22%7C%20where%20cloud_RoleName%20in%20(%5C%22community-payback-and-delius%5C%22)%7C%20where%20operation_Name%20in%20(%5C%22GET%20%2Fappointments%5C%22)%7C%20order%20by%20timestamp%20desc%22%2C%22originalParams%22%3A%7B%22eventTypes%22%3A%5B%7B%22value%22%3A%22request%22%2C%22tableName%22%3A%22requests%22%2C%22label%22%3A%22Request%22%7D%5D%2C%22timeContext%22%3A%7B%22durationMs%22%3A86400000%7D%2C%22filter%22%3A%5B%7B%22dimension%22%3A%7B%22displayName%22%3A%22Cloud%20role%20name%22%2C%22tables%22%3A%5B%22availabilityResults%22%2C%22requests%22%2C%22exceptions%22%2C%22pageViews%22%2C%22traces%22%2C%22customEvents%22%2C%22dependencies%22%5D%2C%22name%22%3A%22cloud%2FroleName%22%2C%22draftKey%22%3A%22cloud%2FroleName%22%7D%2C%22values%22%3A%5B%22community-payback-and-delius%22%5D%2C%22operator%22%3A%7B%22label%22%3A%22%3D%22%2C%22value%22%3A%22%3D%3D%22%2C%22isSelected%22%3Atrue%7D%7D%2C%7B%22dimension%22%3A%7B%22displayName%22%3A%22Operation%20name%22%2C%22tables%22%3A%5B%22availabilityResults%22%2C%22requests%22%2C%22exceptions%22%2C%22pageViews%22%2C%22traces%22%2C%22customEvents%22%2C%22dependencies%22%5D%2C%22name%22%3A%22operation%2Fname%22%2C%22draftKey%22%3A%22operation%2Fname%22%7D%2C%22values%22%3A%5B%22GET%20%2Fappointments%22%5D%2C%22operator%22%3A%7B%22label%22%3A%22%3D%22%2C%22value%22%3A%22%3D%3D%22%2C%22isSelected%22%3Atrue%7D%7D%5D%2C%22searchPhrase%22%3A%7B%22originalPhrase%22%3A%22%22%2C%22_tokens%22%3A%5B%5D%7D%2C%22sort%22%3A%22desc%22%7D%7D)