### PR TITLE
Remove annotation-default-target compiler option

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,6 @@ allprojects {
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_25)
             freeCompilerArgs.add("-Xjsr305=strict") // to make use of Spring's null-safety annotations
-            freeCompilerArgs.add("-Xannotation-default-target=param-property") // see https://youtrack.jetbrains.com/issue/KT-73255
         }
     }
 


### PR DESCRIPTION
This is now the default since Kotlin 2.4.0