### PR TITLE
PI-4306 Allow appointment amendments in the past without outcome

### DIFF
--- a/libs/appointments/src/main/kotlin/uk/gov/justice/digital/hmpps/appointments/model/UpdateAppointment.kt
+++ b/libs/appointments/src/main/kotlin/uk/gov/justice/digital/hmpps/appointments/model/UpdateAppointment.kt
@@ -9,6 +9,7 @@ import java.time.ZonedDateTime
 class UpdateAppointment {
     data class Outcome(
         val outcomeCode: String?,
+        val allowMissingOutcomeInThePast: Boolean = false,
     ) {
         internal constructor(entity: AppointmentContact) : this(entity.outcome?.code)
     }

--- a/libs/appointments/src/main/kotlin/uk/gov/justice/digital/hmpps/appointments/service/AppointmentService.kt
+++ b/libs/appointments/src/main/kotlin/uk/gov/justice/digital/hmpps/appointments/service/AppointmentService.kt
@@ -157,12 +157,12 @@ class AppointmentService internal constructor(
     }
 
     private fun <T> UpdatePipeline<T>.validateUpdates(updates: UpdateBuilder<T>) = onEach { (request, existing) ->
-        val outcome = updates.applyOutcome?.invoke(Outcome(existing), request)?.outcomeCode
+        val outcome = updates.applyOutcome?.invoke(Outcome(existing), request)
         updates.amendDateTime?.invoke(Schedule(existing), request)?.apply {
             require(endTime == null || startTime < endTime) {
                 "Start time must be before end time"
             }
-            require(endsInFuture || outcome != null || this isAllowedDurationReductionOf existing) {
+            require(endsInFuture || outcome?.outcomeCode != null || outcome?.allowMissingOutcomeInThePast == true || this isAllowedDurationReductionOf existing) {
                 "Outcome must be provided when amending an appointment in the past"
             }
         }

--- a/libs/appointments/src/test/kotlin/uk/gov/justice/digital/hmpps/appointments/service/AppointmentServiceTest.kt
+++ b/libs/appointments/src/test/kotlin/uk/gov/justice/digital/hmpps/appointments/service/AppointmentServiceTest.kt
@@ -869,6 +869,55 @@ class AppointmentServiceTest {
             .hasMessage("Outcome must be provided when amending an appointment in the past")
     }
 
+    @Test
+    fun `amend past appointment succeeds without outcome when allowed`() {
+        val date = LocalDate.now().minusDays(1)
+        val newDate = date.minusDays(1)
+        val existing = TestData.appointment(
+            date = date,
+            startTime = date.atTime(9, 0).atZone(EuropeLondon),
+            endTime = date.atTime(14, 0).atZone(EuropeLondon)
+        )
+        whenever(appointmentRepository.findByExternalReferenceIn(listOf(existing.externalReference!!)))
+            .thenReturn(listOf(existing))
+        whenever(outcomeRepository.findAllByCodeIn(emptySet())).thenReturn(emptyList())
+        mockEnforcementReferenceData()
+
+        appointmentService.update(existing) {
+            reference = { existing.externalReference }
+            amendDateTime = { copy(date = newDate) }
+            applyOutcome = { Outcome(outcomeCode = null, allowMissingOutcomeInThePast = true) }
+        }
+
+        assertThat(existing.externalReference).isEqualTo("REF01")
+        assertThat(existing.date).isEqualTo(newDate)
+        assertThat(existing.outcome).isNull()
+    }
+
+    @Test
+    fun `removing past outcome fails even if past amendments are allowed`() {
+        val date = LocalDate.now().minusDays(1)
+        val existing = TestData.appointment(
+            date = date,
+            startTime = date.atTime(9, 0).atZone(EuropeLondon),
+            endTime = date.atTime(14, 0).atZone(EuropeLondon),
+            outcome = TestData.OUTCOME,
+        )
+        whenever(appointmentRepository.findByExternalReferenceIn(listOf(existing.externalReference!!)))
+            .thenReturn(listOf(existing))
+        whenever(outcomeRepository.findAllByCodeIn(emptySet())).thenReturn(emptyList())
+        mockEnforcementReferenceData()
+
+        assertThatThrownBy {
+            appointmentService.update(existing) {
+                reference = { existing.externalReference }
+                applyOutcome = { Outcome(outcomeCode = null, allowMissingOutcomeInThePast = true) }
+            }
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("Outcome cannot be amended")
+    }
+
     private fun mockCreateReferenceData() {
         whenever(typeRepository.findAllByCodeIn(any())).thenReturn(listOf(TestData.TYPE))
         whenever(outcomeRepository.findAllByCodeIn(any())).thenReturn(emptyList())

--- a/projects/accredited-programmes-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/AccreditedProgrammesAppointmentService.kt
+++ b/projects/accredited-programmes-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/service/AccreditedProgrammesAppointmentService.kt
@@ -105,7 +105,7 @@ class AccreditedProgrammesAppointmentService(
                 Schedule(it.date, it.startTime, it.endTime, allowConflicts = true, allowDurationReduction = true)
             }
             reassign = { Assignee(it.staff.code, it.team.code, it.location?.code) }
-            applyOutcome = { Outcome(it.outcome?.code) }
+            applyOutcome = { Outcome(it.outcome?.code, allowMissingOutcomeInThePast = true) }
             appendNotes = { it.notes }
             flagAs = { copy(sensitive = it.sensitive) }
         }.onEach { telemetryService.trackEvent("AppointmentUpdated", it.telemetry()) }


### PR DESCRIPTION
This replicates existing Delius/IAPS functionality into the Accredited Programmes integration. Amending or removing the outcome is still not allowed.