### PR TITLE
PI-4192 Handle null document audit info

### DIFF
--- a/libs/oauth-server/src/main/kotlin/uk/gov/justice/digital/hmpps/advice/ControllerAdvice.kt
+++ b/libs/oauth-server/src/main/kotlin/uk/gov/justice/digital/hmpps/advice/ControllerAdvice.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.advice
 
+import io.opentelemetry.api.trace.Span
 import jakarta.validation.ConstraintViolationException
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.dao.DataIntegrityViolationException
@@ -56,6 +57,7 @@ class ControllerAdvice {
     fun handle(e: IllegalArgumentException) = ResponseEntity
         .status(BAD_REQUEST)
         .body(ErrorResponse(status = BAD_REQUEST.value(), message = e.message))
+        .also { Span.current().recordException(e) }
 }
 
 @RestControllerAdvice(basePackages = ["uk.gov.justice.digital.hmpps"])

--- a/projects/dps-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/entity/Document.kt
+++ b/projects/dps-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/entity/Document.kt
@@ -35,13 +35,13 @@ class DocumentEntity(
     val tableName: String,
 
     @Column(name = "created_datetime")
-    val createdAt: ZonedDateTime,
+    val createdAt: ZonedDateTime?,
 
     @Column
-    val createdByUserId: Long = 0,
+    val createdByUserId: Long? = 0,
 
     @Column
-    val lastUpdatedUserId: Long = 0,
+    val lastUpdatedUserId: Long? = 0,
 
     @Column(columnDefinition = "number")
     @Convert(converter = NumericBooleanConverter::class)
@@ -173,6 +173,6 @@ interface DocumentRepository : JpaRepository<DocumentEntity, Long> {
     )
     fun getPersonAndEventDocuments(personId: Long): List<Document>
 
-    @Query("select d from DocumentEntity d where d.alfrescoId = :alfrescoId")
-    fun findByAlfrescoId(alfrescoId: String): DocumentEntity?
+    @Query("select d.name, p.crn from DocumentEntity d join Person p on p.id = d.personId where d.alfrescoId = :alfrescoId")
+    fun findNameAndCrnByAlfrescoId(alfrescoId: String): Pair<String, String>?
 }

--- a/projects/dps-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/DocumentService.kt
+++ b/projects/dps-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/DocumentService.kt
@@ -28,12 +28,10 @@ class DocumentService(
     }
 
     fun downloadDocument(id: String): ResponseEntity<StreamingResponseBody> {
-        val document =
-            documentRepository.findByAlfrescoId(id) ?: throw NotFoundException("Document", "alfrescoId", id)
-        val person = personRepository.findById(document.personId)
-            .orElseThrow { NotFoundException("Person", "id", document.personId) }
-        if (featureFlags.enabled(FLIPT_KEY)) checkForLao(person.crn)
-        return alfrescoClient.streamDocument(id, document.name)
+        val (name, crn) = documentRepository.findNameAndCrnByAlfrescoId(id)
+            ?: throw NotFoundException("Document", "alfrescoId", id)
+        if (featureFlags.enabled(FLIPT_KEY)) checkForLao(crn)
+        return alfrescoClient.streamDocument(id, name)
     }
 
     @Transactional
@@ -88,7 +86,7 @@ class DocumentService(
         val limitedAccessInfo = limitedAccessService.checkLimitedAccessFor(listOf(crn))
         limitedAccessInfo.access.firstOrNull { it.crn == crn }?.let { limitedAccess ->
             if (limitedAccess.userExcluded || limitedAccess.userRestricted) {
-                throw AccessDeniedException("Access Denied for case with crn ${crn}")
+                throw AccessDeniedException("Access Denied for case with crn $crn")
             }
         }
     }

--- a/projects/prisoner-profile-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/documents/entity/Document.kt
+++ b/projects/prisoner-profile-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/integrations/delius/documents/entity/Document.kt
@@ -32,13 +32,13 @@ class DocumentEntity(
     val tableName: String,
 
     @Column(name = "created_datetime")
-    val createdAt: ZonedDateTime,
+    val createdAt: ZonedDateTime?,
 
     @Column
-    val createdByUserId: Long,
+    val createdByUserId: Long?,
 
     @Column
-    val lastUpdatedUserId: Long,
+    val lastUpdatedUserId: Long?,
 
     @Column(columnDefinition = "number")
     @Convert(converter = NumericBooleanConverter::class)
@@ -174,5 +174,6 @@ interface DocumentRepository : JpaRepository<DocumentEntity, Long> {
     )
     fun getPersonAndEventDocuments(personId: Long): List<Document>
 
-    fun findByAlfrescoId(alfrescoId: String): DocumentEntity?
+    @Query("select d.name, p.crn from DocumentEntity d join Person p on p.id = d.personId where d.alfrescoId = :alfrescoId")
+    fun findNameAndCrnByAlfrescoId(alfrescoId: String): Pair<String, String>?
 }

--- a/projects/prisoner-profile-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/DocumentService.kt
+++ b/projects/prisoner-profile-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/DocumentService.kt
@@ -28,13 +28,10 @@ class DocumentService(
     }
 
     fun downloadDocument(id: String): ResponseEntity<StreamingResponseBody> {
-        val document =
-            documentRepository.findByAlfrescoId(id) ?: throw NotFoundException("Document", "alfrescoId", id)
-        if (featureFlags.enabled(FLIPT_KEY)) checkForLao(
-            personRepository.findById(document.personId)
-                .orElseThrow { NotFoundException("Person", "id", document.personId) }.crn
-        )
-        return alfrescoClient.streamDocument(id, document.name)
+        val (name, crn) = documentRepository.findNameAndCrnByAlfrescoId(id)
+            ?: throw NotFoundException("Document", "alfrescoId", id)
+        if (featureFlags.enabled(FLIPT_KEY)) checkForLao(crn)
+        return alfrescoClient.streamDocument(id, name)
     }
 
     @Transactional
@@ -89,7 +86,7 @@ class DocumentService(
         val limitedAccessInfo = limitedAccessService.checkLimitedAccessFor(listOf(crn))
         limitedAccessInfo.access.firstOrNull { it.crn == crn }?.let { limitedAccess ->
             if (limitedAccess.userExcluded || limitedAccess.userRestricted) {
-                throw AccessDeniedException("Access Denied for case with crn ${crn}")
+                throw AccessDeniedException("Access Denied for case with crn $crn")
             }
         }
     }


### PR DESCRIPTION
Also updates the exception handler to log 400 errors caused by IllegalArgumentException to Application Insights so we can see the full stack trace in future.